### PR TITLE
Add graceful runtime channel shutdown

### DIFF
--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -14,11 +14,11 @@
    - ~~`open_read_connection()` dla API GET, najlepiej `mode=ro`.~~
    - ~~Nie odpalaj `ensure_schema()` w read dependency.~~
 
-3. **Zmień shutdown z `qsize()` na close/sentinel/drain**
-   - Najpierw zatrzymaj producers.
-   - Potem drain runtime input channel.
-   - Potem drain event channel.
-   - DbWriter ma zamknąć connection w `finally`.
+3. **~~Zmień shutdown z `qsize()` na close/sentinel/drain~~**
+   - ~~Najpierw zatrzymaj producers.~~
+   - ~~Potem drain runtime input channel.~~
+   - ~~Potem drain event channel.~~
+   - ~~DbWriter ma zamknąć connection w `finally`.~~
 
 4. **Domknij lifecycle backendu Pythonowego w Electronie**
    - Brak orphan processów i wiszących DB connection przy zamykaniu UI/backendu.
@@ -141,8 +141,8 @@
 
 1. ~~API write path -> runtime commands.~~
 2. ~~Read/write SQLite split.~~
-3. Shutdown close/sentinel/drain.
-4. DB connection close.
+3. ~~Shutdown close/sentinel/drain.~~
+4. ~~DB connection close.~~
 5. Electron backend lifecycle.
 6. Worker health.
 7. Drop visibility bug / active map circles.

--- a/apps/game-bridge/src/zml_game_bridge/api/routes/mining_tools.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/routes/mining_tools.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, TypeVar
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -25,7 +25,6 @@ from zml_game_bridge.runtime.runtime import AppRuntime
 from zml_game_bridge.runtime.runtime_commands import RuntimeCommand
 
 router = APIRouter(prefix="/api/v1/mining/tools", tags=["mining-tools"])
-T = TypeVar("T")
 
 
 def get_tool_service(runtime: RuntimeDep) -> MiningToolService:
@@ -91,7 +90,7 @@ def set_active_mining_tools(
     )
 
 
-def _execute_tool_command(runtime: AppRuntime, command: RuntimeCommand[T]) -> T:
+def _execute_tool_command[T](runtime: AppRuntime, command: RuntimeCommand[T]) -> T:
     try:
         return runtime.execute_runtime_command(command)
     except ValueError as exc:

--- a/apps/game-bridge/src/zml_game_bridge/persistence/sqlite.py
+++ b/apps/game-bridge/src/zml_game_bridge/persistence/sqlite.py
@@ -30,7 +30,9 @@ def open_read_connection(
 ) -> sqlite3.Connection:
     """Open a read-only connection for API/read-side queries."""
     path = Path(db_path).resolve()
-    conn = sqlite3.connect(path.as_uri() + "?mode=ro", uri=True, check_same_thread=check_same_thread)
+    conn = sqlite3.connect(
+        path.as_uri() + "?mode=ro", uri=True, check_same_thread=check_same_thread
+    )
     conn.row_factory = sqlite3.Row
 
     conn.execute("PRAGMA query_only=ON")
@@ -45,8 +47,7 @@ def open_sqlite(
     *,
     check_same_thread: bool = True,
 ) -> sqlite3.Connection:
-    """Open a writer connection.
-    """
+    """Open a writer connection."""
     return open_writer_connection(db_path, check_same_thread=check_same_thread)
 
 

--- a/apps/game-bridge/src/zml_game_bridge/runtime/channels.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/channels.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from queue import Empty, Queue
 from typing import Any
 from warnings import deprecated
@@ -9,28 +10,53 @@ from zml_game_bridge.runtime.event_requests import EventWriteRequest
 from zml_game_bridge.runtime.runtime_commands import RuntimeCommandRequest
 
 
