### PR TITLE
feat(mining): persist and aggregate loot per run

### DIFF
--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -58,9 +58,9 @@
    - ~~Extracted claims mają być w historii/statystykach.~~
    - ~~Expiration bardziej pod mapę, nie blokuje MVP.~~
 
-11. **Loot aggregation**
-   - Loot agregować podobnie jak claimy.
-   - Minimum: per run, per segment, per resource/item.
+11. **~~Loot aggregation~~**
+   - ~~Loot agregować podobnie jak claimy.~~
+   - ~~Minimum: per run, per resource/item.~~
 
 12. **Claim extracted event w Dashboardzie**
    - Dashboard chyba powinien pokazywać extract claimu jako event?
@@ -153,7 +153,7 @@
 9. ~~Segment snapshot.~~
 10. ~~Claim segment assignment.~~
 11. ~~Extracted claim history.~~
-12. Loot aggregation.
+12. ~~Loot aggregation.~~
 13. Claim extracted dashboard event.
 14. Safe delete run.
 

--- a/apps/electron-ui/electron/agent/restClient.ts
+++ b/apps/electron-ui/electron/agent/restClient.ts
@@ -7,6 +7,7 @@ import {
   isActiveMiningToolsWire,
   isMiningClaimWire,
   isMiningDropWire,
+  isMiningLootItemWire,
   isMiningToolProfileWire,
   setActiveMiningToolsRequestToWire,
   startRunRequestToWire,
@@ -16,6 +17,7 @@ import {
   wireToActiveMiningToolsDto,
   wireToMiningClaimDto,
   wireToMiningDropDto,
+  wireToMiningLootItemDto,
   wireToMiningToolProfileDto,
   wireToRunSegmentDto,
   wireToRunDto,
@@ -24,6 +26,7 @@ import {
   type CreateMiningToolProfileRequest,
   type MiningClaimDto,
   type MiningDropDto,
+  type MiningLootItemDto,
   type MiningToolProfileDto,
   type RunDto,
   type RunSegmentDto,
@@ -53,6 +56,7 @@ export type AgentClient = {
   stopRun: (request: StopRunRequest) => Promise<RunDto>;
   listMiningClaims: (request?: ListMiningClaimsRequest) => Promise<MiningClaimDto[]>;
   listMiningDrops: (request?: ListMiningDropsRequest) => Promise<MiningDropDto[]>;
+  listMiningLoot: (request?: ListMiningLootRequest) => Promise<MiningLootItemDto[]>;
   listMiningTools: () => Promise<MiningToolProfileDto[]>;
   createMiningTool: (request: CreateMiningToolProfileRequest) => Promise<MiningToolProfileDto>;
   deleteMiningTool: (toolId: string) => Promise<void>;
@@ -68,6 +72,11 @@ export type ListMiningClaimsRequest = {
 
 export type ListMiningDropsRequest = {
   windowMinutes?: number;
+  runId?: number;
+  activeRun?: boolean;
+};
+
+export type ListMiningLootRequest = {
   runId?: number;
   activeRun?: boolean;
 };
@@ -198,6 +207,24 @@ export class AgentRestClient implements AgentClient {
       throw new Error("Agent mining drops returned an invalid payload");
     }
     return data.map(wireToMiningDropDto);
+  }
+
+  async listMiningLoot(request: ListMiningLootRequest = {}): Promise<MiningLootItemDto[]> {
+    const params = new URLSearchParams();
+    if (request.runId !== undefined) {
+      params.set("run_id", String(request.runId));
+    }
+    if (request.activeRun !== undefined) {
+      params.set("active_run", request.activeRun ? "yes" : "no");
+    }
+
+    const serializedParams = params.toString();
+    const query = serializedParams ? `?${serializedParams}` : "";
+    const data = await this.getJson(`/api/v1/mining/loot${query}`);
+    if (!Array.isArray(data) || !data.every(isMiningLootItemWire)) {
+      throw new Error("Agent mining loot returned an invalid payload");
+    }
+    return data.map(wireToMiningLootItemDto);
   }
 
   async listMiningTools(): Promise<MiningToolProfileDto[]> {

--- a/apps/electron-ui/electron/ipc/registerIpc.ts
+++ b/apps/electron-ui/electron/ipc/registerIpc.ts
@@ -15,6 +15,7 @@ import { runtime } from "../runtime";
 import type { AgentClient } from "../agent/restClient.ts";
 import { pushStatePatch } from "./pushStatePatch.ts";
 import { replaceMiningClaims, replaceMiningDrops } from "../mining/miningDropsState.ts";
+import { replaceMiningLoot } from "../mining/miningLootState.ts";
 import { replaceActiveRun, replaceRunSegments } from "../runs/runSegmentsState.ts";
 
 type RegisterIpcDeps = {
@@ -63,12 +64,14 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
             runtime.runSegments = [];
             replaceMiningClaims([]);
             replaceMiningDrops([]);
+            replaceMiningLoot([]);
             pushStatePatch({ activeRun: null, runSegments: [] });
             return activeRun;
         }
         replaceActiveRun(activeRun);
         replaceMiningClaims(await agentRestClient.listMiningClaims({ active: false, runId: activeRun.runId }));
         replaceMiningDrops(await agentRestClient.listMiningDrops({ runId: activeRun.runId }));
+        replaceMiningLoot(await agentRestClient.listMiningLoot({ runId: activeRun.runId }));
         return activeRun;
     });
 
@@ -84,18 +87,20 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
             throw new Error("Invalid resume run request");
         }
         const activeRun = await agentRestClient.resumeRun(runId);
-        const [runs, runSegments, miningClaims, miningDrops] = await Promise.all([
+        const [runs, runSegments, miningClaims, miningDrops, miningLoot] = await Promise.all([
             agentRestClient.listRuns(),
             agentRestClient.listActiveRunSegments(),
             agentRestClient.listMiningClaims({ active: false, runId }),
             agentRestClient.listMiningDrops({ runId }),
+            agentRestClient.listMiningLoot({ runId }),
         ]);
         runtime.activeRun = activeRun;
         runtime.runs = runs;
         runtime.runSegments = runSegments;
         runtime.miningClaims = miningClaims;
         runtime.miningDrops = miningDrops;
-        pushStatePatch({ activeRun, runs, runSegments, miningClaims, miningDrops });
+        runtime.miningLoot = miningLoot;
+        pushStatePatch({ activeRun, runs, runSegments, miningClaims, miningDrops, miningLoot });
         return activeRun;
     });
 
@@ -143,7 +148,8 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
         runtime.runSegments = [];
         runtime.miningClaims = [];
         runtime.miningDrops = [];
-        pushStatePatch({ activeRun, runs, runSegments: [], miningClaims: [], miningDrops: [] });
+        runtime.miningLoot = [];
+        pushStatePatch({ activeRun, runs, runSegments: [], miningClaims: [], miningDrops: [], miningLoot: [] });
         return activeRun;
     });
 
