### PR TITLE
fix(ui): keep depleted claims in run history

### DIFF
--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -53,10 +53,10 @@
    - ~~Do runów już wpadają.~~
    - ~~Claim powinien dostać segment z dropa/kontekstu, nie z aktualnego segmentu przy extract.~~
 
-10. **Extracted claimy nie mogą znikać ze statystyk**
-   - Active claims zostają jako aktywna lista.
-   - Extracted claims mają być w historii/statystykach.
-   - Expiration bardziej pod mapę, nie blokuje MVP.
+10. **~~Extracted claimy nie mogą znikać ze statystyk~~**
+   - ~~Active claims zostają jako aktywna lista.~~
+   - ~~Extracted claims mają być w historii/statystykach.~~
+   - ~~Expiration bardziej pod mapę, nie blokuje MVP.~~
 
 11. **Loot aggregation**
    - Loot agregować podobnie jak claimy.
@@ -152,7 +152,7 @@
 8. ~~Segment lifecycle.~~
 9. ~~Segment snapshot.~~
 10. ~~Claim segment assignment.~~
-11. Extracted claim history.
+11. ~~Extracted claim history.~~
 12. Loot aggregation.
 13. Claim extracted dashboard event.
 14. Safe delete run.

--- a/apps/electron-ui/electron/ipc/registerIpc.ts
+++ b/apps/electron-ui/electron/ipc/registerIpc.ts
@@ -67,7 +67,7 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
             return activeRun;
         }
         replaceActiveRun(activeRun);
-        replaceMiningClaims(await agentRestClient.listMiningClaims({ active: true, runId: activeRun.runId }));
+        replaceMiningClaims(await agentRestClient.listMiningClaims({ active: false, runId: activeRun.runId }));
         replaceMiningDrops(await agentRestClient.listMiningDrops({ runId: activeRun.runId }));
         return activeRun;
     });
@@ -87,7 +87,7 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
         const [runs, runSegments, miningClaims, miningDrops] = await Promise.all([
             agentRestClient.listRuns(),
             agentRestClient.listActiveRunSegments(),
-            agentRestClient.listMiningClaims({ active: true, runId }),
+            agentRestClient.listMiningClaims({ active: false, runId }),
             agentRestClient.listMiningDrops({ runId }),
         ]);
         runtime.activeRun = activeRun;
@@ -141,8 +141,9 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
         runtime.activeRun = activeRun;
         runtime.runs = runs;
         runtime.runSegments = [];
+        runtime.miningClaims = [];
         runtime.miningDrops = [];
-        pushStatePatch({ activeRun, runs, runSegments: [], miningDrops: [] });
+        pushStatePatch({ activeRun, runs, runSegments: [], miningClaims: [], miningDrops: [] });
         return activeRun;
     });
 
@@ -155,8 +156,9 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
         runtime.activeRun = null;
         runtime.runs = runs;
         runtime.runSegments = [];
+        runtime.miningClaims = [];
         runtime.miningDrops = [];
-        pushStatePatch({ activeRun: null, runs, runSegments: [], miningDrops: [] });
+        pushStatePatch({ activeRun: null, runs, runSegments: [], miningClaims: [], miningDrops: [] });
         return stoppedRun;
     });
 

