### PR TITLE
refactor(game-bridge): split runtime bootstrap and supervision

### DIFF
--- a/apps/game-bridge/src/zml_game_bridge/api/app.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/app.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from zml_game_bridge.api.channels.position_hub import OcrPositionHub
 from zml_game_bridge.api.channels.sse_hub import SseHub
 from zml_game_bridge.api.routes import register_routes
+from zml_game_bridge.runtime.bootstrap import build_runtime_components, build_worker_supervisor
 from zml_game_bridge.runtime.runtime import AppRuntime
 from zml_game_bridge.settings import Settings
 
@@ -27,23 +28,16 @@ def create_app() -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        runtime = AppRuntime(
-            db_path=settings.db_path,
-            chat_log_path=settings.chat_log_path,
-            mining_resource_catalog_path=settings.mining_resource_catalog_path,
-            mining_tools_path=settings.mining_tools_path,
-            chat_start_at_end=settings.chat_start_at_end,
-            ocr_enabled=settings.ocr_enabled,
-            mock_inputs_enabled=settings.mock_inputs_enabled,
-            mock_mining_interval_ms=settings.mock_mining_interval_ms,
-        )
-
         loop = asyncio.get_running_loop()
         sse_hub = SseHub(loop)
         position_hub = OcrPositionHub(loop)
-
-        runtime.attach_sse_hub(sse_hub)
-        runtime.attach_position_hub(position_hub)
+        runtime = AppRuntime(
+            settings=settings,
+            components=build_runtime_components(settings),
+            supervisor=build_worker_supervisor(settings),
+            sse_hub=sse_hub,
+            position_hub=position_hub,
+        )
 
         app.state.runtime = runtime
         runtime.start()

