### PR TITLE
Add finder OCR crop recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,4 @@ apps/game-bridge/*.spec
 apps/game-bridge/.pytest-cache/
 apps/game-bridge/.pytest-cache-local/
 apps/game-bridge/.pytest-tmp/
+apps/game-bridge/.pytest-tmp-*/

--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -84,10 +84,10 @@
    - ~~Usuwamy runtime path oparty o `pytesseract`.~~
    - ~~OCR worker ma używać małego wrappera wokół `tesserocr`, żeby nie rozlewać biblioteki po kodzie.~~
 
-16. **Recording screenshotów findera**
-   - Potrzebne do testowania OCR frameworków.
-   - Zapisywać crop + metadata.
-   - Tryby: manual, low-confidence, state-change, every N seconds.
+16. **~~Recording screenshotów findera~~**
+   - ~~Potrzebne do testowania OCR frameworków.~~
+   - ~~Zapisywać crop + metadata.~~
+   - ~~Tryby: manual, low-confidence, state-change, every N seconds.~~
 
 17. **Profilowanie OCR**
    - Zmierzyć capture/crop/preprocess/ocr/parse/emit.
@@ -160,7 +160,7 @@
 ### Batch 3 — OCR/config
 
 15. ~~ROI config.~~
-16. Finder screenshot recording.
+16. ~~Finder screenshot recording.~~
 17. OCR profiling.
 18. ~~`pytesseract` -> `tesserocr`.~~
 19. Compass latest-wins.

--- a/apps/game-bridge/README.md
+++ b/apps/game-bridge/README.md
@@ -59,6 +59,12 @@ Input modes:
 - `ZML_MOCK_INPUTS`: enable mock mining input.
 - `ZML_MOCK_MINING_INTERVAL_MS`: mock drop interval.
 - `ZML_FINDER_DEBUG`: enable detailed finder OCR debug logging.
+- `ZML_FINDER_RECORDING`: finder crop recording modes, comma-separated: `manual`, `state-change`, `low-confidence`, `interval`, or `all`.
+- `ZML_FINDER_RECORDING_DIR`: output directory for finder crop PNG + JSON metadata.
+- `ZML_FINDER_RECORDING_INTERVAL_S`: cadence for `interval` recording mode, defaults to `10`.
+- `ZML_FINDER_RECORDING_LOW_CONFIDENCE_INTERVAL_S`: minimum cadence for low-confidence samples, defaults to `5`.
+
+For manual finder recording, enable `manual` mode and create a `record-now.flag` file in `ZML_FINDER_RECORDING_DIR`; the OCR worker consumes the flag on the next finder frame.
 
 By default, error logs are written to:
 