--- a/apps/electron-ui/electron/main.ts
+++ b/apps/electron-ui/electron/main.ts
@@ -93,7 +93,7 @@ function handleEventStreamStatus(status: AgentEventStreamStatus, err?: string) {
 async function refreshMiningSnapshot() {
   try {
     const [miningClaims, miningDrops] = await Promise.all([
-      agentRestClient.listMiningClaims({ active: true, activeRun: true }),
+      agentRestClient.listMiningClaims({ active: false, activeRun: true }),
       agentRestClient.listMiningDrops({ activeRun: true }),
     ]);
     replaceMiningClaims(miningClaims);

--- a/apps/electron-ui/electron/mining/miningDropsState.ts
+++ b/apps/electron-ui/electron/mining/miningDropsState.ts
@@ -9,7 +9,10 @@ import {
     miningDropDtoWithHitHint,
     miningDropDtoWithNoResources,
     type AgentEventEnvelope,
+    type MiningClaimDepletedEventWire,
     type MiningClaimDto,
+    type MiningClaimPositionDto,
+    type MiningClaimPositionWire,
     type MiningDropDto,
 } from "@zml/shared";
 
@@ -44,11 +47,7 @@ export function applyMiningEvent(event: AgentEventEnvelope<string, unknown>): vo
     }
 
     if (event.type === "MiningClaimDepletedEvent" && isMiningClaimDepletedEventWire(event.payload)) {
-        removeMiningClaim({
-            claimId: event.payload.claim_id,
-            dropId: event.payload.drop_id,
-            hitId: event.payload.hit_id,
-        });
+        markMiningClaimDepleted(event.payload, event.eventId ?? null, event.eventDt);
         return;
     }
 
@@ -59,29 +58,30 @@ export function applyMiningEvent(event: AgentEventEnvelope<string, unknown>): vo
 }
 
 function upsertMiningClaim(claim: MiningClaimDto): void {
-    if (claim.status !== "active") return;
     const withoutCurrent = runtime.miningClaims.filter((item) => item.claimId !== claim.claimId);
     runtime.miningClaims = sortClaims([claim, ...withoutCurrent]);
     pushStatePatch({ miningClaims: runtime.miningClaims });
 }
 
-function removeMiningClaim({
-    claimId,
-    dropId,
-    hitId,
-}: {
-    claimId: string;
-    dropId: string | null;
-    hitId: string | null;
-}): void {
-    const nextClaims = runtime.miningClaims.filter((claim) => {
-        if (claim.claimId === claimId) return false;
-        if (dropId !== null && claim.dropId === dropId) return false;
-        if (hitId !== null && claim.hitId === hitId) return false;
-        return true;
-    });
-    if (nextClaims.length === runtime.miningClaims.length) return;
-    runtime.miningClaims = nextClaims;
+function markMiningClaimDepleted(
+    payload: MiningClaimDepletedEventWire,
+    eventId: number | null,
+    eventDt: string | null,
+): void {
+    const hasClaim = runtime.miningClaims.some((claim) => claim.claimId === payload.claim_id);
+    if (!hasClaim) return;
+
+    runtime.miningClaims = sortClaims(runtime.miningClaims.map((claim) => {
+        if (claim.claimId !== payload.claim_id) return claim;
+        return {
+            ...claim,
+            status: "depleted",
+            depletedEventId: eventId,
+            depletedEventDt: eventDt,
+            depletedPosition: wireToClaimPosition(payload.position),
+            depletedDistanceM: payload.distance_m,
+        };
+    }));
     pushStatePatch({ miningClaims: runtime.miningClaims });
 }
 
@@ -113,7 +113,14 @@ function sortDrops(drops: MiningDropDto[]): MiningDropDto[] {
 }
 
 function sortClaims(claims: MiningClaimDto[]): MiningClaimDto[] {
-    return claims
-        .filter((claim) => claim.status === "active")
-        .sort((a, b) => b.observedTsMs - a.observedTsMs);
+    return claims.sort((a, b) => b.observedTsMs - a.observedTsMs);
+}
+
+function wireToClaimPosition(wire: MiningClaimPositionWire): MiningClaimPositionDto {
+    return {
+        planetName: wire.planet_name ?? "",
+        x: wire.x,
+        y: wire.y,
+        z: wire.z ?? null,
+    };
 }

--- a/apps/electron-ui/electron/mocks/mockAgentRestClient.ts
+++ b/apps/electron-ui/electron/mocks/mockAgentRestClient.ts
@@ -23,6 +23,7 @@ import type {
 const MOCK_MINING_CLAIMS: MiningClaimDto[] = [
     createMockMiningClaim("mock-claim-1", Date.now() - 5 * 60_000, 58913, 84653, "Lysterium Stone", "ore"),
     createMockMiningClaim("mock-claim-2", Date.now() - 90_000, 58940, 84667, "Crude Oil", "enmatter"),
+    createMockMiningClaim("mock-claim-3", Date.now() - 18 * 60_000, 58890, 84639, "Belkar Stone", "ore", "depleted"),
 ];
 
 const MOCK_MINING_DROPS: MiningDropDto[] = [
@@ -177,6 +178,7 @@ export class MockAgentRestClient implements AgentClient {
     }
 
     async listMiningClaims(request: ListMiningClaimsRequest = {}): Promise<MiningClaimDto[]> {
+        if (request.activeRun && this.activeRun === null) return [];
         const runId = request.activeRun ? this.activeRun?.runId ?? null : request.runId ?? null;
         const claims = runId === null
             ? MOCK_MINING_CLAIMS
@@ -330,6 +332,7 @@ function createMockMiningClaim(
     y: number,
     resourceName: string,
     miningType: MiningClaimDto["miningType"],
+    status: MiningClaimDto["status"] = "active",
 ): MiningClaimDto {
     return {
         claimId,
@@ -353,10 +356,17 @@ function createMockMiningClaim(
         expectedExpiresTsMs: observedTsMs + 60 * 60_000,
         rangeM: 51.14,
         depthM: 53,
-        status: "active",
-        depletedEventId: null,
-        depletedEventDt: null,
-        depletedPosition: null,
-        depletedDistanceM: null,
+        status,
+        depletedEventId: status === "depleted" ? -2 : null,
+        depletedEventDt: status === "depleted" ? new Date(observedTsMs + 8 * 60_000).toISOString() : null,
+        depletedPosition: status === "depleted"
+            ? {
+                planetName: "Calypso",
+                x: x + 4,
+                y: y + 3,
+                z: null,
+            }
+            : null,
+        depletedDistanceM: status === "depleted" ? 5 : null,
     };
 }

--- a/apps/electron-ui/src/widgets/map/mapViewport.tsx
+++ b/apps/electron-ui/src/widgets/map/mapViewport.tsx
@@ -141,6 +141,14 @@ export function MapViewport({
           return [];
         }
 
+        const expiresAtSec =
+          claim.expectedExpiresTsMs !== null
+            ? Math.floor(claim.expectedExpiresTsMs / 1000)
+            : null;
+        if (expiresAtSec !== null && expiresAtSec <= currentSec) {
+          return [];
+        }
+
         return [
           {
             id: claim.claimId,
@@ -148,14 +156,11 @@ export function MapViewport({
             y: claim.position.y,
             position: entropiaToDeckPosition(planetId, claim.position),
             resourceKind: resourceKindFromName(claim.resourceName),
-            expiresAtSec:
-              claim.expectedExpiresTsMs !== null
-                ? Math.floor(claim.expectedExpiresTsMs / 1000)
-                : null,
+            expiresAtSec,
           },
         ];
       }),
-    [miningClaims, planetId],
+    [currentSec, miningClaims, planetId],
   );
   const hasClaimTimers = useMemo(
     () => mapMiningClaims.some((claim) => claim.expiresAtSec !== null),

--- a/apps/electron-ui/src/windows/mainWindow.css
+++ b/apps/electron-ui/src/windows/mainWindow.css
@@ -272,6 +272,11 @@
   font-size: 13px;
 }
 
+.zml-subsection-head {
+  min-height: 44px;
+  padding-top: 16px;
+}
+
 .zml-section-total {
   color: #40d889;
   font-family: "Cascadia Mono", "Consolas", monospace;
@@ -567,8 +572,16 @@
   background: #8994a3;
 }
 
+.zml-feed-row.is-depleted .zml-feed-kind {
+  background: #40d889;
+}
+
 .zml-feed-row.is-claim b {
   color: #f5d96b;
+}
+
+.zml-feed-row.is-depleted b {
+  color: #40d889;
 }
 
 .zml-warning-list {

--- a/apps/electron-ui/src/windows/mainWindow.tsx
+++ b/apps/electron-ui/src/windows/mainWindow.tsx
@@ -31,7 +31,7 @@ type MainView = "dashboard" | "runs" | "segments" | "loot" | "claims" | "setup" 
 type FeedItem = {
   id: string;
   tsMs: number;
-  kind: "drop" | "hit" | "miss" | "claim";
+  kind: "drop" | "hit" | "miss" | "claim" | "depleted";
   title: string;
   detail: string;
   amount?: string;
@@ -323,6 +323,9 @@ function RunSummaryPanel({
       <MetricRow label="Hits" value={String(stats.hitCount)} accent="warn" />
       <MetricRow label="Misses" value={String(stats.noResourceCount)} />
       <MetricRow label="Hit rate" value={formatPercent(stats.hitRate)} />
+      <MetricRow label="Claims" value={String(stats.totalClaimCount)} accent="warn" />
+      <MetricRow label="Extracted" value={String(stats.depletedClaimCount)} />
+      <MetricRow label="Active claims" value={String(stats.activeClaimCount)} accent="gain" />
       <MetricRow label="Cost TT" value={formatPed(stats.totalCostPed)} accent="loss" />
       <MetricRow label="Return TT" value={formatPed(stats.totalReturnPed)} accent="gain" />
       <MetricRow
@@ -330,7 +333,6 @@ function RunSummaryPanel({
         value={formatPed(stats.profitPed)}
         accent={stats.profitPed >= 0 ? "gain" : "loss"}
       />
-      <MetricRow label="Active claims" value={String(stats.activeClaimCount)} accent="gain" />
     </section>
   );
 }
@@ -572,11 +574,20 @@ function ClaimsView({ claims }: { claims: MiningClaimDto[] }) {
     () => claims.filter((claim) => claim.status === "active"),
     [claims],
   );
+  const depletedClaims = useMemo(
+    () => claims.filter((claim) => claim.status === "depleted"),
+    [claims],
+  );
+  const filteredHistory = useMemo(
+    () => sortClaimHistory(
+      filter === "all" ? claims : claims.filter((claim) => claim.miningType === filter),
+    ),
+    [claims, filter],
+  );
   const rows = useMemo(
     () => buildClaimDistribution(activeClaims, filter),
     [activeClaims, filter],
   );
-  const totals = useMemo(() => getClaimTypeTotals(activeClaims), [activeClaims]);
   const visibleTotal = rows.reduce((sum, row) => sum + row.count, 0);
 
   return (
@@ -584,7 +595,7 @@ function ClaimsView({ claims }: { claims: MiningClaimDto[] }) {
       <div className="zml-section-head">
         <div>
           <h2>Claims</h2>
-          <span>Active claim distribution</span>
+          <span>Active distribution and run claim history</span>
         </div>
       </div>
       <div className="zml-tabs-inline">
@@ -600,15 +611,22 @@ function ClaimsView({ claims }: { claims: MiningClaimDto[] }) {
         ))}
       </div>
       <div className="zml-claim-summary-grid">
-        <ClaimSummaryCard label="Visible" value={String(visibleTotal)} />
-        <ClaimSummaryCard label="Ore" value={String(totals.ore)} />
-        <ClaimSummaryCard label="Enmatter" value={String(totals.enmatter)} />
-        <ClaimSummaryCard label="Treasure" value={String(totals.treasure)} />
+        <ClaimSummaryCard label="Total" value={String(claims.length)} />
+        <ClaimSummaryCard label="Active" value={String(activeClaims.length)} />
+        <ClaimSummaryCard label="Extracted" value={String(depletedClaims.length)} />
+        <ClaimSummaryCard label="Visible Active" value={String(visibleTotal)} />
+      </div>
+
+      <div className="zml-section-head zml-subsection-head">
+        <div>
+          <h2>Active Distribution</h2>
+          <span>Map-visible claims only</span>
+        </div>
       </div>
       {activeClaims.length === 0 ? (
-        <EmptyState text="No active claims" />
+        <EmptyState text="No active claims" compact />
       ) : rows.length === 0 ? (
-        <EmptyState text="No claims for this filter" />
+        <EmptyState text="No active claims for this filter" compact />
       ) : (
         <div className="zml-table-wrap">
           <table className="zml-data-table">
@@ -638,6 +656,51 @@ function ClaimsView({ claims }: { claims: MiningClaimDto[] }) {
                     </div>
                   </td>
                   <td>{formatExpires(row.nextExpiresTsMs)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="zml-section-head zml-subsection-head">
+        <div>
+          <h2>Claim History</h2>
+          <span>Extracted claims stay here for run and segment stats</span>
+        </div>
+      </div>
+      {filteredHistory.length === 0 ? (
+        <EmptyState text="No claim history for this filter" compact />
+      ) : (
+        <div className="zml-table-wrap">
+          <table className="zml-data-table">
+            <thead>
+              <tr>
+                <th>Found</th>
+                <th>Resource</th>
+                <th>Type</th>
+                <th>Size</th>
+                <th>Status</th>
+                <th>Segment</th>
+                <th>Depleted</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredHistory.map((claim) => (
+                <tr key={claim.claimId}>
+                  <td>{formatTime(claim.observedTsMs)}</td>
+                  <td>
+                    <strong>{claim.resourceName ?? "Unknown resource"}</strong>
+                  </td>
+                  <td>{formatMiningType(claim.miningType)}</td>
+                  <td>{formatSize(claim.sizeLabel, claim.sizeIndex)}</td>
+                  <td>
+                    <span className={claim.status === "active" ? "zml-tag is-active" : "zml-tag"}>
+                      {claim.status === "active" ? "active" : "extracted"}
+                    </span>
+                  </td>
+                  <td>{formatSegmentRef(claim.segmentId)}</td>
+                  <td>{formatClaimDepletion(claim)}</td>
                 </tr>
               ))}
             </tbody>
@@ -860,7 +923,9 @@ type RunStats = {
   dropCount: number;
   hitCount: number;
   noResourceCount: number;
+  totalClaimCount: number;
   activeClaimCount: number;
+  depletedClaimCount: number;
   hitRate: number | null;
   totalCostPed: number;
   totalReturnPed: number;
@@ -922,27 +987,14 @@ function buildClaimDistribution(
     .sort((a, b) => b.count - a.count || a.resourceName.localeCompare(b.resourceName));
 }
 
-function getClaimTypeTotals(claims: MiningClaimDto[]): Record<ClaimFilter, number> {
-  const totals: Record<ClaimFilter, number> = {
-    all: claims.length,
-    ore: 0,
-    enmatter: 0,
-    treasure: 0,
-  };
-
-  for (const claim of claims) {
-    if (claim.miningType === "ore" || claim.miningType === "enmatter" || claim.miningType === "treasure") {
-      totals[claim.miningType] += 1;
-    }
-  }
-
-  return totals;
-}
-
 function minNullableTs(left: number | null, right: number | null): number | null {
   if (left === null) return right;
   if (right === null) return left;
   return Math.min(left, right);
+}
+
+function sortClaimHistory(claims: MiningClaimDto[]): MiningClaimDto[] {
+  return [...claims].sort((a, b) => claimActivityTsMs(b) - claimActivityTsMs(a));
 }
 
 function findToolName(
@@ -958,6 +1010,8 @@ function findToolName(
 function getRunStats(drops: MiningDropDto[], claims: MiningClaimDto[], loot: MiningLootItemDto[]): RunStats {
   const hitCount = drops.filter((drop) => drop.result === "hit").length;
   const noResourceCount = drops.filter((drop) => drop.result === "no_resources").length;
+  const activeClaimCount = claims.filter((claim) => claim.status === "active").length;
+  const depletedClaimCount = claims.filter((claim) => claim.status === "depleted").length;
   const totalCostPed = drops.reduce((sum, drop) => sum + drop.cost.totalMpec, 0) / 100_000;
   const totalReturnPed = loot.reduce((sum, item) => sum + item.valueMpec, 0) / 100_000;
 
@@ -965,7 +1019,9 @@ function getRunStats(drops: MiningDropDto[], claims: MiningClaimDto[], loot: Min
     dropCount: drops.length,
     hitCount,
     noResourceCount,
-    activeClaimCount: claims.filter((claim) => claim.status === "active").length,
+    totalClaimCount: claims.length,
+    activeClaimCount,
+    depletedClaimCount,
     hitRate: drops.length === 0 ? null : hitCount / drops.length,
     totalCostPed,
     totalReturnPed,
@@ -1008,13 +1064,14 @@ function buildFeed(drops: MiningDropDto[], claims: MiningClaimDto[]): FeedItem[]
   }
 
   for (const claim of claims) {
+    const isDepleted = claim.status === "depleted";
     items.push({
-      id: `${claim.claimId}:claim`,
-      tsMs: claim.observedTsMs,
-      kind: "claim",
-      title: "Claim Active",
+      id: `${claim.claimId}:claim:${claim.status}`,
+      tsMs: claimActivityTsMs(claim),
+      kind: isDepleted ? "depleted" : "claim",
+      title: isDepleted ? "Claim Extracted" : "Claim Active",
       detail: `${claim.resourceName ?? "Unknown resource"} ${formatSize(claim.sizeLabel, claim.sizeIndex)}`,
-      amount: formatExpires(claim.expectedExpiresTsMs),
+      amount: isDepleted ? formatMeters(claim.depletedDistanceM) : formatExpires(claim.expectedExpiresTsMs),
     });
   }
 
@@ -1078,6 +1135,33 @@ function formatPosition(position?: { x: number; y: number } | null): string {
 function formatMeters(value: number | null | undefined): string {
   if (value === null || value === undefined) return "-";
   return `${value.toFixed(1)} m`;
+}
+
+function formatSegmentRef(segmentId: string | null): string {
+  if (segmentId === null) return "-";
+  return segmentId.length <= 8 ? segmentId : segmentId.slice(0, 8);
+}
+
+function formatClaimDepletion(claim: MiningClaimDto): string {
+  if (claim.status !== "depleted") return "-";
+  const distance = formatMeters(claim.depletedDistanceM);
+  if (claim.depletedEventDt === null) return distance;
+  const when = formatDateTimeString(claim.depletedEventDt);
+  if (distance === "-") return when;
+  return `${when} / ${distance}`;
+}
+
+function claimActivityTsMs(claim: MiningClaimDto): number {
+  if (claim.status !== "depleted" || claim.depletedEventDt === null) {
+    return claim.observedTsMs;
+  }
+  const parsed = Date.parse(claim.depletedEventDt);
+  return Number.isFinite(parsed) ? parsed : claim.observedTsMs;
+}
+
+function formatDateTimeString(value: string): string {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? formatTime(parsed) : value;
 }
 
 function formatMiningType(value: MiningResourceType | null): string {


### PR DESCRIPTION
- Fetch full active-run claim history instead of only active claims
- Mark claims as depleted on MiningClaimDepletedEvent instead of removing them
- Keep map markers limited to active non-expired claims
- Show claim history and total/extracted/active stats in the Claims UI
- Mark roadmap P1:10 as completed