--- a/apps/game-bridge/src/zml_game_bridge/runtime/bootstrap.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/bootstrap.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from zml_game_bridge.application.mining import MiningCoordinator
+from zml_game_bridge.application.mining.equipment.service import MiningEquipmentService
+from zml_game_bridge.application.mining.segments.session import RunSessionService
+from zml_game_bridge.application.mining.settings import default_id_factory
+from zml_game_bridge.application.position.latest_position import LatestPositionState
+from zml_game_bridge.domain.mining_cost import MiningEquipmentProfile
+from zml_game_bridge.domain.position import WorldPos
+from zml_game_bridge.events.in_memory_persisted_event_bus import InMemoryPersistedEventBus
+from zml_game_bridge.persistence.event_projector import CompositeEventProjector
+from zml_game_bridge.persistence.mining_claims import MiningClaimProjector
+from zml_game_bridge.persistence.mining_drops import MiningDropProjector
+from zml_game_bridge.persistence.runs import RunSegmentProjector
+from zml_game_bridge.resources.mining_resources import MiningResourceCatalog
+from zml_game_bridge.runtime.channels import EventChannel, RuntimeInputChannel
+from zml_game_bridge.runtime.db_commands import DbCommandChannel
+from zml_game_bridge.runtime.db_writer import DbWriterWorker
+from zml_game_bridge.runtime.input_coordinator import InputCoordinator
+from zml_game_bridge.runtime.restore import MiningLifecycleRestorer
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
+from zml_game_bridge.settings import Settings
+
+
+@dataclass(slots=True)
+class RuntimeComponents:
+    pending_inputs: RuntimeInputChannel
+    pending_events: EventChannel
+    pending_db_commands: DbCommandChannel
+    persisted_events: InMemoryPersistedEventBus
+    latest_position: LatestPositionState
+    mining_equipment_service: MiningEquipmentService
+    run_session_service: RunSessionService
+    mining_coordinator: MiningCoordinator
+    input_coordinator: InputCoordinator
+    db_writer_worker: DbWriterWorker
+    lifecycle_restorer: MiningLifecycleRestorer
+
+
+def build_runtime_components(settings: Settings) -> RuntimeComponents:
+    pending_inputs = RuntimeInputChannel()
+    pending_events = EventChannel()
+    pending_db_commands = DbCommandChannel()
+    persisted_events = InMemoryPersistedEventBus()
+    latest_position = LatestPositionState()
+    resource_catalog = MiningResourceCatalog(user_path=settings.mining_resource_catalog_path)
+    mining_equipment_service = MiningEquipmentService(path=settings.mining_tools_path)
+    run_session_service = RunSessionService(
+        db_path=settings.db_path,
+        id_factory=default_id_factory,
+    )
+
+    def current_position() -> WorldPos | None:
+        position = latest_position.get()
+        return position.position if position is not None else None
+
+    def run_context_for_drop(observed_ts_ms: int, profile: MiningEquipmentProfile):
+        return run_session_service.context_for_drop(
+            observed_ts_ms=observed_ts_ms,
+            profile=profile,
+        )
+
+    mining_coordinator = MiningCoordinator(
+        profile_provider=mining_equipment_service.get_equipment_profile,
+        position_provider=current_position,
+        resource_catalog=resource_catalog,
+        run_context_provider=run_context_for_drop,
+        db_command_executor=pending_db_commands.execute,
+        mining_equipment_service=mining_equipment_service,
+    )
+    input_coordinator = InputCoordinator(
+        pending_inputs=pending_inputs,
+        pending_events=pending_events,
+        input_processor=mining_coordinator,
+    )
+    db_writer_worker = DbWriterWorker(
+        db_path=settings.db_path,
+        pending_events=pending_events,
+        pending_commands=pending_db_commands,
+        persisted_events=persisted_events,
+        projector=CompositeEventProjector(
+            [
+                RunSegmentProjector(),
+                MiningDropProjector(),
+                MiningClaimProjector(),
+            ]
+        ),
+    )
+    lifecycle_restorer = MiningLifecycleRestorer(
+        db_path=settings.db_path,
+        mining_coordinator=mining_coordinator,
+    )
+
+    return RuntimeComponents(
+        pending_inputs=pending_inputs,
+        pending_events=pending_events,
+        pending_db_commands=pending_db_commands,
+        persisted_events=persisted_events,
+        latest_position=latest_position,
+        mining_equipment_service=mining_equipment_service,
+        run_session_service=run_session_service,
+        mining_coordinator=mining_coordinator,
+        input_coordinator=input_coordinator,
+        db_writer_worker=db_writer_worker,
+        lifecycle_restorer=lifecycle_restorer,
+    )
+
+
+def build_worker_supervisor(settings: Settings) -> WorkerSupervisor:
+    supervisor = WorkerSupervisor()
+    supervisor.register("db_writer", enabled=True)
+    supervisor.register("input_coordinator", enabled=True)
+    supervisor.register("chat_tail", enabled=True)
+    supervisor.register("ocr_worker", enabled=settings.ocr_enabled)
+    supervisor.register("mock_mining_input", enabled=settings.mock_inputs_enabled)
+    return supervisor

--- a/apps/game-bridge/src/zml_game_bridge/runtime/restore.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/restore.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from zml_game_bridge.application.mining import MiningCoordinator
+from zml_game_bridge.application.mining.claims.lifecycle import ActiveClaim
+from zml_game_bridge.persistence.mining_claims import MiningClaimReader
+from zml_game_bridge.persistence.schema import ensure_schema
+from zml_game_bridge.persistence.sqlite import open_read_connection, open_writer_connection
+
+
+class MiningLifecycleRestorer:
+    """Restores volatile mining lifecycle state from durable read models."""
+
+    def __init__(self, *, db_path: Path, mining_coordinator: MiningCoordinator) -> None:
+        self._db_path = db_path
+        self._mining_coordinator = mining_coordinator
+
+    def restore(self) -> None:
+        conn = open_writer_connection(self._db_path)
+        try:
+            ensure_schema(conn)
+        finally:
+            conn.close()
+
+        conn = open_read_connection(self._db_path)
+        try:
+            rows = MiningClaimReader(conn).list_active(now_ts_ms=_now_ms())
+        finally:
+            conn.close()
+
+        self._mining_coordinator.restore_active_claims(
+            ActiveClaim(
+                claim_id=row.claim_id,
+                drop_id=row.drop_id,
+                hit_id=row.hit_id,
+                position=row.position,
+                search_radius_m=row.search_radius_m,
+            )
+            for row in rows
+        )
+
+
+def _now_ms() -> int:
+    return time.time_ns() // 1_000_000

