### PR TITLE
Add runtime worker health endpoint

### DIFF
--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -24,9 +24,9 @@
    - Brak orphan processów i wiszących DB connection przy zamykaniu UI/backendu.
    - Naprawić przypadki `Waiting for background tasks to complete`.
 
-5. **Health state workerów**
-   - Minimalnie: running/degraded/crashed/stopped.
-   - DB writer/OCR/input coordinator crash ma być widoczny w `/health`.
+5. **~~Health state workerów~~**
+   - ~~Minimalnie: running/degraded/crashed/stopped.~~
+   - ~~DB writer/OCR/input coordinator crash ma być widoczny w `/health`.~~
 
 6. **Drop visibility bug / active map circles**
    - Dropy są trwałą historią runa/segmentu i nie mogą znikać ze statystyk.
@@ -144,7 +144,7 @@
 3. ~~Shutdown close/sentinel/drain.~~
 4. ~~DB connection close.~~
 5. Electron backend lifecycle.
-6. Worker health.
+6. ~~Worker health.~~
 7. Drop visibility bug / active map circles.
 
 ### Batch 2 — Mining correctness

--- a/apps/electron-ui/electron/agent/restClient.ts
+++ b/apps/electron-ui/electron/agent/restClient.ts
@@ -3,6 +3,7 @@ import {
   isRunWireOrNull,
   isRunWire,
   createMiningToolProfileRequestToWire,
+  isAgentHealthWire,
   isActiveMiningToolsWire,
   isMiningClaimWire,
   isMiningDropWire,
@@ -11,6 +12,7 @@ import {
   startRunRequestToWire,
   stopRunRequestToWire,
   updateRunRequestToWire,
+  wireToAgentHealthDto,
   wireToActiveMiningToolsDto,
   wireToMiningClaimDto,
   wireToMiningDropDto,
@@ -79,10 +81,10 @@ export class AgentRestClient implements AgentClient {
 
   async getHealth(): Promise<AgentHealthDto> {
     const data = await this.getJson("/health");
-    if (!isAgentHealthDto(data)) {
+    if (!isAgentHealthWire(data)) {
       throw new Error("Agent /health returned an invalid payload");
     }
-    return data;
+    return wireToAgentHealthDto(data);
   }
 
   async getActiveRun(): Promise<RunDto | null> {
@@ -284,8 +286,3 @@ function normalizeBaseUrl(baseUrl: string): string {
   return `http://${baseUrl}`;
 }
 
-function isAgentHealthDto(value: unknown): value is AgentHealthDto {
-  if (typeof value !== "object" || value === null) return false;
-  const record = value as Record<string, unknown>;
-  return typeof record.status === "string";
-}

--- a/apps/electron-ui/electron/mocks/mockAgentRestClient.ts
+++ b/apps/electron-ui/electron/mocks/mockAgentRestClient.ts
@@ -52,7 +52,36 @@ export class MockAgentRestClient implements AgentClient {
     };
 
     async getHealth(): Promise<AgentHealthDto> {
-        return { status: "mock" };
+        const now = Date.now();
+        return {
+            status: "running",
+            workers: {
+                db_writer: {
+                    state: "running",
+                    enabled: true,
+                    lastError: null,
+                    lastSeenTsMs: now,
+                },
+                input_coordinator: {
+                    state: "running",
+                    enabled: true,
+                    lastError: null,
+                    lastSeenTsMs: now,
+                },
+                ocr_worker: {
+                    state: "running",
+                    enabled: true,
+                    lastError: null,
+                    lastSeenTsMs: now,
+                },
+                chat_tail: {
+                    state: "running",
+                    enabled: true,
+                    lastError: null,
+                    lastSeenTsMs: now,
+                },
+            },
+        };
     }
 
     async startRun(request: StartRunRequest): Promise<RunDto> {

--- a/apps/game-bridge/src/zml_game_bridge/api/routes/health.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/routes/health.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from zml_game_bridge.api.dependencies import RuntimeDep
+from zml_game_bridge.api.schemas.health import HealthDto
+
 router = APIRouter()
 
 
-@router.get("/health")
-def health() -> dict[str, str]:
-    return {"status": "ok"}
+@router.get("/health", response_model=HealthDto)
+def health(runtime: RuntimeDep) -> HealthDto:
+    return HealthDto.model_validate(runtime.health())

--- a/apps/game-bridge/src/zml_game_bridge/api/schemas/health.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/schemas/health.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+WorkerStateDto = Literal["running", "degraded", "crashed", "stopped"]
+
+
+class WorkerHealthDto(BaseModel):
+    state: WorkerStateDto
+    enabled: bool
+    last_error: str | None
+    last_seen_ts_ms: int
+
+
+class HealthDto(BaseModel):
+    status: WorkerStateDto
+    workers: dict[str, WorkerHealthDto]

--- a/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 from threading import Thread
+from typing import Any
 
 from zml_game_bridge.api.channels.position_hub import OcrPositionHub
 from zml_game_bridge.api.channels.sse_hub import SseHub
@@ -36,6 +38,7 @@ from zml_game_bridge.runtime.mining.settings import default_id_factory
 from zml_game_bridge.runtime.mining.tools import MiningToolService
 from zml_game_bridge.runtime.position_state import LatestPositionState
 from zml_game_bridge.runtime.runtime_commands import RuntimeCommand, RuntimeCommandRequest
+from zml_game_bridge.runtime.worker_health import WorkerHealthRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +66,8 @@ class AppRuntime:
         self._mock_mining_interval_ms = mock_mining_interval_ms
 
         self._stop_event = threading.Event()
+        self._worker_health = WorkerHealthRegistry()
+        self._register_worker_health()
         self._pending_inputs = RuntimeInputChannel()
         self._pending_events = EventChannel()
         self._pending_db_commands = DbCommandChannel()
@@ -142,6 +147,9 @@ class AppRuntime:
     def execute_db_command[T](self, command: DbCommand[T], *, timeout_s: float = 5.0) -> T:
         return self._pending_db_commands.execute(command, timeout_s=timeout_s)
 
+    def health(self) -> dict[str, object]:
+        return self._worker_health.as_dict()
+
     def execute_runtime_command[T](
         self,
         command: RuntimeCommand[T],
@@ -181,55 +189,59 @@ class AppRuntime:
             self._mock_inputs_enabled,
         )
 
-        self._t_db = Thread(
+        self._t_db = self._create_worker_thread(
+            name="db_writer",
             target=self._db_writer_worker.run,
-            kwargs={"stop_event": self._stop_event},
-            daemon=True,
+            worker_kwargs={"stop_event": self._stop_event},
         )
         self._t_db.start()
 
-        self._t_input = Thread(
+        self._t_input = self._create_worker_thread(
+            name="input_coordinator",
             target=self._input_coordinator.run,
-            kwargs={"stop_event": self._stop_event},
-            daemon=True,
+            worker_kwargs={"stop_event": self._stop_event},
         )
         self._t_input.start()
 
-        self._t_chat = Thread(
+        self._t_chat = self._create_worker_thread(
+            name="chat_tail",
             target=start_chat_input,
-            kwargs={
+            worker_kwargs={
                 "path": self._chat_log_path,
                 "signal_sink": self._pending_inputs.emit,
                 "stop_event": self._stop_event,
                 "start_at_end": self._chat_start_at_end,
             },
-            daemon=True,
         )
         self._t_chat.start()
 
         if self._ocr_enabled:
-            preload_tesserocr()  # Needed for 'tesserocr import failed: signal only works in main thread of the main interpreter'
+            try:
+                preload_tesserocr()  # Needed for 'tesserocr import failed: signal only works in main thread of the main interpreter'
+            except Exception as exc:
+                self._worker_health.mark_crashed("ocr_worker", exc)
+                raise
 
-            self._t_ocr = Thread(
+            self._t_ocr = self._create_worker_thread(
+                name="ocr_worker",
                 target=start_ocr_input,
-                kwargs={
+                worker_kwargs={
                     "position_sink": self._on_position,
                     "signal_sink": self._pending_inputs.emit,
                     "stop_event": self._stop_event,
                 },
-                daemon=True,
             )
             self._t_ocr.start()
 
         if self._mock_inputs_enabled:
-            self._t_mock = Thread(
+            self._t_mock = self._create_worker_thread(
+                name="mock_mining_input",
                 target=start_mock_mining_input,
-                kwargs={
+                worker_kwargs={
                     "signal_sink": self._pending_inputs.emit,
                     "stop_event": self._stop_event,
                     "interval_ms": self._mock_mining_interval_ms,
                 },
-                daemon=True,
             )
             self._t_mock.start()
 
@@ -285,9 +297,9 @@ class AppRuntime:
             self._sub_sse.close()
             self._sub_sse = None
 
-        self._join_thread(self._t_chat, "chat_input")
-        self._join_thread(self._t_ocr, "ocr_input")
-        self._join_thread(self._t_mock, "mock_input")
+        self._join_thread(self._t_chat, "chat_tail")
+        self._join_thread(self._t_ocr, "ocr_worker")
+        self._join_thread(self._t_mock, "mock_mining_input")
 
         self._pending_inputs.close()
         self._join_thread(self._t_input, "input_coordinator")
@@ -298,12 +310,51 @@ class AppRuntime:
         self._started = False
         logger.info("app_stopped")
 
+    def _register_worker_health(self) -> None:
+        self._worker_health.register("db_writer", enabled=True)
+        self._worker_health.register("input_coordinator", enabled=True)
+        self._worker_health.register("chat_tail", enabled=True)
+        self._worker_health.register("ocr_worker", enabled=self._ocr_enabled)
+        self._worker_health.register("mock_mining_input", enabled=self._mock_inputs_enabled)
+
+    def _create_worker_thread(
+        self,
+        *,
+        name: str,
+        target: Callable[..., None],
+        worker_kwargs: dict[str, Any],
+    ) -> Thread:
+        return Thread(
+            target=self._run_worker,
+            kwargs={"name": name, "target": target, "worker_kwargs": worker_kwargs},
+            daemon=True,
+        )
+
+    def _run_worker(
+        self,
+        *,
+        name: str,
+        target: Callable[..., None],
+        worker_kwargs: dict[str, Any],
+    ) -> None:
+        self._worker_health.mark_running(name)
+        try:
+            target(**worker_kwargs)
+        except Exception as exc:
+            self._worker_health.mark_crashed(name, exc)
+            raise
+        if self._stop_event.is_set():
+            self._worker_health.mark_stopped(name)
+        else:
+            self._worker_health.mark_degraded(name, "worker returned before runtime shutdown")
+
     def _join_thread(self, thread: Thread | None, name: str) -> bool:
         if thread is None:
             return True
         thread.join(timeout=5.0)
         if thread.is_alive():
             logger.warning("runtime_thread_did_not_stop thread=%s", name)
+            self._worker_health.mark_degraded(name, "worker did not stop within 5s")
             return False
         return True
 

--- a/apps/game-bridge/src/zml_game_bridge/runtime/worker_health.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/worker_health.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+WorkerState = Literal["running", "degraded", "crashed", "stopped"]
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerHealthSnapshot:
+    state: WorkerState
+    enabled: bool
+    last_error: str | None
+    last_seen_ts_ms: int
+
+
+class WorkerHealthRegistry:
+    """Thread-safe in-memory health state for long-running runtime workers."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._workers: dict[str, WorkerHealthSnapshot] = {}
+
+    def register(self, name: str, *, enabled: bool) -> None:
+        with self._lock:
+            self._workers[name] = WorkerHealthSnapshot(
+                state="stopped",
+                enabled=enabled,
+                last_error=None,
+                last_seen_ts_ms=_now_ms(),
+            )
+
+    def mark_running(self, name: str) -> None:
+        self._set_state(name, state="running", last_error=None)
+
+    def mark_stopped(self, name: str) -> None:
+        self._set_state(name, state="stopped", last_error=None)
+
+    def mark_degraded(self, name: str, message: str) -> None:
+        self._set_state(name, state="degraded", last_error=message)
+
+    def mark_crashed(self, name: str, error: BaseException) -> None:
+        self._set_state(name, state="crashed", last_error=f"{type(error).__name__}: {error}")
+
+    def snapshot(self) -> dict[str, WorkerHealthSnapshot]:
+        with self._lock:
+            return dict(self._workers)
+
+    def as_dict(self) -> dict[str, object]:
+        workers = self.snapshot()
+        return {
+            "status": _overall_status(workers),
+            "workers": {name: asdict(worker) for name, worker in workers.items()},
+        }
+
+    def _set_state(
+        self,
+        name: str,
+        *,
+        state: WorkerState,
+        last_error: str | None,
+    ) -> None:
+        with self._lock:
+            previous = self._workers.get(name)
+            enabled = previous.enabled if previous is not None else True
+            self._workers[name] = WorkerHealthSnapshot(
+                state=state,
+                enabled=enabled,
+                last_error=last_error,
+                last_seen_ts_ms=_now_ms(),
+            )
+
+
+def _overall_status(workers: dict[str, WorkerHealthSnapshot]) -> WorkerState:
+    enabled_workers = [worker for worker in workers.values() if worker.enabled]
+    if not enabled_workers:
+        return "stopped"
+    if any(worker.state == "crashed" for worker in enabled_workers):
+        return "crashed"
+    if any(worker.state == "degraded" for worker in enabled_workers):
+        return "degraded"
+    if any(worker.state == "running" for worker in enabled_workers):
+        return "running"
+    return "stopped"
+
+
+def _now_ms() -> int:
+    return time.time_ns() // 1_000_000

--- a/apps/game-bridge/tests/runtime/test_worker_health.py
+++ b/apps/game-bridge/tests/runtime/test_worker_health.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from zml_game_bridge.runtime.worker_health import WorkerHealthRegistry
+
+
+def test_worker_health_registry_reports_running_status() -> None:
+    registry = WorkerHealthRegistry()
+    registry.register("db_writer", enabled=True)
+
+    registry.mark_running("db_writer")
+
+    snapshot = registry.as_dict()
+    workers = cast(dict[str, dict[str, Any]], snapshot["workers"])
+    assert snapshot["status"] == "running"
+    assert workers["db_writer"]["state"] == "running"
+    assert workers["db_writer"]["last_error"] is None
+
+
+def test_worker_health_registry_reports_crashed_status() -> None:
+    registry = WorkerHealthRegistry()
+    registry.register("db_writer", enabled=True)
+    registry.register("ocr_worker", enabled=False)
+
+    registry.mark_crashed("db_writer", RuntimeError("boom"))
+
+    snapshot = registry.as_dict()
+    workers = cast(dict[str, dict[str, Any]], snapshot["workers"])
+    assert snapshot["status"] == "crashed"
+    assert workers["db_writer"]["state"] == "crashed"
+    assert workers["db_writer"]["last_error"] == "RuntimeError: boom"
+    assert workers["ocr_worker"]["enabled"] is False

--- a/packages/shared/src/agent/health.ts
+++ b/packages/shared/src/agent/health.ts
@@ -1,3 +1,73 @@
-export type AgentHealthDto = {
-    status: string;
+export type WorkerHealthState = "running" | "degraded" | "crashed" | "stopped";
+
+export type WorkerHealthDto = {
+    state: WorkerHealthState;
+    enabled: boolean;
+    lastError: string | null;
+    lastSeenTsMs: number;
 };
+
+export type AgentHealthDto = {
+    status: WorkerHealthState;
+    workers: Record<string, WorkerHealthDto>;
+};
+
+export type WorkerHealthWire = {
+    state: WorkerHealthState;
+    enabled: boolean;
+    last_error: string | null;
+    last_seen_ts_ms: number;
+};
+
+export type AgentHealthWire = {
+    status: WorkerHealthState;
+    workers: Record<string, WorkerHealthWire>;
+};
+
+export function isAgentHealthWire(value: unknown): value is AgentHealthWire {
+    if (!isRecord(value) || !isWorkerHealthState(value.status) || !isRecord(value.workers)) {
+        return false;
+    }
+    return Object.values(value.workers).every(isWorkerHealthWire);
+}
+
+export function wireToAgentHealthDto(wire: AgentHealthWire): AgentHealthDto {
+    return {
+        status: wire.status,
+        workers: Object.fromEntries(
+            Object.entries(wire.workers).map(([name, worker]) => [
+                name,
+                {
+                    state: worker.state,
+                    enabled: worker.enabled,
+                    lastError: worker.last_error,
+                    lastSeenTsMs: worker.last_seen_ts_ms,
+                },
+            ]),
+        ),
+    };
+}
+
+function isWorkerHealthWire(value: unknown): value is WorkerHealthWire {
+    if (!isRecord(value)) return false;
+    return (
+        isWorkerHealthState(value.state) &&
+        typeof value.enabled === "boolean" &&
+        (value.last_error === null || typeof value.last_error === "string") &&
+        typeof value.last_seen_ts_ms === "number" &&
+        Number.isFinite(value.last_seen_ts_ms)
+    );
+}
+
+function isWorkerHealthState(value: unknown): value is WorkerHealthState {
+    return (
+        value === "running" ||
+        value === "degraded" ||
+        value === "crashed" ||
+        value === "stopped"
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
- track worker states for DB writer, input coordinator, chat, OCR, and mock input
- expose structured worker health from /health
- update shared Electron health contract and wire mapping
- add worker health registry tests
- mark worker health roadmap item complete