+class ChannelClosed:
+    """Sentinel returned by take() after the channel has been closed and drained."""
+
+
+CHANNEL_CLOSED = ChannelClosed()
+
+
+class ChannelClosedError(RuntimeError):
+    pass
+
+
 class RuntimeChannel[T]:
     """Thread-safe queue for values crossing runtime worker boundaries."""
 
-    _q: Queue[T]
+    _q: Queue[T | ChannelClosed]
 
     def __init__(self, *, maxsize: int = 10_000) -> None:
         self._q = Queue(maxsize=maxsize)
+        self._closed = False
+        self._lock = threading.Lock()
 
     def emit(self, item: T) -> None:
         """Blocking by default (backpressure)."""
-        # TODO: Backpressure policy:
-        # - block indefinitely (current)
-        # - block with timeout + drop
-        # - non-blocking drop (put_nowait)
-        self._q.put(item)
+        with self._lock:
+            if self._closed:
+                raise ChannelClosedError(f"{type(self).__name__} is closed")
+            # Hold the lock while putting so close() cannot enqueue the sentinel
+            # ahead of an item that was already accepted by a producer.
+            self._q.put(item)
 
-    def take(self, *, timeout_s: float) -> T | None:
-        """Consumer side. Returns None on timeout."""
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._q.put(CHANNEL_CLOSED)
+
+    def take(self, *, timeout_s: float) -> T | ChannelClosed | None:
+        """Consumer side. Returns None on timeout or CHANNEL_CLOSED after close()."""
         try:
             return self._q.get(timeout=timeout_s)
         except Empty:
             return None
+
+    def is_closed(self) -> bool:
+        with self._lock:
+            return self._closed
 
     def size(self) -> int:
         return self._q.qsize()

--- a/apps/game-bridge/src/zml_game_bridge/runtime/db_commands.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/db_commands.py
@@ -3,22 +3,19 @@ from __future__ import annotations
 import sqlite3
 import threading
 from dataclasses import dataclass, field
-from typing import Any, Generic, Protocol, TypeVar, cast
+from typing import Any, Protocol, cast
 
 from zml_game_bridge.runtime.channels import RuntimeChannel
 
-T = TypeVar("T")
-T_co = TypeVar("T_co", covariant=True)
 
-
-class DbCommand(Protocol[T_co]):
+class DbCommand[T_co](Protocol):
     """A synchronous DB write/read unit executed by DbWriterWorker."""
 
     def execute(self, conn: sqlite3.Connection) -> T_co: ...
 
 
 @dataclass(slots=True)
-class DbCommandRequest(Generic[T]):
+class DbCommandRequest[T]:
     command: DbCommand[T]
     _done: threading.Event = field(default_factory=threading.Event, init=False)
     _result: T | None = field(default=None, init=False)
@@ -43,7 +40,7 @@ class DbCommandRequest(Generic[T]):
 class DbCommandChannel(RuntimeChannel[DbCommandRequest[Any]]):
     """Thread-safe queue for API/runtime commands that must use the DB writer."""
 
-    def execute(self, command: DbCommand[T], *, timeout_s: float = 5.0) -> T:
+    def execute[T](self, command: DbCommand[T], *, timeout_s: float = 5.0) -> T:
         request = DbCommandRequest(command)
         self.emit(request)
         return request.result(timeout_s=timeout_s)

--- a/apps/game-bridge/src/zml_game_bridge/runtime/db_writer.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/db_writer.py
@@ -11,7 +11,7 @@ from zml_game_bridge.persistence.event_projector import EventProjector
 from zml_game_bridge.persistence.event_writer import EventWriter
 from zml_game_bridge.persistence.schema import ensure_schema
 from zml_game_bridge.persistence.sqlite import open_writer_connection
-from zml_game_bridge.runtime.channels import EventChannel
+from zml_game_bridge.runtime.channels import ChannelClosed, EventChannel
 from zml_game_bridge.runtime.db_commands import DbCommandChannel, DbCommandRequest
 from zml_game_bridge.runtime.event_requests import EventWriteRequest
 