--- a/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
@@ -2,43 +2,23 @@ from __future__ import annotations
 
 import logging
 import threading
-import time
-from collections.abc import Callable
 from pathlib import Path
-from threading import Thread
-from typing import Any
 
 from zml_game_bridge.api.channels.position_hub import OcrPositionHub
 from zml_game_bridge.api.channels.sse_hub import SseHub
-from zml_game_bridge.application.mining import MiningCoordinator
-from zml_game_bridge.application.mining.claims.lifecycle import ActiveClaim
 from zml_game_bridge.application.mining.equipment.service import MiningEquipmentService
 from zml_game_bridge.application.mining.segments.session import RunSessionService
-from zml_game_bridge.application.mining.settings import default_id_factory
 from zml_game_bridge.application.position.latest_position import LatestPositionState
-from zml_game_bridge.domain.mining_cost import MiningEquipmentProfile
-from zml_game_bridge.domain.position import WorldPos
-from zml_game_bridge.events.in_memory_persisted_event_bus import (
-    InMemoryPersistedEventBus,
-)
 from zml_game_bridge.inputs.chat.runner import start_chat_input
 from zml_game_bridge.inputs.mock.mining import start_mock_mining_input
 from zml_game_bridge.inputs.ocr.pipelines.position.engine import preload_tesserocr
 from zml_game_bridge.inputs.ocr.pipelines.position.model import OcrPosition
 from zml_game_bridge.inputs.ocr.runner import start_ocr_input
-from zml_game_bridge.persistence.event_projector import CompositeEventProjector
-from zml_game_bridge.persistence.mining_claims import MiningClaimProjector, MiningClaimReader
-from zml_game_bridge.persistence.mining_drops import MiningDropProjector
-from zml_game_bridge.persistence.runs import RunSegmentProjector
-from zml_game_bridge.persistence.schema import ensure_schema
-from zml_game_bridge.persistence.sqlite import open_read_connection, open_writer_connection
-from zml_game_bridge.resources.mining_resources import MiningResourceCatalog
-from zml_game_bridge.runtime.channels import EventChannel, RuntimeInputChannel
-from zml_game_bridge.runtime.db_commands import DbCommand, DbCommandChannel
-from zml_game_bridge.runtime.db_writer import DbWriterWorker
-from zml_game_bridge.runtime.input_coordinator import InputCoordinator
+from zml_game_bridge.runtime.bootstrap import RuntimeComponents
+from zml_game_bridge.runtime.db_commands import DbCommand
 from zml_game_bridge.runtime.runtime_commands import RuntimeCommand, RuntimeCommandRequest
-from zml_game_bridge.runtime.worker_health import WorkerHealthRegistry
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
+from zml_game_bridge.settings import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -47,80 +27,24 @@ class AppRuntime:
     def __init__(
         self,
         *,
-        db_path: Path,
-        chat_log_path: Path | None,
-        mining_resource_catalog_path: Path,
-        mining_tools_path: Path,
-        chat_start_at_end: bool,
-        ocr_enabled: bool,
-        mock_inputs_enabled: bool,
-        mock_mining_interval_ms: int,
+        settings: Settings,
+        components: RuntimeComponents,
+        supervisor: WorkerSupervisor,
+        sse_hub: SseHub | None = None,
+        position_hub: OcrPositionHub | None = None,
     ) -> None:
-        self._db_path = db_path
-        self._chat_log_path = chat_log_path
-        self._mining_resource_catalog_path = mining_resource_catalog_path
-        self._mining_tools_path = mining_tools_path
-        self._chat_start_at_end = chat_start_at_end
-        self._ocr_enabled = ocr_enabled
-        self._mock_inputs_enabled = mock_inputs_enabled
-        self._mock_mining_interval_ms = mock_mining_interval_ms
-
+        self._settings = settings
+        self._components = components
+        self._supervisor = supervisor
         self._stop_event = threading.Event()
