### PR TITLE
chore(ci): add bridge and frontend verification workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bridge:
+    name: Bridge / Python
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up just
+        uses: extractions/setup-just@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        working-directory: apps/game-bridge
+        run: uv python install
+
+      - name: Install bridge dependencies
+        working-directory: apps/game-bridge
+        run: uv sync --locked --all-extras --dev
+
+      - name: Verify bridge
+        working-directory: apps/game-bridge
+        run: just verify
+
+  frontend:
+    name: Shared + Electron UI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify frontend
+        run: pnpm frontend:verify

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -1,0 +1,84 @@
+name: Package Windows
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_name:
+        description: Build name
+        required: true
+        default: snapshot
+  push:
+    tags:
+      - snapshot-*
+      - v*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-windows
+  cancel-in-progress: false
+
+jobs:
+  package-windows:
+    name: Package Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        working-directory: apps/game-bridge
+        run: uv python install
+
+      - name: Install backend dependencies
+        working-directory: apps/game-bridge
+        run: uv sync --locked --all-extras --dev
+
+      - name: Build backend executable
+        working-directory: apps/game-bridge
+        run: uv run pyinstaller --noconfirm --onedir --name zml-game-bridge src/zml_game_bridge/main.py
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared contracts
+        run: pnpm --filter ./packages/shared build
+
+      - name: Build electron-ui
+        run: pnpm --filter ./apps/electron-ui build
+
+      - name: Copy backend into Electron resources
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path apps/electron-ui/resources/backend | Out-Null
+          Copy-Item -Recurse -Force apps/game-bridge/dist/zml-game-bridge/* apps/electron-ui/resources/backend/
+
+      - name: Package Electron app
+        run: pnpm --filter ./apps/electron-ui electron:build
+
+      - name: Upload packaged app
+        uses: actions/upload-artifact@v5
+        with:
+          name: zml-windows-${{ github.event.inputs.build_name || github.ref_name }}
+          path: |
+            apps/electron-ui/dist-electron
+            apps/electron-ui/release
+            apps/electron-ui/dist
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ database writes stay predictable.
 Backend:
 
 ```bash
-npm run bridge:verify
+pnpm run bridge:verify
 ```
 
 This runs:

--- a/apps/electron-ui/package.json
+++ b/apps/electron-ui/package.json
@@ -6,9 +6,16 @@
   "scripts": {
     "dev": "vite",
     "dev:mocks": "node ./scripts/dev-with-mocks.mjs",
-    "build": "tsc && vite build && electron-builder",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
+    "test": "vitest run",
+
+    "build:web": "vite build",
+    "build:desktop": "tsc -p electron/tsconfig.json",
+    "build": "pnpm build:web && pnpm build:desktop",
+
+    "package": "pnpm build && electron-builder"
   },
   "dependencies": {
     "@deck.gl/core": "^9.3.2",

--- a/apps/game-bridge/README.md
+++ b/apps/game-bridge/README.md
@@ -39,28 +39,6 @@ Events are durable domain facts. They are persisted and can be streamed to the U
 
 Read models are query-friendly tables derived from events, for example active mining claims. They are written by the same single DB writer, so they do not introduce a second SQLite writer.
 
-## Running
-
-From the repository root:
-
-```bash
-npm run bridge:config
-npm run bridge:dev
-npm run bridge:ocr
-npm run bridge:mock
-npm run bridge:finder-debug
-```
-
-Directly from `apps/game-bridge`:
-
-```bash
-uv run python -m zml_game_bridge.dev_cli config
-uv run python -m zml_game_bridge.dev_cli serve
-uv run python -m zml_game_bridge.dev_cli serve --mode live
-uv run python -m zml_game_bridge.dev_cli serve --mode mock
-uv run python -m zml_game_bridge.dev_cli serve --mode live --finder-debug
-```
-
 Input modes:
 
 - `env`: use current environment variables.

--- a/apps/game-bridge/justfile
+++ b/apps/game-bridge/justfile
@@ -1,0 +1,34 @@
+default:
+    just --list
+
+config:
+    uv run python -m zml_game_bridge.dev_cli config
+
+dev:
+    uv run python -m zml_game_bridge.dev_cli serve
+
+ocr:
+    uv run python -m zml_game_bridge.dev_cli serve --mode live
+
+mock:
+    uv run python -m zml_game_bridge.dev_cli serve --mode mock
+
+finder-debug:
+    uv run python -m zml_game_bridge.dev_cli serve --mode live --finder-debug
+
+lint:
+    uv run ruff check .
+
+format:
+    uv run ruff format .
+
+format-check:
+    uv run ruff format --check .
+
+typecheck:
+    uv run pyright
+
+test:
+    uv run pytest --basetemp .pytest-tmp -o cache_dir=.pytest-cache-local
+
+verify: lint format-check typecheck test

--- a/package.json
+++ b/package.json
@@ -7,23 +7,21 @@
     "packages/*"
   ],
   "scripts": {
-    "dev:ui": "pnpm --filter @zml/ui dev",
-    "dev:desktop": "pnpm --filter @zml/electron-ui dev",
-    "dev:desktop:mocks": "pnpm --filter @zml/electron-ui dev:mocks",
-    "dev:bridge": "npm run bridge:dev",
-    "bridge:config": "cd apps/game-bridge && uv run python -m zml_game_bridge.dev_cli config",
-    "bridge:dev": "cd apps/game-bridge && uv run python -m zml_game_bridge.dev_cli serve",
-    "bridge:ocr": "cd apps/game-bridge && uv run python -m zml_game_bridge.dev_cli serve --mode live",
-    "bridge:mock": "cd apps/game-bridge && uv run python -m zml_game_bridge.dev_cli serve --mode mock",
-    "bridge:finder-debug": "cd apps/game-bridge && uv run python -m zml_game_bridge.dev_cli serve --mode live --finder-debug",
-    "bridge:lint": "cd apps/game-bridge && uv run ruff check .",
-    "bridge:format": "cd apps/game-bridge && uv run ruff format .",
-    "bridge:typecheck": "cd apps/game-bridge && uv run pyright",
-    "bridge:test": "cd apps/game-bridge && uv run pytest --basetemp .pytest-tmp -o cache_dir=.pytest-cache-local",
-    "bridge:verify": "npm run bridge:lint && npm run bridge:typecheck && npm run bridge:test",
-    "dev": "concurrently -k \"pnpm dev:desktop\" \"pnpm dev:bridge\"",
-    "build": "pnpm -r build",
-    "lint": "pnpm -r --if-present lint"
+    "dev": "concurrently -n bridge,web -c cyan,magenta \"cd apps/game-bridge && just ocr\" \"pnpm --filter @zml/electron-ui dev\"",
+
+    "bridge:format": "cd apps/game-bridge && just format",
+    "bridge:verify": "cd apps/game-bridge && just verify",
+
+    "shared:verify": "pnpm --filter @zml/shared typecheck && pnpm --filter @zml/shared build",
+
+    "frontend:verify": "pnpm shared:verify && pnpm --filter @zml/electron-ui typecheck && pnpm --filter @zml/electron-ui lint && pnpm --filter @zml/electron-ui test && pnpm --filter @zml/electron-ui build",
+    "frontend:build": "pnpm --filter @zml/shared build && pnpm --filter @zml/electron-ui build",
+    "frontend:package": "pnpm --filter @zml/shared build && pnpm --filter @zml/electron-ui package",
+
+    "verify": "pnpm bridge:verify && pnpm frontend:verify",
+    "build": "pnpm frontend:build",
+    "package": "pnpm frontend:package",
+    "lint": "cd apps/game-bridge && just lint && pnpm --filter @zml/electron-ui lint"
   },
   "devDependencies": {
     "concurrently": "^9.2.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "dev": "tsc -w",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
     "typescript": "^5.5.0"


### PR DESCRIPTION
- add justfile task runner for Python bridge commands
- simplify root monorepo scripts for dev, verify, build and package
- add PR CI with separate bridge and frontend jobs
- verify shared contracts and Electron UI build in frontend CI