@@ -49,6 +49,8 @@ class DbWriterWorker:
             self.conn = None
 
     def run(self, *, stop_event: threading.Event) -> None:
+        # Runtime closes both DB channels when no more work can arrive.
+        _ = stop_event
         self.open()
         if self.conn is None:
             raise RuntimeError("Failed to open DB connection")
@@ -64,17 +66,24 @@ class DbWriterWorker:
         current_event_type: str | None = None
 
         try:
-            while (
-                not stop_event.is_set()
-                or self.pending_events.size() > 0
-                or self._pending_commands_size() > 0
-            ):
-                command = self._take_command()
+            events_open = True
+            commands_open = self.pending_commands is not None
+            while events_open or commands_open:
+                command = self._take_command(timeout_s=0.0 if events_open else 0.1)
+                if isinstance(command, ChannelClosed):
+                    commands_open = False
+                    continue
                 if command is not None:
                     self._execute_command(command)
                     continue
 
+                if not events_open:
+                    continue
+
                 item = self.pending_events.take(timeout_s=0.1)
+                if isinstance(item, ChannelClosed):
+                    events_open = False
+                    continue
                 if item is None:
                     continue
                 event = item.event if isinstance(item, EventWriteRequest) else item
@@ -110,13 +119,10 @@ class DbWriterWorker:
             logger.info("db_writer_stopped persisted_events=%s", persisted_events_count)
             self.close()
 
-    def _pending_commands_size(self) -> int:
-        return self.pending_commands.size() if self.pending_commands is not None else 0
-
-    def _take_command(self) -> DbCommandRequest[Any] | None:
+    def _take_command(self, *, timeout_s: float) -> DbCommandRequest[Any] | ChannelClosed | None:
         if self.pending_commands is None:
             return None
-        return self.pending_commands.take(timeout_s=0.0)
+        return self.pending_commands.take(timeout_s=timeout_s)
 
     def _execute_command(self, request: DbCommandRequest[Any]) -> None:
         if self.conn is None:

--- a/apps/game-bridge/src/zml_game_bridge/runtime/input_coordinator.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/input_coordinator.py
@@ -5,7 +5,7 @@ import threading
 from typing import Any
 
 from zml_game_bridge.events.base import EventBase, should_persist_event
-from zml_game_bridge.runtime.channels import EventChannel, RuntimeInputChannel
+from zml_game_bridge.runtime.channels import ChannelClosed, EventChannel, RuntimeInputChannel
 from zml_game_bridge.runtime.event_requests import EventWriteRequest
 from zml_game_bridge.runtime.runtime_commands import RuntimeCommandRequest
 from zml_game_bridge.runtime.signal_processor import NoOpSignalProcessor, SignalProcessor
@@ -37,10 +37,16 @@ class InputCoordinator:
         self.command_persist_timeout_s = command_persist_timeout_s
 
     def run(self, *, stop_event: threading.Event) -> None:
-        while not stop_event.is_set() or self.pending_signals.size() > 0:
+        # Producers observe stop_event; this worker exits only after the input channel is closed.
+        _ = stop_event
+        processed_inputs = 0
+        while True:
             item = self.pending_signals.take(timeout_s=0.1)
+            if isinstance(item, ChannelClosed):
+                break
             if item is None:
                 continue
+            processed_inputs += 1
             if isinstance(item, RuntimeCommandRequest):
                 self._process_command(item)
                 continue
@@ -60,6 +66,7 @@ class InputCoordinator:
 
             for event in derived_events:
                 self._route_durable_event(event)
+        logger.info("input_coordinator_stopped processed_inputs=%s", processed_inputs)
 
     def _process_command(self, request: RuntimeCommandRequest[Any]) -> None:
         command_type = type(request.command).__name__

--- a/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
@@ -148,6 +148,8 @@ class AppRuntime:
         *,
         timeout_s: float = 5.0,
     ) -> T:
+        if self._stop_event.is_set():
+            raise RuntimeError("Runtime is stopping")
         request = RuntimeCommandRequest(command)
         self._pending_inputs.emit(request)
         return request.result(timeout_s=timeout_s)
@@ -161,6 +163,11 @@ class AppRuntime:
     def start(self) -> None:
         if self._started:
             return
+        if self._pending_inputs.is_closed():
+            raise RuntimeError("Runtime cannot be restarted after shutdown")
+        if self._chat_log_path is None:
+            raise RuntimeError("Chat log path is not set; cannot start chat input")
+        self._stop_event.clear()
         self._restore_mining_lifecycle()
         self._started = True
         logger.info(
@@ -174,13 +181,6 @@ class AppRuntime:
             self._mock_inputs_enabled,
         )
 
-        self._t_input = Thread(
-            target=self._input_coordinator.run,
-            kwargs={"stop_event": self._stop_event},
-            daemon=True,
-        )
-        self._t_input.start()
-
         self._t_db = Thread(
             target=self._db_writer_worker.run,
             kwargs={"stop_event": self._stop_event},
@@ -188,8 +188,12 @@ class AppRuntime:
         )
         self._t_db.start()
 
-        if self._chat_log_path is None:
-            raise RuntimeError("Chat log path is not set; cannot start chat input")
+        self._t_input = Thread(
+            target=self._input_coordinator.run,
+            kwargs={"stop_event": self._stop_event},
+            daemon=True,
+        )
+        self._t_input.start()
 
         self._t_chat = Thread(
             target=start_chat_input,
@@ -272,6 +276,8 @@ class AppRuntime:
         )
 
     def stop(self) -> None:
+        if not self._started:
+            return
         logger.info("app_stopping")
         self._stop_event.set()
 
@@ -279,18 +285,27 @@ class AppRuntime:
             self._sub_sse.close()
             self._sub_sse = None
 
-        if self._t_chat is not None:
-            self._t_chat.join(timeout=2.0)
-        if self._t_ocr is not None:
-            self._t_ocr.join(timeout=2.0)
-        if self._t_mock is not None:
-            self._t_mock.join(timeout=2.0)
-        if self._t_input is not None:
-            self._t_input.join(timeout=2.0)
-        if self._t_db is not None:
-            self._t_db.join(timeout=2.0)
+        self._join_thread(self._t_chat, "chat_input")
+        self._join_thread(self._t_ocr, "ocr_input")
+        self._join_thread(self._t_mock, "mock_input")
+
+        self._pending_inputs.close()
+        self._join_thread(self._t_input, "input_coordinator")
+
+        self._pending_db_commands.close()
+        self._pending_events.close()
+        self._join_thread(self._t_db, "db_writer")
         self._started = False
         logger.info("app_stopped")
+
+    def _join_thread(self, thread: Thread | None, name: str) -> bool:
+        if thread is None:
+            return True
+        thread.join(timeout=5.0)
+        if thread.is_alive():
+            logger.warning("runtime_thread_did_not_stop thread=%s", name)
+            return False
+        return True
 
 
 def _now_ms() -> int:

--- a/apps/game-bridge/src/zml_game_bridge/runtime/runtime_commands.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/runtime_commands.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar, cast
+from typing import cast
 
 from zml_game_bridge.events.base import EventBase
-
-T = TypeVar("T")
 
 
 class UnsupportedRuntimeCommandError(Exception):
@@ -15,20 +13,20 @@ class UnsupportedRuntimeCommandError(Exception):
         self.command_type = command_type
 
 
-class RuntimeCommand(Generic[T]):
+class RuntimeCommand[T]:
     """Marker base for commands that enter the runtime input queue."""
 
     __slots__ = ()
 
 
 @dataclass(frozen=True, slots=True)
-class RuntimeCommandResult(Generic[T]):
+class RuntimeCommandResult[T]:
     value: T
     events: tuple[EventBase, ...] = ()
 
 
 @dataclass(slots=True)