-        self._worker_health = WorkerHealthRegistry()
-        self._register_worker_health()
-        self._pending_inputs = RuntimeInputChannel()
-        self._pending_events = EventChannel()
-        self._pending_db_commands = DbCommandChannel()
-        self._persisted_events = InMemoryPersistedEventBus()
-        self._latest_position = LatestPositionState()
-        self._resource_catalog = MiningResourceCatalog(user_path=self._mining_resource_catalog_path)
-        self._mining_equipment_service = MiningEquipmentService(path=self._mining_tools_path)
-        self._run_session_service = RunSessionService(
-            db_path=self._db_path,
-            id_factory=default_id_factory,
-        )
-        self._mining_coordinator = MiningCoordinator(
-            profile_provider=self._mining_equipment_service.get_equipment_profile,
-            position_provider=self._current_position,
-            resource_catalog=self._resource_catalog,
-            run_context_provider=self._run_context_for_drop,
-            db_command_executor=self.execute_db_command,
-            mining_equipment_service=self._mining_equipment_service,
-        )
-        self._input_coordinator = InputCoordinator(
-            pending_inputs=self._pending_inputs,
-            pending_events=self._pending_events,
-            input_processor=self._mining_coordinator,
-        )
-        self._db_writer_worker = DbWriterWorker(
-            db_path=self._db_path,
-            pending_events=self._pending_events,
-            pending_commands=self._pending_db_commands,
-            persisted_events=self._persisted_events,
-            projector=CompositeEventProjector(
-                [
-                    RunSegmentProjector(),
-                    MiningDropProjector(),
-                    MiningClaimProjector(),
-                ]
-            ),
-        )
-
-        self._t_input: Thread | None = None
-        self._t_db: Thread | None = None
-        self._t_chat: Thread | None = None
-        self._t_ocr: Thread | None = None
-        self._t_mock: Thread | None = None
-
         self._sub_sse = None
-
-        self._sse_hub: SseHub | None = None
-        self._position_hub: OcrPositionHub | None = None
+        self._sse_hub = sse_hub
+        self._position_hub = position_hub
         self._started = False
 
     @property
     def db_path(self) -> Path:
-        return self._db_path
+        return self._settings.db_path
 
     @property
     def position_hub(self) -> OcrPositionHub:
@@ -134,21 +58,21 @@ class AppRuntime:
 
     @property
     def latest_position(self) -> LatestPositionState:
-        return self._latest_position
+        return self._components.latest_position
 
     @property
     def mining_equipment_service(self) -> MiningEquipmentService:
-        return self._mining_equipment_service
+        return self._components.mining_equipment_service
 
     @property
     def run_session_service(self) -> RunSessionService:
-        return self._run_session_service
+        return self._components.run_session_service
 
     def execute_db_command[T](self, command: DbCommand[T], *, timeout_s: float = 5.0) -> T:
-        return self._pending_db_commands.execute(command, timeout_s=timeout_s)
+        return self._components.pending_db_commands.execute(command, timeout_s=timeout_s)
 
     def health(self) -> dict[str, object]:
-        return self._worker_health.as_dict()
+        return self._supervisor.health()
 
     def execute_runtime_command[T](
         self,
@@ -159,7 +83,7 @@ class AppRuntime:
         if self._stop_event.is_set():
             raise RuntimeError("Runtime is stopping")
         request = RuntimeCommandRequest(command)
-        self._pending_inputs.emit(request)
+        self._components.pending_inputs.emit(request)
         return request.result(timeout_s=timeout_s)
 
     def attach_sse_hub(self, hub: SseHub) -> None:
@@ -171,121 +95,82 @@ class AppRuntime:
     def start(self) -> None:
         if self._started:
             return
-        if self._pending_inputs.is_closed():
+        if self._components.pending_inputs.is_closed():
             raise RuntimeError("Runtime cannot be restarted after shutdown")
-        if self._chat_log_path is None:
+        if self._settings.chat_log_path is None:
             raise RuntimeError("Chat log path is not set; cannot start chat input")
         self._stop_event.clear()
-        self._restore_mining_lifecycle()
+        self._components.lifecycle_restorer.restore()
         self._started = True
         logger.info(
             "app_started db_path=%s chat_log_path=%s mining_resource_catalog_path=%s "
             "mining_tools_path=%s ocr_enabled=%s mock_inputs_enabled=%s",
-            self._db_path,
-            self._chat_log_path,
-            self._mining_resource_catalog_path,
-            self._mining_tools_path,
-            self._ocr_enabled,
-            self._mock_inputs_enabled,
+            self._settings.db_path,
+            self._settings.chat_log_path,
+            self._settings.mining_resource_catalog_path,
+            self._settings.mining_tools_path,
+            self._settings.ocr_enabled,
+            self._settings.mock_inputs_enabled,
         )
 
-        self._t_db = self._create_worker_thread(
+        self._supervisor.start_thread(
             name="db_writer",
-            target=self._db_writer_worker.run,
+            target=self._components.db_writer_worker.run,
             worker_kwargs={"stop_event": self._stop_event},
         )
-        self._t_db.start()
 
-        self._t_input = self._create_worker_thread(
+        self._supervisor.start_thread(
             name="input_coordinator",
-            target=self._input_coordinator.run,
+            target=self._components.input_coordinator.run,
             worker_kwargs={"stop_event": self._stop_event},
         )
-        self._t_input.start()
 
-        self._t_chat = self._create_worker_thread(
+        self._supervisor.start_thread(
             name="chat_tail",
             target=start_chat_input,
             worker_kwargs={
-                "path": self._chat_log_path,
-                "signal_sink": self._pending_inputs.emit,
+                "path": self._settings.chat_log_path,
+                "signal_sink": self._components.pending_inputs.emit,
                 "stop_event": self._stop_event,
-                "start_at_end": self._chat_start_at_end,
+                "start_at_end": self._settings.chat_start_at_end,
             },
         )
-        self._t_chat.start()
 
-        if self._ocr_enabled:
+        if self._settings.ocr_enabled:
             try:
-                preload_tesserocr()  # Needed for 'tesserocr import failed: signal only works in main thread of the main interpreter'
+                # Needed for 'tesserocr import failed: signal only works in main thread of the main interpreter'
+                preload_tesserocr()
             except Exception as exc:
-                self._worker_health.mark_crashed("ocr_worker", exc)
+                self._supervisor.mark_crashed("ocr_worker", exc)
                 raise
 
-            self._t_ocr = self._create_worker_thread(
+            self._supervisor.start_thread(
                 name="ocr_worker",
                 target=start_ocr_input,
                 worker_kwargs={
                     "position_sink": self._on_position,
-                    "signal_sink": self._pending_inputs.emit,
+                    "signal_sink": self._components.pending_inputs.emit,
                     "stop_event": self._stop_event,
                 },
             )
-            self._t_ocr.start()
 
-        if self._mock_inputs_enabled:
-            self._t_mock = self._create_worker_thread(
+        if self._settings.mock_inputs_enabled:
+            self._supervisor.start_thread(
                 name="mock_mining_input",
                 target=start_mock_mining_input,
                 worker_kwargs={
-                    "signal_sink": self._pending_inputs.emit,
+                    "signal_sink": self._components.pending_inputs.emit,
                     "stop_event": self._stop_event,
-                    "interval_ms": self._mock_mining_interval_ms,
+                    "interval_ms": self._settings.mock_mining_interval_ms,
                 },
             )
-            self._t_mock.start()
 
-        # SSE fan-out (if attached)
         if self._sse_hub is not None:
-            self._sub_sse = self._persisted_events.subscribe(self._sse_hub.on_envelope)
+            self._sub_sse = self._components.persisted_events.subscribe(self._sse_hub.on_envelope)
 
     def _on_position(self, position: OcrPosition) -> None:
-        self._latest_position.update(position)
+        self._components.latest_position.update(position)
         self.position_hub.publish_threadsafe(position)
-
-    def _current_position(self) -> WorldPos | None:
-        position = self._latest_position.get()
-        return position.position if position is not None else None
-
-    def _run_context_for_drop(self, observed_ts_ms: int, profile: MiningEquipmentProfile):
-        return self._run_session_service.context_for_drop(
-            observed_ts_ms=observed_ts_ms,
-            profile=profile,
-        )
-
-    def _restore_mining_lifecycle(self) -> None:
-        conn = open_writer_connection(self._db_path)
-        try:
-            ensure_schema(conn)
-        finally:
-            conn.close()
-
-        conn = open_read_connection(self._db_path)
-        try:
-            rows = MiningClaimReader(conn).list_active(now_ts_ms=_now_ms())
-        finally:
-            conn.close()
-
-        self._mining_coordinator.restore_active_claims(
-            ActiveClaim(
-                claim_id=row.claim_id,
-                drop_id=row.drop_id,
-                hit_id=row.hit_id,
-                position=row.position,
-                search_radius_m=row.search_radius_m,
-            )
-            for row in rows
-        )
 
     def stop(self) -> None:
         if not self._started:
@@ -297,67 +182,15 @@ class AppRuntime:
             self._sub_sse.close()
             self._sub_sse = None
 
-        self._join_thread(self._t_chat, "chat_tail")
-        self._join_thread(self._t_ocr, "ocr_worker")
-        self._join_thread(self._t_mock, "mock_mining_input")
+        self._supervisor.join_thread("chat_tail")
+        self._supervisor.join_thread("ocr_worker")
+        self._supervisor.join_thread("mock_mining_input")
 
-        self._pending_inputs.close()
-        self._join_thread(self._t_input, "input_coordinator")
+        self._components.pending_inputs.close()
+        self._supervisor.join_thread("input_coordinator")
 
-        self._pending_db_commands.close()
-        self._pending_events.close()
-        self._join_thread(self._t_db, "db_writer")
+        self._components.pending_db_commands.close()
+        self._components.pending_events.close()
+        self._supervisor.join_thread("db_writer")
         self._started = False
         logger.info("app_stopped")
-
-    def _register_worker_health(self) -> None:
-        self._worker_health.register("db_writer", enabled=True)
-        self._worker_health.register("input_coordinator", enabled=True)
-        self._worker_health.register("chat_tail", enabled=True)
-        self._worker_health.register("ocr_worker", enabled=self._ocr_enabled)
-        self._worker_health.register("mock_mining_input", enabled=self._mock_inputs_enabled)
-
-    def _create_worker_thread(
-        self,
-        *,
-        name: str,
-        target: Callable[..., None],
-        worker_kwargs: dict[str, Any],
-    ) -> Thread:
-        return Thread(
-            target=self._run_worker,
-            kwargs={"name": name, "target": target, "worker_kwargs": worker_kwargs},
-            daemon=True,
-        )
-
-    def _run_worker(
-        self,
-        *,
-        name: str,
-        target: Callable[..., None],
-        worker_kwargs: dict[str, Any],
-    ) -> None:
-        self._worker_health.mark_running(name)
-        try:
-            target(**worker_kwargs)
-        except Exception as exc:
-            self._worker_health.mark_crashed(name, exc)
-            raise
-        if self._stop_event.is_set():
-            self._worker_health.mark_stopped(name)
-        else:
-            self._worker_health.mark_degraded(name, "worker returned before runtime shutdown")
-
-    def _join_thread(self, thread: Thread | None, name: str) -> bool:
-        if thread is None:
-            return True
-        thread.join(timeout=5.0)
-        if thread.is_alive():
-            logger.warning("runtime_thread_did_not_stop thread=%s", name)
-            self._worker_health.mark_degraded(name, "worker did not stop within 5s")
-            return False
-        return True
-
-
-def _now_ms() -> int:
-    return time.time_ns() // 1_000_000

--- a/apps/game-bridge/src/zml_game_bridge/runtime/supervisor.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/supervisor.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from threading import Thread
+from typing import Any
+
+from zml_game_bridge.runtime.worker_health import WorkerHealthRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerSupervisor:
+    """Owns runtime worker threads and their health state."""
+
+    def __init__(self, health: WorkerHealthRegistry | None = None) -> None:
+        self._health = health or WorkerHealthRegistry()
+        self._threads: dict[str, Thread] = {}
+
+    def register(self, name: str, *, enabled: bool) -> None:
+        self._health.register(name, enabled=enabled)
+
+    def health(self) -> dict[str, object]:
+        return self._health.as_dict()
+
+    def mark_crashed(self, name: str, exc: BaseException) -> None:
+        self._health.mark_crashed(name, exc)
+
+    def mark_degraded(self, name: str, message: str) -> None:
+        self._health.mark_degraded(name, message)
+
+    def start_thread(
+        self,
+        *,
+        name: str,
+        target: Callable[..., None],
+        worker_kwargs: dict[str, Any],
+    ) -> Thread:
+        thread = Thread(
+            target=self._run_worker,
+            kwargs={"name": name, "target": target, "worker_kwargs": worker_kwargs},
+            daemon=True,
+        )
+        self._threads[name] = thread
+        thread.start()
+        return thread
+
+    def join_thread(self, name: str, *, timeout_s: float = 5.0) -> bool:
+        thread = self._threads.get(name)
+        if thread is None:
+            return True
+        thread.join(timeout=timeout_s)
+        if thread.is_alive():
+            logger.warning("runtime_thread_did_not_stop thread=%s", name)
+            self._health.mark_degraded(name, "worker did not stop within 5s")
+            return False
+        return True
+
+    def _run_worker(
+        self,
+        *,
+        name: str,
+        target: Callable[..., None],
+        worker_kwargs: dict[str, Any],
+    ) -> None:
+        self._health.mark_running(name)
+        try:
+            target(**worker_kwargs)
+        except Exception as exc:
+            self._health.mark_crashed(name, exc)
+            raise
+        stop_event = worker_kwargs.get("stop_event")
+        if stop_event is not None and stop_event.is_set():
+            self._health.mark_stopped(name)
+        else:
+            self._health.mark_degraded(name, "worker returned before runtime shutdown")

--- a/apps/game-bridge/tests/runtime/test_worker_health.py
+++ b/apps/game-bridge/tests/runtime/test_worker_health.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import threading
 from typing import Any, cast
 
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
 from zml_game_bridge.runtime.worker_health import WorkerHealthRegistry
 
 
@@ -31,3 +33,25 @@ def test_worker_health_registry_reports_crashed_status() -> None:
     assert workers["db_writer"]["state"] == "crashed"
     assert workers["db_writer"]["last_error"] == "RuntimeError: boom"
     assert workers["ocr_worker"]["enabled"] is False
+
+
+def test_worker_supervisor_marks_worker_stopped_after_clean_return() -> None:
+    supervisor = WorkerSupervisor()
+    stop_event = threading.Event()
+    supervisor.register("worker", enabled=True)
+
+    def worker(*, stop_event: threading.Event) -> None:
+        stop_event.wait(timeout=1.0)
+
+    thread = supervisor.start_thread(
+        name="worker",
+        target=worker,
+        worker_kwargs={"stop_event": stop_event},
+    )
+
+    stop_event.set()
+    thread.join(timeout=1.0)
+
+    snapshot = supervisor.health()
+    workers = cast(dict[str, dict[str, Any]], snapshot["workers"])
+    assert workers["worker"]["state"] == "stopped"


### PR DESCRIPTION
Extract runtime component construction, worker supervision, and mining lifecycle restore out of AppRuntime. Keep AppRuntime focused on start/stop, command execution, health, and shutdown ordering while api/app wires settings, hubs, and runtime components.