@@ -158,7 +164,8 @@ export function registerIpc({ agentRestClient, toggleMapWindow, toggleOverlayWin
         runtime.runSegments = [];
         runtime.miningClaims = [];
         runtime.miningDrops = [];
-        pushStatePatch({ activeRun: null, runs, runSegments: [], miningClaims: [], miningDrops: [] });
+        runtime.miningLoot = [];
+        pushStatePatch({ activeRun: null, runs, runSegments: [], miningClaims: [], miningDrops: [], miningLoot: [] });
         return stoppedRun;
     });
 

--- a/apps/electron-ui/electron/main.ts
+++ b/apps/electron-ui/electron/main.ts
@@ -23,7 +23,7 @@ import { startMockPositionSource } from "./mocks/mockPositionSource.ts";
 import { pushPosition } from "./ipc/pushPosition.ts";
 import { pushStatePatch } from "./ipc/pushStatePatch.ts";
 import { applyMiningEvent, replaceMiningClaims, replaceMiningDrops } from "./mining/miningDropsState.ts";
-import { applyMiningLootEvent } from "./mining/miningLootState.ts";
+import { applyMiningLootEvent, replaceMiningLoot } from "./mining/miningLootState.ts";
 import { applyRunEvent, replaceActiveRun, replaceRunSegments } from "./runs/runSegmentsState.ts";
 import type { PositionSourceOptions, PositionSourceStatus, StopPositionSource } from "./agent/positionSource.ts";
 