--- a/apps/game-bridge/src/zml_game_bridge/dev_cli.py
+++ b/apps/game-bridge/src/zml_game_bridge/dev_cli.py
@@ -74,7 +74,9 @@ def _apply_env_overrides(
         os.environ["ZML_FINDER_RECORDING_INTERVAL_S"] = str(finder_recording_interval_s)
     if finder_recording_low_confidence_interval_s is not None:
         if finder_recording_low_confidence_interval_s <= 0:
-            raise typer.BadParameter("finder recording low confidence interval must be greater than 0")
+            raise typer.BadParameter(
+                "finder recording low confidence interval must be greater than 0"
+            )
         os.environ["ZML_FINDER_RECORDING_LOW_CONFIDENCE_INTERVAL_S"] = str(
             finder_recording_low_confidence_interval_s
         )

--- a/apps/game-bridge/src/zml_game_bridge/dev_cli.py
+++ b/apps/game-bridge/src/zml_game_bridge/dev_cli.py
@@ -33,6 +33,10 @@ def _apply_env_overrides(
     chat_log_path: Path | None,
     ocr_profile_path: Path | None,
     finder_debug: bool,
+    finder_recording: str | None = None,
+    finder_recording_dir: Path | None = None,
+    finder_recording_interval_s: float | None = None,
+    finder_recording_low_confidence_interval_s: float | None = None,
     log_level: str | None,
     mock_interval_ms: int | None,
 ) -> None:
@@ -60,6 +64,20 @@ def _apply_env_overrides(
         os.environ["ZML_OCR_PROFILE_PATH"] = str(ocr_profile_path)
     if finder_debug:
         os.environ["ZML_FINDER_DEBUG"] = "1"
+    if finder_recording is not None:
+        os.environ["ZML_FINDER_RECORDING"] = finder_recording
+    if finder_recording_dir is not None:
+        os.environ["ZML_FINDER_RECORDING_DIR"] = str(finder_recording_dir)
+    if finder_recording_interval_s is not None:
+        if finder_recording_interval_s <= 0:
+            raise typer.BadParameter("finder recording interval must be greater than 0")
+        os.environ["ZML_FINDER_RECORDING_INTERVAL_S"] = str(finder_recording_interval_s)
+    if finder_recording_low_confidence_interval_s is not None:
+        if finder_recording_low_confidence_interval_s <= 0:
+            raise typer.BadParameter("finder recording low confidence interval must be greater than 0")
+        os.environ["ZML_FINDER_RECORDING_LOW_CONFIDENCE_INTERVAL_S"] = str(
+            finder_recording_low_confidence_interval_s
+        )
     if log_level is not None:
         os.environ["ZML_LOG_LEVEL"] = log_level.upper()
     if mock_interval_ms is not None:
@@ -89,6 +107,13 @@ def _settings_table(settings: Settings) -> Table:
     table.add_row("ocr_enabled", _format_bool(settings.ocr_enabled))
     table.add_row("mock_inputs_enabled", _format_bool(settings.mock_inputs_enabled))
     table.add_row("mock_mining_interval_ms", str(settings.mock_mining_interval_ms))
+    table.add_row("finder_recording_modes", settings.finder_recording_modes or "[dim]<off>[/]")
+    table.add_row("finder_recording_dir", str(settings.finder_recording_dir))
+    table.add_row("finder_recording_interval_s", str(settings.finder_recording_interval_s))
+    table.add_row(
+        "finder_recording_low_confidence_interval_s",
+        str(settings.finder_recording_low_confidence_interval_s),
+    )
     return table
 
 
@@ -124,6 +149,28 @@ def show_config(
         bool,
         typer.Option("--finder-debug", help="Enable finder OCR debug logging."),
     ] = False,
+    finder_recording: Annotated[
+        str | None,
+        typer.Option(
+            "--finder-record",
+            help="Finder crop recording modes: manual,state-change,low-confidence,interval,all.",
+        ),
+    ] = None,
+    finder_recording_dir: Annotated[
+        Path | None,
+        typer.Option("--finder-record-dir", help="Override ZML_FINDER_RECORDING_DIR."),
+    ] = None,
+    finder_recording_interval_s: Annotated[
+        float | None,
+        typer.Option("--finder-record-interval-s", help="Interval recording cadence in seconds."),
+    ] = None,
+    finder_recording_low_confidence_interval_s: Annotated[
+        float | None,
+        typer.Option(
+            "--finder-record-low-confidence-interval-s",
+            help="Minimum seconds between low-confidence samples.",
+        ),
+    ] = None,
     log_level: Annotated[
         str | None, typer.Option("--log-level", help="Override ZML_LOG_LEVEL.")
     ] = None,
@@ -138,6 +185,10 @@ def show_config(
         chat_log_path=chat_log_path,
         ocr_profile_path=ocr_profile_path,
         finder_debug=finder_debug,
+        finder_recording=finder_recording,
+        finder_recording_dir=finder_recording_dir,
+        finder_recording_interval_s=finder_recording_interval_s,
+        finder_recording_low_confidence_interval_s=finder_recording_low_confidence_interval_s,
         log_level=log_level,
         mock_interval_ms=mock_interval_ms,
     )
@@ -168,6 +219,28 @@ def serve(
         bool,
         typer.Option("--finder-debug", help="Enable finder OCR debug logging."),
     ] = False,
+    finder_recording: Annotated[
+        str | None,
+        typer.Option(
+            "--finder-record",
+            help="Finder crop recording modes: manual,state-change,low-confidence,interval,all.",
+        ),
+    ] = None,
+    finder_recording_dir: Annotated[
+        Path | None,
+        typer.Option("--finder-record-dir", help="Override ZML_FINDER_RECORDING_DIR."),
+    ] = None,
+    finder_recording_interval_s: Annotated[
+        float | None,
+        typer.Option("--finder-record-interval-s", help="Interval recording cadence in seconds."),
+    ] = None,
+    finder_recording_low_confidence_interval_s: Annotated[
+        float | None,
+        typer.Option(
+            "--finder-record-low-confidence-interval-s",
+            help="Minimum seconds between low-confidence samples.",
+        ),
+    ] = None,
     log_level: Annotated[
         str | None, typer.Option("--log-level", help="Override ZML_LOG_LEVEL.")
     ] = None,
@@ -182,6 +255,10 @@ def serve(
         chat_log_path=chat_log_path,
         ocr_profile_path=ocr_profile_path,
         finder_debug=finder_debug,
+        finder_recording=finder_recording,
+        finder_recording_dir=finder_recording_dir,
+        finder_recording_interval_s=finder_recording_interval_s,
+        finder_recording_low_confidence_interval_s=finder_recording_low_confidence_interval_s,
         log_level=log_level,
         mock_interval_ms=mock_interval_ms,
     )

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/pipeline.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Protocol
 
 import numpy as np
 
@@ -29,15 +30,28 @@ class MiningFinderPipelineConfig:
     debug_logging: bool = False
 
 
+class FinderFrameObserver(Protocol):
+    def record_frame(
+        self,
+        finder_roi: np.ndarray,
+        *,
+        ts_ms: int,
+        features: FinderFeatures,
+        signals: list[MiningFinderSignal],
+    ) -> None: ...
+
+
 class MiningFinderPipeline:
     def __init__(
         self,
         *,
         detector: FinderFeatureDetector | None = None,
         cfg: MiningFinderPipelineConfig | None = None,
+        frame_observer: FinderFrameObserver | None = None,
     ) -> None:
         self._detector = detector or VisionFinderFeatureDetector()
         self._cfg = cfg or MiningFinderPipelineConfig()
+        self._frame_observer = frame_observer
 
         self._last_status_kind: FinderStatusKind | None = None
         self._last_probe_ts_ms: int | None = None
@@ -95,6 +109,13 @@ class MiningFinderPipeline:
             signals.append(no_resources_signal)
 
         self._log_debug_changes(features, signals, ts_ms)
+        if self._frame_observer is not None:
+            self._frame_observer.record_frame(
+                finder_roi,
+                ts_ms=ts_ms,
+                features=features,
+                signals=signals,
+            )
         self._last_status_kind = features.status_kind
         return signals
 

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/recording.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/recording.py
@@ -73,7 +73,9 @@ class FinderCropRecorder:
             if not reasons:
                 return
 
-            self._write_sample(finder_roi, ts_ms=ts_ms, features=features, signals=signals, reasons=reasons)
+            self._write_sample(
+                finder_roi, ts_ms=ts_ms, features=features, signals=signals, reasons=reasons
+            )
         except Exception:
             logger.warning("finder_crop_record_failed ts_ms=%s", ts_ms, exc_info=True)
 
@@ -92,20 +94,26 @@ class FinderCropRecorder:
         if "state-change" in self._config.modes and self._is_state_change(features, signals):
             reasons.append("state-change")
 
-        if "low-confidence" in self._config.modes and self._is_low_confidence(features):
-            if self._last_low_confidence_ts_ms is None or (
-                ts_ms - self._last_low_confidence_ts_ms
-                >= self._config.low_confidence_min_interval_ms
-            ):
-                self._last_low_confidence_ts_ms = ts_ms
-                reasons.append("low-confidence")
+        if (
+            "low-confidence" in self._config.modes
+            and self._is_low_confidence(features)
+            and (
+                self._last_low_confidence_ts_ms is None
+                or (
+                    ts_ms - self._last_low_confidence_ts_ms
+                    >= self._config.low_confidence_min_interval_ms
+                )
+            )
+        ):
+            self._last_low_confidence_ts_ms = ts_ms
+            reasons.append("low-confidence")
 
-        if "interval" in self._config.modes:
-            if self._last_interval_ts_ms is None or (
-                ts_ms - self._last_interval_ts_ms >= self._config.interval_ms
-            ):
-                self._last_interval_ts_ms = ts_ms
-                reasons.append("interval")
+        if "interval" in self._config.modes and (
+            self._last_interval_ts_ms is None
+            or (ts_ms - self._last_interval_ts_ms >= self._config.interval_ms)
+        ):
+            self._last_interval_ts_ms = ts_ms
+            reasons.append("interval")
 
         return reasons
 
@@ -116,7 +124,9 @@ class FinderCropRecorder:
         try:
             trigger.unlink()
         except OSError:
-            logger.warning("finder_record_manual_trigger_delete_failed path=%s", trigger, exc_info=True)
+            logger.warning(
+                "finder_record_manual_trigger_delete_failed path=%s", trigger, exc_info=True
+            )
         return True
 
     def _is_state_change(
@@ -189,7 +199,9 @@ def finder_recording_config_from_env(
 ) -> FinderRecordingConfig:
     return FinderRecordingConfig(
         modes=_parse_modes(modes if modes is not None else os.getenv("ZML_FINDER_RECORDING")),
-        root_dir=root_dir or _env_path("ZML_FINDER_RECORDING_DIR") or default_finder_recording_dir(),
+        root_dir=root_dir
+        or _env_path("ZML_FINDER_RECORDING_DIR")
+        or default_finder_recording_dir(),
         interval_ms=_seconds_to_ms(
             interval_s
             if interval_s is not None

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/recording.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/recording.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+import cv2
+import numpy as np
+
+from zml_game_bridge.inputs.ocr.pipelines.mining_finder.model import (
+    FinderFeatures,
+    MiningFinderSignal,
+)
+
+logger = logging.getLogger(__name__)
+
+FinderRecordingMode = Literal["manual", "low-confidence", "state-change", "interval"]
+_VALID_MODES: set[FinderRecordingMode] = {
+    "manual",
+    "low-confidence",
+    "state-change",
+    "interval",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class FinderRecordingConfig:
+    modes: frozenset[FinderRecordingMode]
+    root_dir: Path
+    interval_ms: int = 10_000
+    low_confidence_min_interval_ms: int = 5_000
+    manual_trigger_filename: str = "record-now.flag"
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.modes)
+
+
+class FinderCropRecorder:
+    def __init__(
+        self,
+        *,
+        config: FinderRecordingConfig,
+        roi_name: str,
+    ) -> None:
+        self._config = config
+        self._roi_name = roi_name
+        self._last_status_kind: str | None = None
+        self._last_interval_ts_ms: int | None = None
+        self._last_low_confidence_ts_ms: int | None = None
+        self._sequence = 0
+        if config.enabled:
+            config.root_dir.mkdir(parents=True, exist_ok=True)
+
+    def record_frame(
+        self,
+        finder_roi: np.ndarray,
+        *,
+        ts_ms: int,
+        features: FinderFeatures,
+        signals: list[MiningFinderSignal],
+    ) -> None:
+        if not self._config.enabled:
+            return
+
+        try:
+            reasons = self._recording_reasons(ts_ms=ts_ms, features=features, signals=signals)
+            self._last_status_kind = features.status_kind
+            if not reasons:
+                return
+
+            self._write_sample(finder_roi, ts_ms=ts_ms, features=features, signals=signals, reasons=reasons)
+        except Exception:
+            logger.warning("finder_crop_record_failed ts_ms=%s", ts_ms, exc_info=True)
+
+    def _recording_reasons(
+        self,
+        *,
+        ts_ms: int,
+        features: FinderFeatures,
+        signals: list[MiningFinderSignal],
+    ) -> list[str]:
+        reasons: list[str] = []
+
+        if "manual" in self._config.modes and self._consume_manual_trigger():
+            reasons.append("manual")
+
+        if "state-change" in self._config.modes and self._is_state_change(features, signals):
+            reasons.append("state-change")
+
+        if "low-confidence" in self._config.modes and self._is_low_confidence(features):
+            if self._last_low_confidence_ts_ms is None or (
+                ts_ms - self._last_low_confidence_ts_ms
+                >= self._config.low_confidence_min_interval_ms
+            ):
+                self._last_low_confidence_ts_ms = ts_ms
+                reasons.append("low-confidence")
+
+        if "interval" in self._config.modes:
+            if self._last_interval_ts_ms is None or (
+                ts_ms - self._last_interval_ts_ms >= self._config.interval_ms
+            ):
+                self._last_interval_ts_ms = ts_ms
+                reasons.append("interval")
+
+        return reasons
+
+    def _consume_manual_trigger(self) -> bool:
+        trigger = self._config.root_dir / self._config.manual_trigger_filename
+        if not trigger.exists():
+            return False
+        try:
+            trigger.unlink()
+        except OSError:
+            logger.warning("finder_record_manual_trigger_delete_failed path=%s", trigger, exc_info=True)
+        return True
+
+    def _is_state_change(
+        self,
+        features: FinderFeatures,
+        signals: list[MiningFinderSignal],
+    ) -> bool:
+        return bool(signals) or features.status_kind != self._last_status_kind
+
+    def _is_low_confidence(self, features: FinderFeatures) -> bool:
+        if features.status_kind is None:
+            return True
+        if features.status_kind == "found":
+            return (
+                features.hit_size_label is None
+                or features.hit_size_index is None
+                or features.resource_name is None
+            )
+        if features.status_kind == "no_resources":
+            return not bool(features.raw_status_text)
+        return False
+
+    def _write_sample(
+        self,
+        finder_roi: np.ndarray,
+        *,
+        ts_ms: int,
+        features: FinderFeatures,
+        signals: list[MiningFinderSignal],
+        reasons: list[str],
+    ) -> None:
+        self._sequence += 1
+        timestamp = datetime.fromtimestamp(ts_ms / 1000, tz=UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        reason_slug = "_".join(reason.replace("-", "_") for reason in reasons)
+        stem = f"{timestamp}_{self._sequence:06d}_{reason_slug}"
+        png_path = self._config.root_dir / f"{stem}.png"
+        json_path = self._config.root_dir / f"{stem}.json"
+
+        if not cv2.imwrite(str(png_path), finder_roi):
+            raise RuntimeError(f"Failed to write finder crop: {png_path}")
+
+        json_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "created_at": datetime.now(tz=UTC).isoformat(),
+                    "ts_ms": ts_ms,
+                    "roi_name": self._roi_name,
+                    "image_file": png_path.name,
+                    "image_shape": list(finder_roi.shape),
+                    "reasons": reasons,
+                    "features": _features_to_json(features),
+                    "signals": [_signal_to_json(signal) for signal in signals],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        logger.debug("finder_crop_recorded path=%s reasons=%s", png_path, ",".join(reasons))
+
+
+def finder_recording_config_from_env(
+    *,
+    modes: str | None = None,
+    root_dir: Path | None = None,
+    interval_s: float | None = None,
+    low_confidence_interval_s: float | None = None,
+) -> FinderRecordingConfig:
+    return FinderRecordingConfig(
+        modes=_parse_modes(modes if modes is not None else os.getenv("ZML_FINDER_RECORDING")),
+        root_dir=root_dir or _env_path("ZML_FINDER_RECORDING_DIR") or default_finder_recording_dir(),
+        interval_ms=_seconds_to_ms(
+            interval_s
+            if interval_s is not None
+            else _env_float("ZML_FINDER_RECORDING_INTERVAL_S", default=10.0)
+        ),
+        low_confidence_min_interval_ms=_seconds_to_ms(
+            low_confidence_interval_s
+            if low_confidence_interval_s is not None
+            else _env_float("ZML_FINDER_RECORDING_LOW_CONFIDENCE_INTERVAL_S", default=5.0)
+        ),
+    )
+
+
+def _parse_modes(raw: str | None) -> frozenset[FinderRecordingMode]:
+    if raw is None or raw.strip() == "":
+        return frozenset()
+
+    modes: set[FinderRecordingMode] = set()
+    for item in raw.replace(";", ",").replace(" ", ",").split(","):
+        normalized = item.strip().lower()
+        if normalized in {"", "0", "false", "off", "none"}:
+            continue
+        if normalized == "all":
+            modes.update(_VALID_MODES)
+            continue
+        if normalized in {"every", "timer", "every-n-seconds"}:
+            normalized = "interval"
+        if normalized == "manual":
+            modes.add("manual")
+        elif normalized == "low-confidence":
+            modes.add("low-confidence")
+        elif normalized == "state-change":
+            modes.add("state-change")
+        elif normalized == "interval":
+            modes.add("interval")
+        else:
+            logger.warning("finder_recording_mode_ignored mode=%r", item)
+
+    return frozenset(modes)
+
+
+def _features_to_json(features: FinderFeatures) -> dict[str, object]:
+    return {
+        "status_kind": features.status_kind,
+        "radar_signal_active": features.radar_signal_active,
+        "modes_mask": features.modes_mask,
+        "probes_per_drop": features.probes_per_drop,
+        "ammo_per_drop": features.ammo_per_drop,
+        "raw_status_text": features.raw_status_text,
+        "raw_units_text": features.raw_units_text,
+        "raw_details_text": features.raw_details_text,
+        "hit_size_label": features.hit_size_label,
+        "hit_size_index": features.hit_size_index,
+        "resource_name": features.resource_name,
+        "range_m": features.range_m,
+        "depth_m": features.depth_m,
+        "debug": dict(features.debug),
+    }
+
+
+def _signal_to_json(signal: MiningFinderSignal) -> dict[str, object]:
+    return {
+        "kind": signal.kind,
+        "ts_ms": signal.ts_ms,
+        "modes_mask": signal.modes_mask,
+        "previous_modes_mask": signal.previous_modes_mask,
+        "probes_per_drop": signal.probes_per_drop,
+        "ammo_per_drop": signal.ammo_per_drop,
+        "raw_text": signal.raw_text,
+        "raw_details_text": signal.raw_details_text,
+        "hit_size_label": signal.hit_size_label,
+        "hit_size_index": signal.hit_size_index,
+        "resource_name": signal.resource_name,
+        "range_m": signal.range_m,
+        "depth_m": signal.depth_m,
+        "debug": dict(signal.debug),
+    }
+
+
+def default_finder_recording_dir() -> Path:
+    app_data = os.getenv("LOCALAPPDATA") or os.getenv("APPDATA") or str(Path.home())
+    return Path(app_data) / "z-mining-log" / "ocr" / "finder-crops"
+
+
+def _env_path(name: str) -> Path | None:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return None
+    return Path(value)
+
+
+def _env_float(name: str, *, default: float) -> float:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def _seconds_to_ms(value: float) -> int:
+    return max(1, int(value * 1000))

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/runner.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/runner.py
@@ -17,6 +17,10 @@ from zml_game_bridge.inputs.ocr.pipelines.mining_finder.pipeline import (
     MiningFinderPipeline,
     MiningFinderPipelineConfig,
 )
+from zml_game_bridge.inputs.ocr.pipelines.mining_finder.recording import (
+    FinderCropRecorder,
+    finder_recording_config_from_env,
+)
 from zml_game_bridge.inputs.ocr.pipelines.mining_finder.signals import (
     FinderHitHintSignal,
     FinderModeInvalidatedSignal,
@@ -40,6 +44,10 @@ def start_ocr_input(
     stop_event: threading.Event,
     target_hz: float = 10.0,
     finder_debug_logging: bool | None = None,
+    finder_recording_modes: str | None = None,
+    finder_recording_dir: Path | None = None,
+    finder_recording_interval_s: float | None = None,
+    finder_recording_low_confidence_interval_s: float | None = None,
     roi_profile_path: Path | None = None,
     roi_profile: OcrRoiProfile | None = None,
 ) -> None:
@@ -65,9 +73,33 @@ def start_ocr_input(
         _configure_finder_debug_logging()
         logger.info("finder_debug_enabled")
 
+    finder_recording_config = finder_recording_config_from_env(
+        modes=finder_recording_modes,
+        root_dir=finder_recording_dir,
+        interval_s=finder_recording_interval_s,
+        low_confidence_interval_s=finder_recording_low_confidence_interval_s,
+    )
+    finder_recorder = (
+        FinderCropRecorder(
+            config=finder_recording_config,
+            roi_name=roi_profile.screen_rois.finder.name,
+        )
+        if finder_recording_config.enabled
+        else None
+    )
+    if finder_recorder is not None:
+        logger.info(
+            "finder_recording_enabled modes=%s dir=%s interval_ms=%s low_confidence_interval_ms=%s",
+            ",".join(sorted(finder_recording_config.modes)),
+            finder_recording_config.root_dir,
+            finder_recording_config.interval_ms,
+            finder_recording_config.low_confidence_min_interval_ms,
+        )
+
     finder_pipeline = MiningFinderPipeline(
         detector=VisionFinderFeatureDetector(layout=roi_profile.finder_panel.to_panel_layout()),
         cfg=MiningFinderPipelineConfig(debug_logging=finder_debug_logging),
+        frame_observer=finder_recorder,
     )
     # deeds_pipeline = ...     # step(deeds_roi, ts_ms) -> ...
 

--- a/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
@@ -104,7 +104,8 @@ class AppRuntime:
         self._started = True
         logger.info(
             "app_started db_path=%s chat_log_path=%s mining_resource_catalog_path=%s "
-            "mining_tools_path=%s ocr_profile_path=%s ocr_enabled=%s mock_inputs_enabled=%s",
+            "mining_tools_path=%s ocr_profile_path=%s ocr_enabled=%s mock_inputs_enabled=%s "
+            "finder_recording_modes=%s",
             self._settings.db_path,
             self._settings.chat_log_path,
             self._settings.mining_resource_catalog_path,
@@ -112,6 +113,7 @@ class AppRuntime:
             self._settings.ocr_profile_path,
             self._settings.ocr_enabled,
             self._settings.mock_inputs_enabled,
+            self._settings.finder_recording_modes,
         )
 
         self._supervisor.start_thread(
@@ -153,6 +155,12 @@ class AppRuntime:
                     "signal_sink": self._components.pending_inputs.emit,
                     "stop_event": self._stop_event,
                     "roi_profile_path": self._settings.ocr_profile_path,
+                    "finder_recording_modes": self._settings.finder_recording_modes,
+                    "finder_recording_dir": self._settings.finder_recording_dir,
+                    "finder_recording_interval_s": self._settings.finder_recording_interval_s,
+                    "finder_recording_low_confidence_interval_s": (
+                        self._settings.finder_recording_low_confidence_interval_s
+                    ),
                 },
             )
 

--- a/apps/game-bridge/src/zml_game_bridge/settings.py
+++ b/apps/game-bridge/src/zml_game_bridge/settings.py
@@ -178,8 +178,39 @@ def _env_int(name: str, *, default: int) -> int:
         return default
 
 
+def _env_float(name: str, *, default: float) -> float:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
 def _default_mock_mining_interval_ms() -> int:
     return _env_int("ZML_MOCK_MINING_INTERVAL_MS", default=3_000)
+
+
+def _default_finder_recording_modes() -> str:
+    return os.getenv("ZML_FINDER_RECORDING", "").strip()
+
+
+def _default_finder_recording_dir() -> Path:
+    env_path = _env_path("ZML_FINDER_RECORDING_DIR")
+    if env_path is not None:
+        return env_path
+
+    app_data = os.getenv("LOCALAPPDATA") or os.getenv("APPDATA") or str(Path.home())
+    return Path(app_data) / APP_DATA_DIR_NAME / "ocr" / "finder-crops"
+
+
+def _default_finder_recording_interval_s() -> float:
+    return _env_float("ZML_FINDER_RECORDING_INTERVAL_S", default=10.0)
+
+
+def _default_finder_recording_low_confidence_interval_s() -> float:
+    return _env_float("ZML_FINDER_RECORDING_LOW_CONFIDENCE_INTERVAL_S", default=5.0)
 
 
 def configure_logging_from_env() -> None:
@@ -262,3 +293,9 @@ class Settings:
     ocr_enabled: bool = field(default_factory=_default_ocr_enabled)
     mock_inputs_enabled: bool = field(default_factory=_default_mock_inputs_enabled)
     mock_mining_interval_ms: int = field(default_factory=_default_mock_mining_interval_ms)
+    finder_recording_modes: str = field(default_factory=_default_finder_recording_modes)
+    finder_recording_dir: Path = field(default_factory=_default_finder_recording_dir)
+    finder_recording_interval_s: float = field(default_factory=_default_finder_recording_interval_s)
+    finder_recording_low_confidence_interval_s: float = field(
+        default_factory=_default_finder_recording_low_confidence_interval_s
+    )

--- a/apps/game-bridge/src/zml_game_bridge/testing/finder_debug.py
+++ b/apps/game-bridge/src/zml_game_bridge/testing/finder_debug.py
@@ -8,6 +8,9 @@ import cv2
 from zml_game_bridge.inputs.ocr.pipelines.mining_finder.pipeline import (
     MiningFinderPipeline,
 )
+from zml_game_bridge.inputs.ocr.pipelines.mining_finder.recording import (
+    default_finder_recording_dir,
+)
 from zml_game_bridge.inputs.ocr.pipelines.mining_finder.vision import (
     VisionFinderFeatureDetector,
 )
@@ -18,7 +21,7 @@ def main() -> int:
     parser.add_argument(
         "--root",
         type=Path,
-        default=Path("src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/finder_debug_crops"),
+        default=default_finder_recording_dir(),
         help="Folder with finder crop PNG/JPG files.",
     )
     args = parser.parse_args()

--- a/apps/game-bridge/tests/inputs/ocr/test_finder_recording.py
+++ b/apps/game-bridge/tests/inputs/ocr/test_finder_recording.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from zml_game_bridge.inputs.ocr.pipelines.mining_finder.model import (
+    FinderFeatures,
+    MiningFinderSignal,
+)
+from zml_game_bridge.inputs.ocr.pipelines.mining_finder.recording import (
+    FinderCropRecorder,
+    FinderRecordingConfig,
+    finder_recording_config_from_env,
+)
+
+
+def test_finder_crop_recorder_writes_state_change_sample(tmp_path: Path) -> None:
+    recorder = FinderCropRecorder(
+        config=FinderRecordingConfig(modes=frozenset({"state-change"}), root_dir=tmp_path),
+        roi_name="finder_test",
+    )
+    crop = np.zeros((8, 12, 4), dtype=np.uint8)
+
+    recorder.record_frame(
+        crop,
+        ts_ms=1_000,
+        features=FinderFeatures(status_kind="idle", raw_status_text="Press E to initiate survey"),
+        signals=[],
+    )
+    recorder.record_frame(
+        crop,
+        ts_ms=1_100,
+        features=FinderFeatures(status_kind="idle", raw_status_text="Press E to initiate survey"),
+        signals=[],
+    )
+
+    png_files = sorted(tmp_path.glob("*.png"))
+    json_files = sorted(tmp_path.glob("*.json"))
+    assert len(png_files) == 1
+    assert len(json_files) == 1
+
+    metadata = json.loads(json_files[0].read_text(encoding="utf-8"))
+    assert metadata["roi_name"] == "finder_test"
+    assert metadata["reasons"] == ["state-change"]
+    assert metadata["features"]["status_kind"] == "idle"
+    assert metadata["image_shape"] == [8, 12, 4]
+
+
+def test_finder_crop_recorder_writes_manual_sample_and_consumes_trigger(tmp_path: Path) -> None:
+    recorder = FinderCropRecorder(
+        config=FinderRecordingConfig(modes=frozenset({"manual"}), root_dir=tmp_path),
+        roi_name="finder_test",
+    )
+    trigger = tmp_path / "record-now.flag"
+    trigger.write_text("", encoding="utf-8")
+
+    recorder.record_frame(
+        np.zeros((2, 3, 4), dtype=np.uint8),
+        ts_ms=1_000,
+        features=FinderFeatures(status_kind="idle"),
+        signals=[],
+    )
+
+    assert not trigger.exists()
+    assert len(list(tmp_path.glob("*.png"))) == 1
+    metadata = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+    assert metadata["reasons"] == ["manual"]
+
+
+def test_finder_crop_recorder_throttles_interval_and_low_confidence(tmp_path: Path) -> None:
+    recorder = FinderCropRecorder(
+        config=FinderRecordingConfig(
+            modes=frozenset({"interval", "low-confidence"}),
+            root_dir=tmp_path,
+            interval_ms=1_000,
+            low_confidence_min_interval_ms=1_000,
+        ),
+        roi_name="finder_test",
+    )
+    crop = np.zeros((2, 3, 4), dtype=np.uint8)
+
+    for ts_ms in (1_000, 1_500, 2_000):
+        recorder.record_frame(
+            crop,
+            ts_ms=ts_ms,
+            features=FinderFeatures(status_kind=None),
+            signals=[],
+        )
+
+    assert len(list(tmp_path.glob("*.png"))) == 2
+
+
+def test_finder_recording_config_from_env_parses_modes(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("ZML_FINDER_RECORDING", "manual,state-change,interval")
+    monkeypatch.setenv("ZML_FINDER_RECORDING_DIR", str(tmp_path))
+    monkeypatch.setenv("ZML_FINDER_RECORDING_INTERVAL_S", "2.5")
+
+    config = finder_recording_config_from_env()
+
+    assert config.modes == frozenset({"manual", "state-change", "interval"})
+    assert config.root_dir == tmp_path
+    assert config.interval_ms == 2_500
+
+
+def test_finder_crop_recorder_records_signals_in_metadata(tmp_path: Path) -> None:
+    recorder = FinderCropRecorder(
+        config=FinderRecordingConfig(modes=frozenset({"state-change"}), root_dir=tmp_path),
+        roi_name="finder_test",
+    )
+
+    recorder.record_frame(
+        np.zeros((2, 3, 4), dtype=np.uint8),
+        ts_ms=1_000,
+        features=FinderFeatures(status_kind="sending_probe"),
+        signals=[MiningFinderSignal(ts_ms=1_000, kind="probe_fired", modes_mask=1)],
+    )
+
+    metadata = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+    assert metadata["signals"][0]["kind"] == "probe_fired"
+    assert metadata["signals"][0]["modes_mask"] == 1

--- a/apps/game-bridge/tests/test_dev_cli.py
+++ b/apps/game-bridge/tests/test_dev_cli.py
@@ -18,6 +18,9 @@ def test_apply_env_overrides_sets_mock_mode(monkeypatch, tmp_path: Path) -> None
     monkeypatch.delenv("ZML_CHAT_LOG_PATH", raising=False)
     monkeypatch.delenv("ZML_OCR_PROFILE_PATH", raising=False)
     monkeypatch.delenv("ZML_FINDER_DEBUG", raising=False)
+    monkeypatch.delenv("ZML_FINDER_RECORDING", raising=False)
+    monkeypatch.delenv("ZML_FINDER_RECORDING_DIR", raising=False)
+    monkeypatch.delenv("ZML_FINDER_RECORDING_INTERVAL_S", raising=False)
     monkeypatch.delenv("ZML_LOG_LEVEL", raising=False)
     monkeypatch.delenv("ZML_MOCK_MINING_INTERVAL_MS", raising=False)
 
@@ -27,6 +30,9 @@ def test_apply_env_overrides_sets_mock_mode(monkeypatch, tmp_path: Path) -> None
         chat_log_path=chat_log_path,
         ocr_profile_path=tmp_path / "ocr_profile.json",
         finder_debug=True,
+        finder_recording="state-change",
+        finder_recording_dir=tmp_path / "finder-crops",
+        finder_recording_interval_s=2.5,
         log_level="debug",
         mock_interval_ms=1_250,
     )
@@ -37,6 +43,9 @@ def test_apply_env_overrides_sets_mock_mode(monkeypatch, tmp_path: Path) -> None
     assert os.environ["ZML_CHAT_LOG_PATH"] == str(chat_log_path)
     assert os.environ["ZML_OCR_PROFILE_PATH"] == str(tmp_path / "ocr_profile.json")
     assert os.environ["ZML_FINDER_DEBUG"] == "1"
+    assert os.environ["ZML_FINDER_RECORDING"] == "state-change"
+    assert os.environ["ZML_FINDER_RECORDING_DIR"] == str(tmp_path / "finder-crops")
+    assert os.environ["ZML_FINDER_RECORDING_INTERVAL_S"] == "2.5"
     assert os.environ["ZML_LOG_LEVEL"] == "DEBUG"
     assert os.environ["ZML_MOCK_MINING_INTERVAL_MS"] == "1250"
 
@@ -56,3 +65,4 @@ def test_config_command_prints_resolved_settings(monkeypatch, tmp_path: Path) ->
     assert "mock_inputs_enabled" in result.output
     assert "ocr_enabled" in result.output
     assert "ocr_profile_path" in result.output
+    assert "finder_recording_modes" in result.output


### PR DESCRIPTION
- record finder crop PNGs with JSON metadata from the finder pipeline
- support manual, state-change, low-confidence, and interval recording modes
- expose finder recording config through env, CLI, and settings
- point finder debug tooling at the recording output directory
- document recording env vars and mark roadmap item done