### PR TITLE
fix: keep run drop history separate from map circle TTL

### DIFF
--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -28,7 +28,7 @@
    - ~~Minimalnie: running/degraded/crashed/stopped.~~
    - ~~DB writer/OCR/input coordinator crash ma być widoczny w `/health`.~~
 
-6. **Drop visibility bug / active map circles**
+6. **~~Drop visibility bug / active map circles~~**
    - Dropy są trwałą historią runa/segmentu i nie mogą znikać ze statystyk.
    - Kółka z mapy mogą znikać, ale nie statystyki runa.
    - Aktywność kółek dropów powinna być UI visibility/TTL, nie backendowym usuwaniem dropów.
@@ -145,7 +145,7 @@
 4. ~~DB connection close.~~
 5. Electron backend lifecycle.
 6. ~~Worker health.~~
-7. Drop visibility bug / active map circles.
+7. ~~Drop visibility bug / active map circles.~~
 
 ### Batch 2 — Mining correctness
 

--- a/apps/electron-ui/electron/agent/restClient.ts
+++ b/apps/electron-ui/electron/agent/restClient.ts
@@ -66,6 +66,8 @@ export type ListMiningClaimsRequest = {
 
 export type ListMiningDropsRequest = {
   windowMinutes?: number;
+  runId?: number;
+  activeRun?: boolean;
 };
 
 export class AgentRestClient implements AgentClient {
@@ -173,6 +175,12 @@ export class AgentRestClient implements AgentClient {
     const params = new URLSearchParams();
     if (request.windowMinutes !== undefined) {
       params.set("window_minutes", String(request.windowMinutes));
+    }
+    if (request.runId !== undefined) {
+      params.set("run_id", String(request.runId));
+    }
+    if (request.activeRun !== undefined) {
+      params.set("active_run", request.activeRun ? "yes" : "no");
     }
 
     const serializedParams = params.toString();

--- a/apps/electron-ui/electron/ipc/registerIpc.ts
+++ b/apps/electron-ui/electron/ipc/registerIpc.ts
@@ -14,6 +14,7 @@ import {
 import { runtime } from "../runtime";
 import type { AgentClient } from "../agent/restClient.ts";
 import { pushStatePatch } from "./pushStatePatch.ts";
+import { replaceMiningDrops } from "../mining/miningDropsState.ts";
 import { replaceActiveRun, replaceRunSegments } from "../runs/runSegmentsState.ts";
 
 type RegisterIpcDeps = {
@@ -60,10 +61,12 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
         if (activeRun === null) {
             runtime.activeRun = null;
             runtime.runSegments = [];
+            replaceMiningDrops([]);
             pushStatePatch({ activeRun: null, runSegments: [] });
             return activeRun;
         }
         replaceActiveRun(activeRun);
+        replaceMiningDrops(await agentRestClient.listMiningDrops({ runId: activeRun.runId }));
         return activeRun;
     });
 
@@ -79,14 +82,16 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
             throw new Error("Invalid resume run request");
         }
         const activeRun = await agentRestClient.resumeRun(runId);
-        const [runs, runSegments] = await Promise.all([
+        const [runs, runSegments, miningDrops] = await Promise.all([
             agentRestClient.listRuns(),
             agentRestClient.listActiveRunSegments(),
+            agentRestClient.listMiningDrops({ runId }),
         ]);
         runtime.activeRun = activeRun;
         runtime.runs = runs;
         runtime.runSegments = runSegments;
-        pushStatePatch({ activeRun, runs, runSegments });
+        runtime.miningDrops = miningDrops;
+        pushStatePatch({ activeRun, runs, runSegments, miningDrops });
         return activeRun;
     });
 
@@ -132,7 +137,8 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
         runtime.activeRun = activeRun;
         runtime.runs = runs;
         runtime.runSegments = [];
-        pushStatePatch({ activeRun, runs, runSegments: [] });
+        runtime.miningDrops = [];
+        pushStatePatch({ activeRun, runs, runSegments: [], miningDrops: [] });
         return activeRun;
     });
 
@@ -145,7 +151,8 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
         runtime.activeRun = null;
         runtime.runs = runs;
         runtime.runSegments = [];