-class RuntimeCommandRequest(Generic[T]):
+class RuntimeCommandRequest[T]:
     command: RuntimeCommand[T]
     _done: threading.Event = field(default_factory=threading.Event, init=False)
     _result: T | None = field(default=None, init=False)

--- a/apps/game-bridge/tests/runtime/test_channels.py
+++ b/apps/game-bridge/tests/runtime/test_channels.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from zml_game_bridge.runtime.channels import EventChannel
+import pytest
+
+from zml_game_bridge.runtime.channels import CHANNEL_CLOSED, ChannelClosedError, EventChannel
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,3 +27,19 @@ def test_event_channel_take_timeout_returns_none() -> None:
 
     got = channel.take(timeout_s=0.01)
     assert got is None
+
+
+def test_event_channel_close_returns_closed_sentinel() -> None:
+    channel = EventChannel(maxsize=10)
+
+    channel.close()
+
+    assert channel.take(timeout_s=0.1) is CHANNEL_CLOSED
+
+
+def test_event_channel_rejects_emit_after_close() -> None:
+    channel = EventChannel(maxsize=10)
+    channel.close()
+
+    with pytest.raises(ChannelClosedError):
+        channel.emit(DummyEvent(x=123))  # type: ignore[arg-type]

--- a/apps/game-bridge/tests/runtime/test_db_writer.py
+++ b/apps/game-bridge/tests/runtime/test_db_writer.py
@@ -77,6 +77,7 @@ def test_db_writer_persists_and_publishes(monkeypatch, tmp_path: Path) -> None:
 
     assert got.wait(timeout=1.0), "DbWriterWorker didn't publish anything"
     stop.set()
+    channel.close()
     thread.join(timeout=1.0)
 
     assert len(out) == 1
@@ -112,6 +113,7 @@ def test_db_writer_no_event_no_publish(monkeypatch, tmp_path: Path) -> None:
     time.sleep(0.2)
 
     stop.set()
+    channel.close()
     thread.join(timeout=1.0)
 
     assert out == []
@@ -148,6 +150,8 @@ def test_db_writer_executes_commands_on_writer_connection(monkeypatch, tmp_path:
         result = command_channel.execute(DummyCommand(21), timeout_s=1.0)
     finally:
         stop.set()
+        command_channel.close()
+        event_channel.close()
         thread.join(timeout=1.0)
         sub.close()
 
@@ -188,6 +192,7 @@ def test_db_writer_acknowledges_event_write_request(monkeypatch, tmp_path: Path)
         envelope = request.result(timeout_s=1.0)
     finally:
         stop.set()
+        channel.close()
         thread.join(timeout=1.0)
         sub.close()
 

--- a/apps/game-bridge/tests/runtime/test_input_coordinator.py
+++ b/apps/game-bridge/tests/runtime/test_input_coordinator.py
@@ -60,6 +60,7 @@ def test_input_coordinator_routes_derived_event_to_writer_queue_without_publishi
     derived = pending_events.take(timeout_s=1.0)
 
     stop.set()
+    incoming.close()
     thread.join(timeout=1.0)
 
     assert derived == DurableDummyEvent(42)
@@ -81,6 +82,7 @@ def test_input_coordinator_drops_internal_signal_when_no_event_is_derived() -> N
     event = pending_events.take(timeout_s=0.2)
 
     stop.set()
+    incoming.close()
     thread.join(timeout=1.0)
 
     assert event is None
@@ -104,6 +106,7 @@ def test_input_coordinator_processes_runtime_command_response() -> None:
     result = request.result(timeout_s=1.0)
 
     stop.set()
+    incoming.close()
     thread.join(timeout=1.0)
 
     assert result == 42


### PR DESCRIPTION
- add close/sentinel support to runtime channels
- drain input and DB writer queues explicitly during shutdown
- start DB writer before input coordinator
- reject runtime commands after shutdown begins
- update runtime worker tests and roadmap