@@ -92,12 +92,14 @@ function handleEventStreamStatus(status: AgentEventStreamStatus, err?: string) {
 
 async function refreshMiningSnapshot() {
   try {
-    const [miningClaims, miningDrops] = await Promise.all([
+    const [miningClaims, miningDrops, miningLoot] = await Promise.all([
       agentRestClient.listMiningClaims({ active: false, activeRun: true }),
       agentRestClient.listMiningDrops({ activeRun: true }),
+      agentRestClient.listMiningLoot({ activeRun: true }),
     ]);
     replaceMiningClaims(miningClaims);
     replaceMiningDrops(miningDrops);
+    replaceMiningLoot(miningLoot);
   } catch (error) {
     runtime.lastError = error instanceof Error ? error.message : String(error);
     pushStatePatch({

--- a/apps/electron-ui/electron/mining/miningLootState.ts
+++ b/apps/electron-ui/electron/mining/miningLootState.ts
@@ -10,6 +10,11 @@ import { runtime } from "../runtime.ts";
 
 const MAX_LOOT_ITEMS = 500;
 
+export function replaceMiningLoot(items: readonly MiningLootItemDto[]): void {
+    runtime.miningLoot = sortLootItems([...items]);
+    pushStatePatch({ miningLoot: runtime.miningLoot });
+}
+
 export function applyMiningLootEvent(event: AgentEventEnvelope<string, unknown>): void {
     if (event.type !== "MiningItemReceivedEvent" || !isMiningItemReceivedEventWire(event.payload)) {
         return;
@@ -19,8 +24,10 @@ export function applyMiningLootEvent(event: AgentEventEnvelope<string, unknown>)
 
 function upsertLootItem(item: MiningLootItemDto): void {
     const withoutCurrent = runtime.miningLoot.filter((current) => current.eventId !== item.eventId);
-    runtime.miningLoot = [item, ...withoutCurrent]
-        .sort((a, b) => b.createdTsMs - a.createdTsMs)
-        .slice(0, MAX_LOOT_ITEMS);
+    runtime.miningLoot = sortLootItems([item, ...withoutCurrent]).slice(0, MAX_LOOT_ITEMS);
     pushStatePatch({ miningLoot: runtime.miningLoot });
+}
+
+function sortLootItems(items: MiningLootItemDto[]): MiningLootItemDto[] {
+    return items.sort((a, b) => b.createdTsMs - a.createdTsMs || b.eventId - a.eventId);
 }

--- a/apps/electron-ui/electron/mocks/mockAgentRestClient.ts
+++ b/apps/electron-ui/electron/mocks/mockAgentRestClient.ts
@@ -4,6 +4,7 @@ import type {
     CreateMiningToolProfileRequest,
     MiningClaimDto,
     MiningDropDto,
+    MiningLootItemDto,
     MiningToolKind,
     MiningToolProfileDto,
     RunDto,
@@ -18,6 +19,7 @@ import type {
     AgentClient,
     ListMiningClaimsRequest,
     ListMiningDropsRequest,
+    ListMiningLootRequest,
 } from "../agent/restClient.ts";
 
 const MOCK_MINING_CLAIMS: MiningClaimDto[] = [
@@ -30,6 +32,12 @@ const MOCK_MINING_DROPS: MiningDropDto[] = [
     createMockMiningDrop("mock-drop-1", Date.now() - 9 * 60_000, 58890, 84639, "no_resources"),
     createMockMiningDrop("mock-drop-2", Date.now() - 5 * 60_000, 58913, 84653, "hit"),
     createMockMiningDrop("mock-drop-3", Date.now() - 90_000, 58940, 84667, "pending"),
+];
+
+const MOCK_MINING_LOOT: MiningLootItemDto[] = [
+    createMockMiningLoot(1, Date.now() - 4 * 60_000, "Lysterium Stone", 8, 64_000, 170),
+    createMockMiningLoot(2, Date.now() - 3 * 60_000, "Lysterium Stone", 4, 32_000, 170),
+    createMockMiningLoot(3, Date.now() - 2 * 60_000, "Crude Oil", 12, 120_000, 170),
 ];
 
 export class MockAgentRestClient implements AgentClient {
@@ -197,6 +205,13 @@ export class MockAgentRestClient implements AgentClient {
         return MOCK_MINING_DROPS.filter((drop) => drop.observedTsMs >= cutoff);
     }
 
+    async listMiningLoot(request: ListMiningLootRequest = {}): Promise<MiningLootItemDto[]> {
+        if (request.activeRun && this.activeRun === null) return [];
+        const runId = request.activeRun ? this.activeRun?.runId ?? null : request.runId ?? null;
+        if (runId === null) return [...MOCK_MINING_LOOT];
+        return MOCK_MINING_LOOT.filter((item) => item.runId === runId);
+    }
+
     async listMiningTools(): Promise<MiningToolProfileDto[]> {
         return [...this.miningTools];
     }
@@ -322,6 +337,26 @@ function createMockMiningDrop(
         expectedExpiresTsMs: isHit ? observedTsMs + 60 * 60_000 : null,
         rangeM: isHit ? 51.14 : null,
         depthM: isHit ? 53 : null,
+    };
+}
+
+function createMockMiningLoot(
+    eventId: number,
+    createdTsMs: number,
+    itemName: string,
+    qty: number,
+    valueMpec: number,
+    extractionCostMpec: number | null,
+): MiningLootItemDto {
+    return {
+        eventId,
+        createdTsMs,
+        eventDt: new Date(createdTsMs).toISOString(),
+        runId: 1,
+        itemName,
+        qty,
+        valueMpec,
+        extractionCostMpec,
     };
 }
 

--- a/apps/electron-ui/src/windows/mainWindow.tsx
+++ b/apps/electron-ui/src/windows/mainWindow.tsx
@@ -518,42 +518,98 @@ function SegmentsView({
 
 function LootView({ loot }: { loot: MiningLootItemDto[] }) {
   const totalMpec = loot.reduce((sum, item) => sum + item.valueMpec, 0);
+  const extractionCostMpec = totalExtractionCostMpec(loot);
+  const netMpec = totalMpec - extractionCostMpec;
+  const rows = useMemo(() => buildLootAggregation(loot), [loot]);
+
   return (
     <section className="zml-work-panel">
       <div className="zml-section-head">
         <div>
           <h2>Loot</h2>
-          <span>Live chat-derived returns</span>
+          <span>Run return aggregation by resource/item</span>
         </div>
         <strong className="zml-section-total">{formatPedFromMpec(totalMpec)}</strong>
       </div>
+      <div className="zml-claim-summary-grid">
+        <ClaimSummaryCard label="Items" value={String(rows.length)} />
+        <ClaimSummaryCard label="Events" value={String(loot.length)} />
+        <ClaimSummaryCard label="Return" value={formatPedFromMpec(totalMpec)} />
+        <ClaimSummaryCard label="Net Return" value={formatPedFromMpec(netMpec)} />
+      </div>
       {loot.length === 0 ? (
-        <EmptyState text="No loot recorded in this UI session" />
+        <EmptyState text="No loot recorded for this run" />
       ) : (
-        <div className="zml-table-wrap">
-          <table className="zml-data-table">
-            <thead>
-              <tr>
-                <th>Time</th>
-                <th>Item</th>
-                <th>Qty</th>
-                <th>Value</th>
-                <th>Extraction cost</th>
-              </tr>
-            </thead>
-            <tbody>
-              {loot.map((item) => (
-                <tr key={`${item.eventId}:${item.createdTsMs}:${item.itemName}`}>
-                  <td>{item.eventDt ?? formatTime(item.createdTsMs)}</td>
-                  <td>{item.itemName}</td>
-                  <td>{item.qty}</td>
-                  <td>{formatPedFromMpec(item.valueMpec)}</td>
-                  <td>{formatPedFromMpec(item.extractionCostMpec)}</td>
+        <>
+          <div className="zml-table-wrap">
+            <table className="zml-data-table">
+              <thead>
+                <tr>
+                  <th>Item</th>
+                  <th>Events</th>
+                  <th>Qty</th>
+                  <th>Return</th>
+                  <th>Extraction Cost</th>
+                  <th>Net Return</th>
+                  <th>Distribution</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.itemName}>
+                    <td>
+                      <strong>{row.itemName}</strong>
+                    </td>
+                    <td>{row.eventCount}</td>
+                    <td>{row.qty}</td>
+                    <td>{formatPedFromMpec(row.valueMpec)}</td>
+                    <td>{formatPedFromMpec(row.extractionCostMpec)}</td>
+                    <td>{formatPedFromMpec(row.netMpec)}</td>
+                    <td>
+                      <div className="zml-distribution-cell">
+                        <div className="zml-distribution-bar" aria-hidden="true">
+                          <span style={{ width: `${row.percent * 100}%` }} />
+                        </div>
+                        <strong>{formatPercent(row.percent)}</strong>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="zml-section-head zml-subsection-head">
+            <div>
+              <h2>Loot History</h2>
+              <span>Raw chat-derived item received events</span>
+            </div>
+          </div>
+          <div className="zml-table-wrap">
+            <table className="zml-data-table">
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Item</th>
+                  <th>Qty</th>
+                  <th>Value</th>
+                  <th>Extraction cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loot.map((item) => (
+                  <tr key={`${item.eventId}:${item.createdTsMs}:${item.itemName}`}>
+                    <td>{formatEventTime(item.eventDt, item.createdTsMs)}</td>
+                    <td>{item.itemName}</td>
+                    <td>{item.qty}</td>
+                    <td>{formatPedFromMpec(item.valueMpec)}</td>
+                    <td>{formatPedFromMpec(item.extractionCostMpec)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </section>
   );
@@ -940,6 +996,16 @@ type ClaimDistributionRow = {
   nextExpiresTsMs: number | null;
 };
 
+type LootAggregationRow = {
+  itemName: string;
+  eventCount: number;
+  qty: number;
+  valueMpec: number;
+  extractionCostMpec: number;
+  netMpec: number;
+  percent: number;
+};
+
 function getActiveSetup(
   tools: MiningToolProfileDto[],
   activeTools?: ActiveMiningToolsDto,
@@ -987,6 +1053,32 @@ function buildClaimDistribution(
     .sort((a, b) => b.count - a.count || a.resourceName.localeCompare(b.resourceName));
 }
 
+function buildLootAggregation(loot: MiningLootItemDto[]): LootAggregationRow[] {
+  const totalMpec = loot.reduce((sum, item) => sum + item.valueMpec, 0);
+  const rows = new Map<string, LootAggregationRow>();
+
+  for (const item of loot) {
+    const current = rows.get(item.itemName);
+    const extractionCostMpec = item.extractionCostMpec ?? 0;
+    rows.set(item.itemName, {
+      itemName: item.itemName,
+      eventCount: (current?.eventCount ?? 0) + 1,
+      qty: (current?.qty ?? 0) + item.qty,
+      valueMpec: (current?.valueMpec ?? 0) + item.valueMpec,
+      extractionCostMpec: (current?.extractionCostMpec ?? 0) + extractionCostMpec,
+      netMpec: (current?.netMpec ?? 0) + item.valueMpec - extractionCostMpec,
+      percent: 0,
+    });
+  }
+
+  return [...rows.values()]
+    .map((row) => ({
+      ...row,
+      percent: totalMpec === 0 ? 0 : row.valueMpec / totalMpec,
+    }))
+    .sort((a, b) => b.valueMpec - a.valueMpec || a.itemName.localeCompare(b.itemName));
+}
+
 function minNullableTs(left: number | null, right: number | null): number | null {
   if (left === null) return right;
   if (right === null) return left;
@@ -1012,7 +1104,9 @@ function getRunStats(drops: MiningDropDto[], claims: MiningClaimDto[], loot: Min
   const noResourceCount = drops.filter((drop) => drop.result === "no_resources").length;
   const activeClaimCount = claims.filter((claim) => claim.status === "active").length;
   const depletedClaimCount = claims.filter((claim) => claim.status === "depleted").length;
-  const totalCostPed = drops.reduce((sum, drop) => sum + drop.cost.totalMpec, 0) / 100_000;
+  const totalCostPed =
+    (drops.reduce((sum, drop) => sum + drop.cost.totalMpec, 0) + totalExtractionCostMpec(loot)) /
+    100_000;
   const totalReturnPed = loot.reduce((sum, item) => sum + item.valueMpec, 0) / 100_000;
 
   return {
@@ -1177,6 +1271,10 @@ function formatPedFromMpec(value: number | null | undefined): string {
   return formatPed(value / 100_000);
 }
 
+function totalExtractionCostMpec(loot: MiningLootItemDto[]): number {
+  return loot.reduce((sum, item) => sum + (item.extractionCostMpec ?? 0), 0);
+}
+
 function formatPed(value: number): string {
   return `${value.toFixed(2)} PED`;
 }
@@ -1192,6 +1290,11 @@ function formatTime(tsMs: number): string {
     minute: "2-digit",
     second: "2-digit",
   });
+}
+
+function formatEventTime(eventDt: string | null, fallbackTsMs: number): string {
+  if (eventDt === null) return formatTime(fallbackTsMs);
+  return formatDateTimeString(eventDt);
 }
 
 function formatExpires(tsMs: number | null): string {

--- a/apps/electron-ui/src/windows/overlayWindow.tsx
+++ b/apps/electron-ui/src/windows/overlayWindow.tsx
@@ -16,7 +16,12 @@ export function OverlayWindow() {
   const state = useZmlRendererStore(windowType);
   const [preferences] = useOverlayPreferences();
   const stats = useMemo(() => {
-    const costMpec = state.miningDrops.reduce((sum, drop) => sum + drop.cost.totalMpec, 0);
+    const dropCostMpec = state.miningDrops.reduce((sum, drop) => sum + drop.cost.totalMpec, 0);
+    const extractionCostMpec = state.miningLoot.reduce(
+      (sum, item) => sum + (item.extractionCostMpec ?? 0),
+      0,
+    );
+    const costMpec = dropCostMpec + extractionCostMpec;
     const returnMpec = state.miningLoot.reduce((sum, item) => sum + item.valueMpec, 0);
     const hitCount = state.miningDrops.filter((drop) => drop.result === "hit").length;
     return {

--- a/apps/game-bridge/src/zml_game_bridge/api/routes/mining.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/routes/mining.py
@@ -7,9 +7,10 @@ from typing import Annotated
 from fastapi import APIRouter, Query
 
 from zml_game_bridge.api.dependencies import ReadConn
-from zml_game_bridge.api.schemas.mining import MiningClaimDto, MiningDropDto
+from zml_game_bridge.api.schemas.mining import MiningClaimDto, MiningDropDto, MiningLootItemDto
 from zml_game_bridge.persistence.mining_claims import MiningClaimReader
 from zml_game_bridge.persistence.mining_drops import MiningDropReader
+from zml_game_bridge.persistence.mining_loot import MiningLootReader
 from zml_game_bridge.persistence.run_state import RunState
 
 router = APIRouter(prefix="/api/v1/mining", tags=["mining"])
@@ -65,6 +66,28 @@ def list_mining_claims(
         len(rows),
     )
     return [MiningClaimDto.from_row(row) for row in rows]
+
+
+@router.get("/loot", response_model=list[MiningLootItemDto])
+def list_mining_loot(
+    conn: ReadConn,
+    run_id: Annotated[int | None, Query(ge=1)] = None,
+    active_run: Annotated[bool, Query()] = False,
+) -> list[MiningLootItemDto]:
+    resolved_run_id = run_id
+    if active_run:
+        resolved_run_id = RunState(conn).try_get_active_run_id()
+        if resolved_run_id is None:
+            return []
+
+    rows = MiningLootReader(conn).list_all(run_id=resolved_run_id)
+    logger.debug(
+        "api_request_read_loot active_run=%s run_id=%s rows=%s",
+        active_run,
+        resolved_run_id,
+        len(rows),
+    )
+    return [MiningLootItemDto.from_row(row) for row in rows]
 
 
 def _now_ms() -> int:

--- a/apps/game-bridge/src/zml_game_bridge/api/schemas/mining.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/schemas/mining.py
@@ -6,6 +6,7 @@ from zml_game_bridge.domain.money import mpec_to_int
 from zml_game_bridge.domain.position import WorldPos
 from zml_game_bridge.persistence.mining_claims import MiningClaimRow
 from zml_game_bridge.persistence.mining_drops import MiningDropRow
+from zml_game_bridge.persistence.mining_loot import MiningLootItemRow
 
 
 class MiningDropPositionDto(BaseModel):
@@ -173,3 +174,33 @@ def _claim_position_dto(position: WorldPos | None) -> MiningClaimPositionDto | N
         if position is not None
         else None
     )
+
+
+class MiningLootItemDto(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: int
+    created_ts_ms: int
+    event_dt: str | None
+    run_id: int | None
+    item_name: str
+    qty: int
+    value_mpec: int
+    extraction_cost_mpec: int | None
+
+    @classmethod
+    def from_row(cls, row: MiningLootItemRow) -> MiningLootItemDto:
+        return cls(
+            event_id=row.event_id,
+            created_ts_ms=row.created_ts_ms,
+            event_dt=row.event_dt.isoformat() if row.event_dt is not None else None,
+            run_id=row.run_id,
+            item_name=row.item_name,
+            qty=row.qty,
+            value_mpec=mpec_to_int(row.value_mpec),
+            extraction_cost_mpec=(
+                mpec_to_int(row.extraction_cost_mpec)
+                if row.extraction_cost_mpec is not None
+                else None
+            ),
+        )

--- a/apps/game-bridge/src/zml_game_bridge/application/mining/chat/correlator.py
+++ b/apps/game-bridge/src/zml_game_bridge/application/mining/chat/correlator.py
@@ -23,6 +23,7 @@ from zml_game_bridge.resources.mining_resources import MiningResourceCatalog
 
 logger = logging.getLogger(__name__)
 ExtractionCostProvider = Callable[[], Mpec | None]
+RunIdProvider = Callable[[], int | None]
 DEFAULT_PENDING_DEED_LINK_WINDOW_MS = 10_000
 
 
@@ -42,11 +43,13 @@ class MiningChatCorrelator:
         *,
         resource_catalog: MiningResourceCatalog | None = None,
         extraction_cost_provider: ExtractionCostProvider | None = None,
+        run_id_provider: RunIdProvider | None = None,
         pending_deed_link_window_ms: int = DEFAULT_PENDING_DEED_LINK_WINDOW_MS,
     ) -> None:
         self._pending_deeds: list[PendingClaimDeed] = []
         self._resource_catalog = resource_catalog or MiningResourceCatalog()
         self._extraction_cost_provider = extraction_cost_provider or _missing_extraction_cost
+        self._run_id_provider = run_id_provider or _missing_run_id
         self._pending_deed_link_window = timedelta(milliseconds=pending_deed_link_window_ms)
 
     def process_signal(self, signal: SignalBase) -> list[EventBase]:
@@ -147,15 +150,17 @@ class MiningChatCorrelator:
             value_mpec=signal.value_mpec,
             raw=signal.raw,
             extraction_cost_mpec=self._extraction_cost_provider(),
+            run_id=self._run_id_provider(),
         )
         logger.debug(
             "item_received_recorded event_type=%s item=%r qty=%s value_mpec=%s "
-            "extraction_cost_mpec=%s event_dt=%s",
+            "extraction_cost_mpec=%s run_id=%s event_dt=%s",
             type(event).__name__,
             event.item_name,
             event.qty,
             event.value_mpec,
             event.extraction_cost_mpec,
+            event.run_id,
             event.event_dt,
         )
         return event
@@ -210,4 +215,8 @@ def _mining_type_from_deed_item_name(item_name: str) -> str | None:
 
 
 def _missing_extraction_cost() -> Mpec | None:
+    return None
+
+
+def _missing_run_id() -> int | None:
     return None

--- a/apps/game-bridge/src/zml_game_bridge/application/mining/coordinator.py
+++ b/apps/game-bridge/src/zml_game_bridge/application/mining/coordinator.py
@@ -35,6 +35,7 @@ from zml_game_bridge.runtime.runtime_commands import (
 )
 
 MiningEquipmentProfileProvider = Callable[[], MiningEquipmentProfile]
+RunIdProvider = Callable[[], int | None]
 
 
 class SignalCorrelator(Protocol):
@@ -72,6 +73,7 @@ class MiningCoordinator:
         position_provider: PositionProvider | None = None,
         resource_catalog: MiningResourceCatalog | None = None,
         run_context_provider: DropRunContextProvider | None = None,
+        run_id_provider: RunIdProvider | None = None,
         db_command_executor: Callable[[DbCommand[Any]], Any] | None = None,
         mining_equipment_service: MiningEquipmentService | None = None,
     ) -> None:
@@ -87,6 +89,7 @@ class MiningCoordinator:
         self._chat = MiningChatCorrelator(
             resource_catalog=resource_catalog,
             extraction_cost_provider=lambda: calculate_extraction_cost(resolved_profile_provider()),
+            run_id_provider=run_id_provider,
         )
         self._claim_lifecycle = ClaimLifecycleCorrelator(
             config=resolved_config,

--- a/apps/game-bridge/src/zml_game_bridge/application/mining/segments/session.py
+++ b/apps/game-bridge/src/zml_game_bridge/application/mining/segments/session.py
@@ -139,6 +139,13 @@ class RunSessionService:
                 lifecycle_events=tuple(lifecycle_events),
             )
 
+    def current_run_id(self) -> int | None:
+        with self._lock:
+            run_id = self._load_active_run_id()
+            if run_id is None:
+                self._reset_active_segment()
+            return run_id
+
     def _reset_active_segment(self) -> None:
         self._active_run_id = None
         self._active_segment_id = None

--- a/apps/game-bridge/src/zml_game_bridge/domain/mining_events.py
+++ b/apps/game-bridge/src/zml_game_bridge/domain/mining_events.py
@@ -96,6 +96,7 @@ class MiningItemReceivedEvent(EventBase):
     value_mpec: Mpec
     raw: str
     extraction_cost_mpec: Mpec | None = None
+    run_id: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/game-bridge/src/zml_game_bridge/persistence/mining_loot.py
+++ b/apps/game-bridge/src/zml_game_bridge/persistence/mining_loot.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from zml_game_bridge.domain.mining_events import MiningItemReceivedEvent
+from zml_game_bridge.domain.money import Mpec, mpec_to_int
+from zml_game_bridge.events.base import EventBase
+from zml_game_bridge.events.envelope import EventEnvelope
+from zml_game_bridge.persistence.event_projector import EventProjector
+
+
+@dataclass(frozen=True, slots=True)
+class MiningLootItemRow:
+    event_id: int
+    created_ts_ms: int
+    event_dt: datetime | None
+    run_id: int | None
+    item_name: str
+    qty: int
+    value_mpec: Mpec
+    extraction_cost_mpec: Mpec | None
+
+
+class MiningLootReader:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def list_all(self, *, run_id: int | None = None) -> list[MiningLootItemRow]:
+        where_clause = "" if run_id is None else "WHERE run_id = ?"
+        params: tuple[int, ...] = () if run_id is None else (run_id,)
+        cur = self._conn.execute(
+            f"""
+            SELECT *
+            FROM mining_loot_items
+            {where_clause}
+            ORDER BY created_ts_ms DESC, event_id DESC
+            """,
+            params,
+        )
+        return [_row_to_loot_item(row) for row in cur.fetchall()]
+
+
+class MiningLootProjector(EventProjector):
+    def project(
+        self,
+        *,
+        conn: sqlite3.Connection,
+        event: EventBase,
+        envelope: EventEnvelope,
+    ) -> None:
+        if isinstance(event, MiningItemReceivedEvent):
+            _MiningLootProjectionWriter(conn).upsert_item(event=event, envelope=envelope)
+
+
+class _MiningLootProjectionWriter:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def upsert_item(
+        self,
+        *,
+        event: MiningItemReceivedEvent,
+        envelope: EventEnvelope,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO mining_loot_items (
+                event_id, created_ts_ms, event_dt, run_id,
+                item_name, qty, value_mpec, extraction_cost_mpec, raw
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(event_id) DO UPDATE SET
+                created_ts_ms = excluded.created_ts_ms,
+                event_dt = excluded.event_dt,
+                run_id = excluded.run_id,
+                item_name = excluded.item_name,
+                qty = excluded.qty,
+                value_mpec = excluded.value_mpec,
+                extraction_cost_mpec = excluded.extraction_cost_mpec,
+                raw = excluded.raw
+            """,
+            (
+                envelope.event_id,
+                envelope.created_ts_ms,
+                event.event_dt.isoformat(),
+                event.run_id,
+                event.item_name,
+                event.qty,
+                mpec_to_int(event.value_mpec),
+                (
+                    mpec_to_int(event.extraction_cost_mpec)
+                    if event.extraction_cost_mpec is not None
+                    else None
+                ),
+                event.raw,
+            ),
+        )
+
+
+def _row_to_loot_item(row: sqlite3.Row) -> MiningLootItemRow:
+    return MiningLootItemRow(
+        event_id=int(row["event_id"]),
+        created_ts_ms=int(row["created_ts_ms"]),
+        event_dt=_optional_datetime(row["event_dt"]),
+        run_id=_optional_int(row["run_id"]),
+        item_name=str(row["item_name"]),
+        qty=int(row["qty"]),
+        value_mpec=Mpec(int(row["value_mpec"])),
+        extraction_cost_mpec=(
+            Mpec(int(row["extraction_cost_mpec"]))
+            if row["extraction_cost_mpec"] is not None
+            else None
+        ),
+    )
+
+
+def _optional_int(value: Any) -> int | None:
+    return int(value) if value is not None else None
+
+
+def _optional_datetime(value: Any) -> datetime | None:
+    return datetime.fromisoformat(str(value)) if value is not None else None

--- a/apps/game-bridge/src/zml_game_bridge/persistence/schema.py
+++ b/apps/game-bridge/src/zml_game_bridge/persistence/schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 SCHEMA_DDL = """
 -- =========================
@@ -150,6 +150,22 @@ CREATE TABLE IF NOT EXISTS mining_claims (
 CREATE INDEX IF NOT EXISTS idx_mining_claims_status ON mining_claims(status);
 CREATE INDEX IF NOT EXISTS idx_mining_claims_observed_ts_ms ON mining_claims(observed_ts_ms);
 CREATE INDEX IF NOT EXISTS idx_mining_claims_expires ON mining_claims(expected_expires_ts_ms);
+
+CREATE TABLE IF NOT EXISTS mining_loot_items (
+    event_id                INTEGER PRIMARY KEY REFERENCES events(event_id) ON DELETE CASCADE,
+    created_ts_ms           INTEGER NOT NULL,
+    event_dt                TEXT,
+    run_id                  INTEGER REFERENCES runs(run_id) ON DELETE SET NULL,
+
+    item_name               TEXT NOT NULL,
+    qty                     INTEGER NOT NULL,
+    value_mpec              INTEGER NOT NULL,
+    extraction_cost_mpec    INTEGER,
+    raw                     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_mining_loot_run_id ON mining_loot_items(run_id, created_ts_ms);
+CREATE INDEX IF NOT EXISTS idx_mining_loot_item_name ON mining_loot_items(item_name);
 
 -- =========================
 -- App state:

--- a/apps/game-bridge/src/zml_game_bridge/runtime/bootstrap.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/bootstrap.py
@@ -15,6 +15,7 @@ from zml_game_bridge.events.in_memory_persisted_event_bus import InMemoryPersist
 from zml_game_bridge.persistence.event_projector import CompositeEventProjector
 from zml_game_bridge.persistence.mining_claims import MiningClaimProjector
 from zml_game_bridge.persistence.mining_drops import MiningDropProjector
+from zml_game_bridge.persistence.mining_loot import MiningLootProjector
 from zml_game_bridge.persistence.runs import RunSegmentProjector
 from zml_game_bridge.resources.mining_resources import MiningResourceCatalog
 from zml_game_bridge.runtime.channels import EventChannel, RuntimeInputChannel
@@ -64,11 +65,15 @@ def build_runtime_components(settings: Settings) -> RuntimeComponents:
             setup=setup,
         )
 
+    def current_run_id() -> int | None:
+        return run_session_service.current_run_id()
+
     mining_coordinator = MiningCoordinator(
         profile_provider=mining_equipment_service.get_equipment_profile,
         position_provider=current_position,
         resource_catalog=resource_catalog,
         run_context_provider=run_context_for_drop,
+        run_id_provider=current_run_id,
         db_command_executor=pending_db_commands.execute,
         mining_equipment_service=mining_equipment_service,
     )
@@ -87,6 +92,7 @@ def build_runtime_components(settings: Settings) -> RuntimeComponents:
                 RunSegmentProjector(),
                 MiningDropProjector(),
                 MiningClaimProjector(),
+                MiningLootProjector(),
             ]
         ),
     )

--- a/apps/game-bridge/tests/api/test_mining_routes.py
+++ b/apps/game-bridge/tests/api/test_mining_routes.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 
-from zml_game_bridge.api.routes.mining import list_mining_claims, list_mining_drops
+from zml_game_bridge.api.routes.mining import (
+    list_mining_claims,
+    list_mining_drops,
+    list_mining_loot,
+)
 from zml_game_bridge.domain.mining_cost import DropCostBreakdown, DropUnitCost
-from zml_game_bridge.domain.mining_events import MiningClaimCreatedEvent, MiningDropEvent
+from zml_game_bridge.domain.mining_events import (
+    MiningClaimCreatedEvent,
+    MiningDropEvent,
+    MiningItemReceivedEvent,
+)
 from zml_game_bridge.domain.money import Mpec
 from zml_game_bridge.domain.position import WorldPos
 from zml_game_bridge.persistence.event_projector import CompositeEventProjector
 from zml_game_bridge.persistence.event_writer import EventWriter
 from zml_game_bridge.persistence.mining_claims import MiningClaimProjector
 from zml_game_bridge.persistence.mining_drops import MiningDropProjector
+from zml_game_bridge.persistence.mining_loot import MiningLootProjector
+from zml_game_bridge.persistence.runs import RunStore
 from zml_game_bridge.persistence.schema import ensure_schema
 from zml_game_bridge.persistence.sqlite import open_sqlite
 
@@ -107,6 +118,32 @@ def test_list_mining_claims_returns_active_unexpired_claims(
         conn.close()
 
 
+def test_list_mining_loot_returns_items_for_run(tmp_path: Path) -> None:
+    conn = _open_test_db(tmp_path)
+    try:
+        with conn:
+            RunStore(conn).create_run(
+                name="Test run",
+                notes=None,
+                ts_ms=1_000,
+                status="running",
+            )
+        writer = EventWriter(conn, projector=MiningLootProjector())
+        writer.write(_loot_event(item_name="Blue Crystal", run_id=1, value_mpec=16_000))
+        writer.write(_loot_event(item_name="Crude Oil", run_id=None, value_mpec=10_000))
+
+        loot = list_mining_loot(conn, run_id=1)
+
+        assert len(loot) == 1
+        assert loot[0].run_id == 1
+        assert loot[0].item_name == "Blue Crystal"
+        assert loot[0].qty == 8
+        assert loot[0].value_mpec == 16_000
+        assert loot[0].extraction_cost_mpec == 125
+    finally:
+        conn.close()
+
+
 def _drop_event(*, drop_id: str, observed_ts_ms: int) -> MiningDropEvent:
     return MiningDropEvent(
         drop_id=drop_id,
@@ -145,4 +182,21 @@ def _claim_created_event(
         expected_expires_ts_ms=expected_expires_ts_ms,
         range_m=51.14,
         depth_m=53.0,
+    )
+
+
+def _loot_event(
+    *,
+    item_name: str,
+    run_id: int | None,
+    value_mpec: int,
+) -> MiningItemReceivedEvent:
+    return MiningItemReceivedEvent(
+        event_dt=datetime(2026, 1, 10, 12, 37, 50),
+        item_name=item_name,
+        qty=8,
+        value_mpec=Mpec(value_mpec),
+        raw="raw",
+        extraction_cost_mpec=Mpec(125),
+        run_id=run_id,
     )

--- a/apps/game-bridge/tests/application/mining/test_mining_coordinator.py
+++ b/apps/game-bridge/tests/application/mining/test_mining_coordinator.py
@@ -723,6 +723,28 @@ def test_mining_coordinator_records_item_received_chat_event() -> None:
     assert event.qty == 8
     assert event.value_mpec == Mpec(16_000)
     assert event.extraction_cost_mpec is None
+    assert event.run_id is None
+
+
+def test_mining_coordinator_attaches_active_run_to_item_received_chat_event() -> None:
+    coordinator = MiningCoordinator(run_id_provider=lambda: 7)
+    event_dt = datetime(2026, 1, 10, 12, 37, 50)
+
+    events = coordinator.process_signal(
+        ItemReceivedSignal(
+            event_dt=event_dt,
+            channel_type=ChannelType.SYSTEM,
+            channel_token="System",
+            raw="2026-01-10 12:37:50 [System] [] You received Blue Crystal x (8) Value: 0.1600 PED",
+            item_name="Blue Crystal",
+            qty=8,
+            value_mpec=Mpec(16_000),
+        )
+    )
+
+    event = events[0]
+    assert isinstance(event, MiningItemReceivedEvent)
+    assert event.run_id == 7
 
 
 def test_mining_coordinator_adds_extractor_cost_to_item_received_event() -> None:

--- a/apps/game-bridge/tests/persistence/test_event_writer.py
+++ b/apps/game-bridge/tests/persistence/test_event_writer.py
@@ -97,7 +97,7 @@ def test_event_writer_stores_event_dt_and_raw_outside_payload(tmp_path: Path) ->
     assert row["event_type"] == "MiningItemReceivedEvent"
     assert (
         row["payload_json"]
-        == '{"item_name":"Blue Crystal","qty":8,"value_mpec":16000,"extraction_cost_mpec":null}'
+        == '{"item_name":"Blue Crystal","qty":8,"value_mpec":16000,"extraction_cost_mpec":null,"run_id":null}'
     )
     assert row["event_dt"] == "2026-01-10T12:37:50"
     assert row["raw"] == raw

--- a/apps/game-bridge/tests/persistence/test_mining_loot.py
+++ b/apps/game-bridge/tests/persistence/test_mining_loot.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from zml_game_bridge.domain.mining_events import MiningItemReceivedEvent
+from zml_game_bridge.domain.money import Mpec
+from zml_game_bridge.persistence.event_writer import EventWriter
+from zml_game_bridge.persistence.mining_loot import MiningLootProjector, MiningLootReader
+from zml_game_bridge.persistence.runs import RunStore
+from zml_game_bridge.persistence.schema import ensure_schema
+from zml_game_bridge.persistence.sqlite import open_sqlite
+
+
+def _open_test_db(tmp_path: Path) -> sqlite3.Connection:
+    conn = open_sqlite(tmp_path / "mining-loot.sqlite3")
+    ensure_schema(conn)
+    with conn:
+        RunStore(conn).create_run(
+            name="Test run",
+            notes=None,
+            ts_ms=1_000,
+            status="running",
+        )
+    return conn
+
+
+def test_mining_loot_projector_stores_item_received_read_model(tmp_path: Path) -> None:
+    conn = _open_test_db(tmp_path)
+    try:
+        event_dt = datetime(2026, 1, 10, 12, 37, 50)
+        env = EventWriter(conn, projector=MiningLootProjector()).write(
+            MiningItemReceivedEvent(
+                event_dt=event_dt,
+                item_name="Blue Crystal",
+                qty=8,
+                value_mpec=Mpec(16_000),
+                raw="raw",
+                extraction_cost_mpec=Mpec(125),
+                run_id=1,
+            )
+        )
+
+        rows = MiningLootReader(conn).list_all(run_id=1)
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.event_id == env.event_id
+        assert row.created_ts_ms == env.created_ts_ms
+        assert row.event_dt == event_dt
+        assert row.run_id == 1
+        assert row.item_name == "Blue Crystal"
+        assert row.qty == 8
+        assert row.value_mpec == Mpec(16_000)
+        assert row.extraction_cost_mpec == Mpec(125)
+    finally:
+        conn.close()

--- a/packages/shared/src/dto/miningLoot.ts
+++ b/packages/shared/src/dto/miningLoot.ts
@@ -4,22 +4,50 @@ export type MiningLootItemDto = {
     eventId: number;
     createdTsMs: number;
     eventDt: string | null;
+    runId: number | null;
     itemName: string;
     qty: number;
     valueMpec: number;
     extractionCostMpec: number | null;
 };
 
+export type MiningLootItemWire = {
+    event_id: number;
+    created_ts_ms: number;
+    event_dt: string | null;
+    run_id: number | null;
+    item_name: string;
+    qty: number;
+    value_mpec: number;
+    extraction_cost_mpec: number | null;
+};
+
 export type MiningItemReceivedEventWire = {
+    run_id?: number | null;
     item_name: string;
     qty: number;
     value_mpec: number;
     extraction_cost_mpec?: number | null;
 };
 
+export function isMiningLootItemWire(value: unknown): value is MiningLootItemWire {
+    if (!isRecord(value)) return false;
+    return (
+        isFiniteNumber(value.event_id) &&
+        isFiniteNumber(value.created_ts_ms) &&
+        isNullableString(value.event_dt) &&
+        isNullableNumber(value.run_id) &&
+        typeof value.item_name === "string" &&
+        isFiniteNumber(value.qty) &&
+        isFiniteNumber(value.value_mpec) &&
+        isNullableNumber(value.extraction_cost_mpec)
+    );
+}
+
 export function isMiningItemReceivedEventWire(value: unknown): value is MiningItemReceivedEventWire {
     if (!isRecord(value)) return false;
     return (
+        (value.run_id === undefined || isNullableNumber(value.run_id)) &&
         typeof value.item_name === "string" &&
         isFiniteNumber(value.qty) &&
         isFiniteNumber(value.value_mpec) &&
@@ -35,6 +63,7 @@ export function miningLootItemDtoFromEventWire(
         eventId: envelope.eventId ?? -1,
         createdTsMs: envelope.createdTsMs,
         eventDt: envelope.eventDt,
+        runId: wire.run_id ?? null,
         itemName: wire.item_name,
         qty: wire.qty,
         valueMpec: wire.value_mpec,
@@ -42,8 +71,25 @@ export function miningLootItemDtoFromEventWire(
     };
 }
 
+export function wireToMiningLootItemDto(wire: MiningLootItemWire): MiningLootItemDto {
+    return {
+        eventId: wire.event_id,
+        createdTsMs: wire.created_ts_ms,
+        eventDt: wire.event_dt,
+        runId: wire.run_id,
+        itemName: wire.item_name,
+        qty: wire.qty,
+        valueMpec: wire.value_mpec,
+        extractionCostMpec: wire.extraction_cost_mpec,
+    };
+}
+
 function isNullableNumber(value: unknown): value is number | null {
     return value === null || isFiniteNumber(value);
+}
+
+function isNullableString(value: unknown): value is string | null {
+    return value === null || typeof value === "string";
 }
 
 function isFiniteNumber(value: unknown): value is number {


### PR DESCRIPTION
- Add mining loot projection table and reader
- Attach active run id to MiningItemReceivedEvent
- Expose mining loot via /api/v1/mining/loot
- Bootstrap and refresh loot in Electron UI
- Aggregate loot by item/resource in the Loot tab
- Include extraction costs in run and overlay cost totals
- Mark roadmap P1:11 as completed