-        pushStatePatch({ activeRun: null, runs, runSegments: [] });
+        runtime.miningDrops = [];
+        pushStatePatch({ activeRun: null, runs, runSegments: [], miningDrops: [] });
         return stoppedRun;
     });
 

--- a/apps/electron-ui/electron/main.ts
+++ b/apps/electron-ui/electron/main.ts
@@ -94,7 +94,7 @@ async function refreshMiningSnapshot() {
   try {
     const [miningClaims, miningDrops] = await Promise.all([
       agentRestClient.listMiningClaims({ active: true }),
-      agentRestClient.listMiningDrops({ windowMinutes: 30 }),
+      agentRestClient.listMiningDrops({ activeRun: true }),
     ]);
     replaceMiningClaims(miningClaims);
     replaceMiningDrops(miningDrops);

--- a/apps/electron-ui/electron/mining/miningDropsState.ts
+++ b/apps/electron-ui/electron/mining/miningDropsState.ts
@@ -16,15 +16,13 @@ import {
 import { pushStatePatch } from "../ipc/pushStatePatch.ts";
 import { runtime } from "../runtime.ts";
 
-const MINING_DROP_WINDOW_MS = 30 * 60_000;
-
 export function replaceMiningClaims(claims: readonly MiningClaimDto[]): void {
     runtime.miningClaims = sortClaims([...claims]);
     pushStatePatch({ miningClaims: runtime.miningClaims });
 }
 
 export function replaceMiningDrops(drops: readonly MiningDropDto[]): void {
-    runtime.miningDrops = sortAndTrimDrops([...drops]);
+    runtime.miningDrops = sortDrops([...drops]);
     pushStatePatch({ miningDrops: runtime.miningDrops });
 }
 
@@ -89,7 +87,7 @@ function removeMiningClaim({
 
 function upsertMiningDrop(drop: MiningDropDto): void {
     const withoutCurrent = runtime.miningDrops.filter((item) => item.dropId !== drop.dropId);
-    runtime.miningDrops = sortAndTrimDrops([drop, ...withoutCurrent]);
+    runtime.miningDrops = sortDrops([drop, ...withoutCurrent]);
     pushStatePatch({ miningDrops: runtime.miningDrops });
 }
 
@@ -105,16 +103,13 @@ function updateMiningDrop(
     });
 
     if (changed) {
-        runtime.miningDrops = sortAndTrimDrops(runtime.miningDrops);
+        runtime.miningDrops = sortDrops(runtime.miningDrops);
         pushStatePatch({ miningDrops: runtime.miningDrops });
     }
 }
 
-function sortAndTrimDrops(drops: MiningDropDto[]): MiningDropDto[] {
-    const cutoff = Date.now() - MINING_DROP_WINDOW_MS;
-    return drops
-        .filter((drop) => drop.observedTsMs >= cutoff)
-        .sort((a, b) => b.observedTsMs - a.observedTsMs);
+function sortDrops(drops: MiningDropDto[]): MiningDropDto[] {
+    return drops.sort((a, b) => b.observedTsMs - a.observedTsMs);
 }
 
 function sortClaims(claims: MiningClaimDto[]): MiningClaimDto[] {

--- a/apps/electron-ui/electron/mocks/mockAgentRestClient.ts
+++ b/apps/electron-ui/electron/mocks/mockAgentRestClient.ts
@@ -182,7 +182,11 @@ export class MockAgentRestClient implements AgentClient {
     }
 
     async listMiningDrops(request: ListMiningDropsRequest = {}): Promise<MiningDropDto[]> {
-        const windowMs = (request.windowMinutes ?? 30) * 60_000;
+        if (request.activeRun || request.runId !== undefined || request.windowMinutes === undefined) {
+            return [...MOCK_MINING_DROPS];
+        }
+
+        const windowMs = request.windowMinutes * 60_000;
         const cutoff = Date.now() - windowMs;
         return MOCK_MINING_DROPS.filter((drop) => drop.observedTsMs >= cutoff);
     }

--- a/apps/electron-ui/src/widgets/map/mapViewport.tsx
+++ b/apps/electron-ui/src/widgets/map/mapViewport.tsx
@@ -38,6 +38,7 @@ const MAP_VIEWS = [MAP_VIEW];
 
 const DEBUG_CLAIMS_ENABLED = import.meta.env.VITE_ZML_UI_MOCKS === "1";
 const DEFAULT_PLAYER_RADIUS_M = 55;
+const DEFAULT_DROP_RADIUS_TTL_MINUTES = 30;
 const MAP_MIN_ZOOM = -2.5;
 const MAP_MAX_ZOOM = 6;
 const MAP_WHEEL_ZOOM_SPEED = 0.0016;
@@ -54,6 +55,7 @@ export function MapViewport({
   miningClaims,
   miningDrops,
   playerRadiusM,
+  dropRadiusTtlMinutes = DEFAULT_DROP_RADIUS_TTL_MINUTES,
   followPlayer,
   onFollowPlayerChange,
 }: {
@@ -62,6 +64,7 @@ export function MapViewport({
   miningClaims: readonly MiningClaimDto[];
   miningDrops: readonly MiningDropDto[];
   playerRadiusM?: number | null;
+  dropRadiusTtlMinutes?: number | null;
   followPlayer: boolean;
   onFollowPlayerChange: (followPlayer: boolean) => void;
 }) {
@@ -98,8 +101,12 @@ export function MapViewport({
   }, [marker]);
 
   const mapMiningDrops = useMemo<MapMiningDrop[]>(
-    () =>
-      miningDrops.flatMap((drop) => {
+    () => {
+      const ttlMinutes = dropRadiusTtlMinutes ?? DEFAULT_DROP_RADIUS_TTL_MINUTES;
+      const cutoffTsMs = ttlMinutes <= 0 ? null : (currentSec - ttlMinutes * 60) * 1000;
+
+      return miningDrops.flatMap((drop) => {
+        if (cutoffTsMs !== null && drop.observedTsMs < cutoffTsMs) return [];
         if (!drop.position || !isDropOnPlanet(planetId, drop)) return [];
 
         return [
@@ -116,8 +123,9 @@ export function MapViewport({
                 : null,
           },
         ];
-      }),
-    [miningDrops, planetId],
+      });
+    },
+    [currentSec, dropRadiusTtlMinutes, miningDrops, planetId],
   );
   const playerRangeRadiusM = useMemo(
     () =>
@@ -153,6 +161,9 @@ export function MapViewport({
     () => mapMiningClaims.some((claim) => claim.expiresAtSec !== null),
     [mapMiningClaims],
   );
+  const hasDropRadiusTtl =
+    miningDrops.length > 0 &&
+    (dropRadiusTtlMinutes ?? DEFAULT_DROP_RADIUS_TTL_MINUTES) > 0;
 
   useEffect(() => {
     const initialViewState = createInitialMapViewState(planetId);
@@ -259,11 +270,11 @@ export function MapViewport({
   }, [followPlayer, marker]);
 
   useEffect(() => {
-    if (!DEBUG_CLAIMS_ENABLED && !hasClaimTimers) return;
+    if (!DEBUG_CLAIMS_ENABLED && !hasClaimTimers && !hasDropRadiusTtl) return;
 
     const timer = window.setInterval(() => setCurrentSec(nowSec()), 1000);
     return () => window.clearInterval(timer);
-  }, [hasClaimTimers]);
+  }, [hasClaimTimers, hasDropRadiusTtl]);
 
   const tileLayer = useMemo(() => createMapTileLayer(planetId), [planetId]);
   const debugClaims = useMemo(

--- a/apps/electron-ui/src/windows/mapPreferences.ts
+++ b/apps/electron-ui/src/windows/mapPreferences.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type MapPreferences = {
+  dropRadiusTtlMinutes: number;
+};
+
+const STORAGE_KEY = "zml.map.preferences";
+const MAP_PREFS_EVENT = "zml-map-preferences";
+const DEFAULT_DROP_RADIUS_TTL_MINUTES = 30;
+const MAX_DROP_RADIUS_TTL_MINUTES = 24 * 60;
+
+export const DEFAULT_MAP_PREFERENCES: MapPreferences = {
+  dropRadiusTtlMinutes: DEFAULT_DROP_RADIUS_TTL_MINUTES,
+};
+
+export function useMapPreferences(): [
+  MapPreferences,
+  (next: MapPreferences | ((current: MapPreferences) => MapPreferences)) => void,
+] {
+  const [preferences, setPreferences] = useState(readMapPreferences);
+
+  useEffect(() => {
+    const handleChange = () => setPreferences(readMapPreferences());
+    window.addEventListener("storage", handleChange);
+    window.addEventListener(MAP_PREFS_EVENT, handleChange);
+    return () => {
+      window.removeEventListener("storage", handleChange);
+      window.removeEventListener(MAP_PREFS_EVENT, handleChange);
+    };
+  }, []);
+
+  const updatePreferences = useCallback(
+    (next: MapPreferences | ((current: MapPreferences) => MapPreferences)) => {
+      const current = readMapPreferences();
+      const resolved = normalizePreferences(
+        typeof next === "function" ? next(current) : next,
+      );
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(resolved));
+      window.dispatchEvent(new Event(MAP_PREFS_EVENT));
+      setPreferences(resolved);
+    },
+    [],
+  );
+
+  return [preferences, updatePreferences];
+}
+
+function readMapPreferences(): MapPreferences {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_MAP_PREFERENCES;
+    return normalizePreferences(JSON.parse(raw));
+  } catch {
+    return DEFAULT_MAP_PREFERENCES;
+  }
+}
+
+function normalizePreferences(value: unknown): MapPreferences {
+  if (!isRecord(value)) return DEFAULT_MAP_PREFERENCES;
+  return {
+    dropRadiusTtlMinutes: clampDropRadiusTtl(value.dropRadiusTtlMinutes),
+  };
+}
+
+function clampDropRadiusTtl(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_DROP_RADIUS_TTL_MINUTES;
+  }
+  return Math.max(0, Math.min(MAX_DROP_RADIUS_TTL_MINUTES, Math.round(value)));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/electron-ui/src/windows/mapWindow.css
+++ b/apps/electron-ui/src/windows/mapWindow.css
@@ -51,6 +51,27 @@
   -webkit-app-region: no-drag;
 }
 
+.zml-map-setting {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #9fb0c7;
+  font-size: 11px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.zml-map-setting select {
+  height: 27px;
+  border: 1px solid #2b3341;
+  border-radius: 6px;
+  background: #111721;
+  color: #d9e7fa;
+  padding: 0 8px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
 .zml-map-actions button {
   min-height: 27px;
   border: 1px solid #2b3341;

--- a/apps/electron-ui/src/windows/mapWindow.tsx
+++ b/apps/electron-ui/src/windows/mapWindow.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import type { WindowType } from "@zml/shared";
 import { MapViewport } from "../widgets/map/mapViewport.tsx";
 import { toggleMapWindow, useZmlRendererStore } from "../state/zmlRendererStore";
+import { useMapPreferences } from "./mapPreferences";
 import "./mapWindow.css";
 
 type MapPoint = { x: number; y: number };
@@ -10,6 +11,7 @@ export function MapWindow() {
   const windowType: WindowType = "map";
   const state = useZmlRendererStore(windowType);
   const [followPlayer, setFollowPlayer] = useState(true);
+  const [preferences, setPreferences] = useMapPreferences();
 
   const point: MapPoint | null = useMemo(() => {
     const pos = state.position?.position;
@@ -28,6 +30,22 @@ export function MapWindow() {
           <span>{planetId}</span>
         </div>
         <div className="zml-map-actions">
+          <label className="zml-map-setting">
+            <span>Drop circles</span>
+            <select
+              value={String(preferences.dropRadiusTtlMinutes)}
+              onChange={(event) => {
+                const value = Number(event.currentTarget.value);
+                setPreferences((current) => ({ ...current, dropRadiusTtlMinutes: value }));
+              }}
+            >
+              <option value="15">15m</option>
+              <option value="30">30m</option>
+              <option value="60">60m</option>
+              <option value="120">120m</option>
+              <option value="0">Always</option>
+            </select>
+          </label>
           <button
             type="button"
             className={followPlayer ? "is-active" : undefined}
@@ -53,6 +71,7 @@ export function MapWindow() {
           miningClaims={state.miningClaims}
           miningDrops={state.miningDrops}
           playerRadiusM={state.activeMiningTools?.effectiveFinderRadiusM}
+          dropRadiusTtlMinutes={preferences.dropRadiusTtlMinutes}
           followPlayer={followPlayer}
           onFollowPlayerChange={setFollowPlayer}
         />

--- a/apps/game-bridge/src/zml_game_bridge/api/routes/mining.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/routes/mining.py
@@ -27,7 +27,9 @@ def list_mining_drops(
     if active_run:
         active_run_id = RunState(conn).try_get_active_run_id()
         rows = [] if active_run_id is None else reader.list_for_run(run_id=active_run_id)
-        logger.debug("api_request_read_drops active_run=true run_id=%s rows=%s", active_run_id, len(rows))
+        logger.debug(
+            "api_request_read_drops active_run=true run_id=%s rows=%s", active_run_id, len(rows)
+        )
     elif run_id is not None:
         rows = reader.list_for_run(run_id=run_id)
         logger.debug("api_request_read_drops run_id=%s rows=%s", run_id, len(rows))

--- a/apps/game-bridge/src/zml_game_bridge/api/routes/mining.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/routes/mining.py
@@ -10,6 +10,7 @@ from zml_game_bridge.api.dependencies import ReadConn
 from zml_game_bridge.api.schemas.mining import MiningClaimDto, MiningDropDto
 from zml_game_bridge.persistence.mining_claims import MiningClaimReader
 from zml_game_bridge.persistence.mining_drops import MiningDropReader
+from zml_game_bridge.runs.state import RunState
 
 router = APIRouter(prefix="/api/v1/mining", tags=["mining"])
 logger = logging.getLogger(__name__)
@@ -19,10 +20,21 @@ logger = logging.getLogger(__name__)
 def list_mining_drops(
     conn: ReadConn,
     window_minutes: Annotated[int, Query(ge=1, le=24 * 60)] = 30,
+    run_id: Annotated[int | None, Query(ge=1)] = None,
+    active_run: Annotated[bool, Query()] = False,
 ) -> list[MiningDropDto]:
-    since_ts_ms = _now_ms() - window_minutes * 60_000
-    rows = MiningDropReader(conn).list_since(since_ts_ms=since_ts_ms)
-    logger.debug("api_request_read_drops window_minutes=%s rows=%s", window_minutes, len(rows))
+    reader = MiningDropReader(conn)
+    if active_run:
+        active_run_id = RunState(conn).try_get_active_run_id()
+        rows = [] if active_run_id is None else reader.list_for_run(run_id=active_run_id)
+        logger.debug("api_request_read_drops active_run=true run_id=%s rows=%s", active_run_id, len(rows))
+    elif run_id is not None:
+        rows = reader.list_for_run(run_id=run_id)
+        logger.debug("api_request_read_drops run_id=%s rows=%s", run_id, len(rows))
+    else:
+        since_ts_ms = _now_ms() - window_minutes * 60_000
+        rows = reader.list_since(since_ts_ms=since_ts_ms)
+        logger.debug("api_request_read_drops window_minutes=%s rows=%s", window_minutes, len(rows))
     return [MiningDropDto.from_row(row) for row in rows]
 
 

--- a/apps/game-bridge/src/zml_game_bridge/persistence/mining_drops.py
+++ b/apps/game-bridge/src/zml_game_bridge/persistence/mining_drops.py
@@ -65,6 +65,18 @@ class MiningDropReader:
         )
         return [_row_to_mining_drop(row) for row in cur.fetchall()]
 
+    def list_for_run(self, *, run_id: int) -> list[MiningDropRow]:
+        cur = self._conn.execute(
+            """
+            SELECT *
+            FROM mining_drops
+            WHERE run_id = ?
+            ORDER BY observed_ts_ms DESC, drop_event_id DESC
+            """,
+            (run_id,),
+        )
+        return [_row_to_mining_drop(row) for row in cur.fetchall()]
+
     def get(self, drop_id: str) -> MiningDropRow | None:
         cur = self._conn.execute(
             """

--- a/apps/game-bridge/tests/persistence/test_mining_drops.py
+++ b/apps/game-bridge/tests/persistence/test_mining_drops.py
@@ -134,9 +134,15 @@ def test_mining_drop_reader_lists_full_run_history(tmp_path: Path) -> None:
         active_run_id = run_store.create_run(name="Active run", notes=None, ts_ms=1_000)
         other_run_id = run_store.create_run(name="Other run", notes=None, ts_ms=1_000)
 
-        writer.write(_drop_event(drop_id="old-active-run-drop", run_id=active_run_id, observed_ts_ms=1_000))
-        writer.write(_drop_event(drop_id="new-active-run-drop", run_id=active_run_id, observed_ts_ms=2_000))
-        writer.write(_drop_event(drop_id="other-run-drop", run_id=other_run_id, observed_ts_ms=3_000))
+        writer.write(
+            _drop_event(drop_id="old-active-run-drop", run_id=active_run_id, observed_ts_ms=1_000)
+        )
+        writer.write(
+            _drop_event(drop_id="new-active-run-drop", run_id=active_run_id, observed_ts_ms=2_000)
+        )
+        writer.write(
+            _drop_event(drop_id="other-run-drop", run_id=other_run_id, observed_ts_ms=3_000)
+        )
 
         rows = MiningDropReader(conn).list_for_run(run_id=active_run_id)
 

--- a/apps/game-bridge/tests/persistence/test_mining_drops.py
+++ b/apps/game-bridge/tests/persistence/test_mining_drops.py
@@ -13,6 +13,7 @@ from zml_game_bridge.domain.money import Mpec
 from zml_game_bridge.domain.position import WorldPos
 from zml_game_bridge.persistence.event_writer import EventWriter
 from zml_game_bridge.persistence.mining_drops import MiningDropProjector, MiningDropReader
+from zml_game_bridge.persistence.runs import RunStore
 from zml_game_bridge.persistence.schema import ensure_schema
 from zml_game_bridge.persistence.sqlite import open_sqlite
 
@@ -125,10 +126,34 @@ def test_mining_drop_projector_ignores_unlinked_result(tmp_path: Path) -> None:
         conn.close()
 
 
-def _drop_event(*, drop_id: str) -> MiningDropEvent:
+def test_mining_drop_reader_lists_full_run_history(tmp_path: Path) -> None:
+    conn = _open_test_db(tmp_path)
+    try:
+        writer = EventWriter(conn, projector=MiningDropProjector())
+        run_store = RunStore(conn)
+        active_run_id = run_store.create_run(name="Active run", notes=None, ts_ms=1_000)
+        other_run_id = run_store.create_run(name="Other run", notes=None, ts_ms=1_000)
+
+        writer.write(_drop_event(drop_id="old-active-run-drop", run_id=active_run_id, observed_ts_ms=1_000))
+        writer.write(_drop_event(drop_id="new-active-run-drop", run_id=active_run_id, observed_ts_ms=2_000))
+        writer.write(_drop_event(drop_id="other-run-drop", run_id=other_run_id, observed_ts_ms=3_000))
+
+        rows = MiningDropReader(conn).list_for_run(run_id=active_run_id)
+
+        assert [row.drop_id for row in rows] == ["new-active-run-drop", "old-active-run-drop"]
+    finally:
+        conn.close()
+
+
+def _drop_event(
+    *,
+    drop_id: str,
+    run_id: int | None = None,
+    observed_ts_ms: int = 1_000,
+) -> MiningDropEvent:
     return MiningDropEvent(
         drop_id=drop_id,
-        observed_ts_ms=1_000,
+        observed_ts_ms=observed_ts_ms,
         position=WorldPos(planet_name="Calypso", x=58_890, y=84_639, z=None),
         modes_mask=1,
         probes_per_drop=None,
@@ -141,4 +166,5 @@ def _drop_event(*, drop_id: str) -> MiningDropEvent:
             total_mpec=Mpec(10_100),
         ),
         drop_radius_m=54.0,
+        run_id=run_id,
     )


### PR DESCRIPTION
- load mining drops by active run/run id instead of a fixed 30 minute backend window
- stop trimming miningDrops in Electron runtime state
- apply configurable TTL only to map drop radius circles
- reload/clear drop state when runs are resumed, started, or stopped
- add persistence coverage for full run drop history