### PR TITLE
Add OCR profiling summaries

### DIFF
--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -89,10 +89,10 @@
    - ~~Zapisywać crop + metadata.~~
    - ~~Tryby: manual, low-confidence, state-change, every N seconds.~~
 
-17. **Profilowanie OCR**
-   - Zmierzyć capture/crop/preprocess/ocr/parse/emit.
-   - Zakładamy, że OCR jest głównym latency cost dla drop eventu, ale najpierw mierzymy.
-   - CPU jest już niskie po zwiększeniu delayu, problemem jest raczej delay między dropem a eventem.
+17. **~~Profilowanie OCR~~**
+   - ~~Zmierzyć capture/crop/preprocess/ocr/parse/emit.~~
+   - ~~Zakładamy, że OCR jest głównym latency cost dla drop eventu, ale najpierw mierzymy.~~
+   - ~~CPU jest już niskie po zwiększeniu delayu, problemem jest raczej delay między dropem a eventem.~~
 
 18. **Compass latest-wins**
    - Max pending job = 1.
@@ -161,7 +161,7 @@
 
 15. ~~ROI config.~~
 16. ~~Finder screenshot recording.~~
-17. OCR profiling.
+17. ~~OCR profiling.~~
 18. ~~`pytesseract` -> `tesserocr`.~~
 19. Compass latest-wins.
 20. Radar/position outlier filtering.

--- a/apps/game-bridge/README.md
+++ b/apps/game-bridge/README.md
@@ -63,6 +63,8 @@ Input modes:
 - `ZML_FINDER_RECORDING_DIR`: output directory for finder crop PNG + JSON metadata.
 - `ZML_FINDER_RECORDING_INTERVAL_S`: cadence for `interval` recording mode, defaults to `10`.
 - `ZML_FINDER_RECORDING_LOW_CONFIDENCE_INTERVAL_S`: minimum cadence for low-confidence samples, defaults to `5`.
+- `ZML_OCR_PROFILING`: enable OCR timing summaries in logs.
+- `ZML_OCR_PROFILING_INTERVAL_S`: OCR profiling summary interval, defaults to `10`.
 
 For manual finder recording, enable `manual` mode and create a `record-now.flag` file in `ZML_FINDER_RECORDING_DIR`; the OCR worker consumes the flag on the next finder frame.
 

--- a/apps/game-bridge/justfile
+++ b/apps/game-bridge/justfile
@@ -16,6 +16,9 @@ mock:
 finder-debug:
     uv run python -m zml_game_bridge.dev_cli serve --mode live --finder-debug
 
+ocr-profile-record:
+    uv run python -m zml_game_bridge.dev_cli serve --mode live --ocr-profiling --ocr-profiling-interval-s 5 --finder-record manual,state-change,low-confidence,interval --finder-record-interval-s 10 --finder-record-low-confidence-interval-s 2
+
 lint-fix:
     uv run ruff check . --fix
 

--- a/apps/game-bridge/src/zml_game_bridge/dev_cli.py
+++ b/apps/game-bridge/src/zml_game_bridge/dev_cli.py
@@ -37,6 +37,8 @@ def _apply_env_overrides(
     finder_recording_dir: Path | None = None,
     finder_recording_interval_s: float | None = None,
     finder_recording_low_confidence_interval_s: float | None = None,
+    ocr_profiling: bool = False,
+    ocr_profiling_interval_s: float | None = None,
     log_level: str | None,
     mock_interval_ms: int | None,
 ) -> None:
@@ -80,6 +82,12 @@ def _apply_env_overrides(
         os.environ["ZML_FINDER_RECORDING_LOW_CONFIDENCE_INTERVAL_S"] = str(
             finder_recording_low_confidence_interval_s
         )
+    if ocr_profiling:
+        os.environ["ZML_OCR_PROFILING"] = "1"
+    if ocr_profiling_interval_s is not None:
+        if ocr_profiling_interval_s <= 0:
+            raise typer.BadParameter("OCR profiling interval must be greater than 0")
+        os.environ["ZML_OCR_PROFILING_INTERVAL_S"] = str(ocr_profiling_interval_s)
     if log_level is not None:
         os.environ["ZML_LOG_LEVEL"] = log_level.upper()
     if mock_interval_ms is not None:
@@ -116,6 +124,8 @@ def _settings_table(settings: Settings) -> Table:
         "finder_recording_low_confidence_interval_s",
         str(settings.finder_recording_low_confidence_interval_s),
     )
+    table.add_row("ocr_profiling_enabled", _format_bool(settings.ocr_profiling_enabled))
+    table.add_row("ocr_profiling_interval_s", str(settings.ocr_profiling_interval_s))
     return table
 
 
@@ -173,6 +183,14 @@ def show_config(
             help="Minimum seconds between low-confidence samples.",
         ),
     ] = None,
+    ocr_profiling: Annotated[
+        bool,
+        typer.Option("--ocr-profiling", help="Log OCR profiling summaries."),
+    ] = False,
+    ocr_profiling_interval_s: Annotated[
+        float | None,
+        typer.Option("--ocr-profiling-interval-s", help="OCR profiling summary interval."),
+    ] = None,
     log_level: Annotated[
         str | None, typer.Option("--log-level", help="Override ZML_LOG_LEVEL.")
     ] = None,
@@ -191,6 +209,8 @@ def show_config(
         finder_recording_dir=finder_recording_dir,
         finder_recording_interval_s=finder_recording_interval_s,
         finder_recording_low_confidence_interval_s=finder_recording_low_confidence_interval_s,
+        ocr_profiling=ocr_profiling,
+        ocr_profiling_interval_s=ocr_profiling_interval_s,
         log_level=log_level,
         mock_interval_ms=mock_interval_ms,
     )
@@ -243,6 +263,14 @@ def serve(
             help="Minimum seconds between low-confidence samples.",
         ),
     ] = None,
+    ocr_profiling: Annotated[
+        bool,
+        typer.Option("--ocr-profiling", help="Log OCR profiling summaries."),
+    ] = False,
+    ocr_profiling_interval_s: Annotated[
+        float | None,
+        typer.Option("--ocr-profiling-interval-s", help="OCR profiling summary interval."),
+    ] = None,
     log_level: Annotated[
         str | None, typer.Option("--log-level", help="Override ZML_LOG_LEVEL.")
     ] = None,
@@ -261,6 +289,8 @@ def serve(
         finder_recording_dir=finder_recording_dir,
         finder_recording_interval_s=finder_recording_interval_s,
         finder_recording_low_confidence_interval_s=finder_recording_low_confidence_interval_s,
+        ocr_profiling=ocr_profiling,
+        ocr_profiling_interval_s=ocr_profiling_interval_s,
         log_level=log_level,
         mock_interval_ms=mock_interval_ms,
     )

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/vision.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/mining_finder/vision.py
@@ -27,6 +27,7 @@ from zml_game_bridge.inputs.ocr.pipelines.mining_finder.parsing import (
     parse_units_text,
 )
 from zml_game_bridge.inputs.ocr.pipelines.text import clean_ocr_text
+from zml_game_bridge.inputs.ocr.profiling import OcrProfiler
 
 logger = logging.getLogger(__name__)
 
@@ -70,46 +71,51 @@ class VisionFinderFeatureDetector:
         cfg: VisionFinderFeatureConfig | None = None,
         text_engine: FinderTextEngine | None = None,
         enable_text_ocr: bool = True,
+        profiler: OcrProfiler | None = None,
     ) -> None:
         self._layout = layout or FinderPanelLayout()
         self._cfg = cfg or VisionFinderFeatureConfig()
+        self._profiler = profiler
         self._previous_radar_blue_mask: np.ndarray | None = None
         self._text_engine = self._build_text_engine(text_engine, enable_text_ocr)
 
     def detect(self, finder_roi: np.ndarray) -> FinderFeatures:
-        radar = crop_relative(finder_roi, self._layout.radar)
-        modes = crop_relative(finder_roi, self._layout.modes)
+        with self._measure("finder.detect"):
+            with self._measure("finder.crop"):
+                radar = crop_relative(finder_roi, self._layout.radar)
+                modes = crop_relative(finder_roi, self._layout.modes)
 
-        radar_active, radar_score, radar_change_score, radar_center_score = (
-            self._detect_radar_signal(radar)
-        )
-        modes_mask, mode_scores = self._detect_modes(modes)
-        text_features = self._detect_text_features(finder_roi)
+            with self._measure("finder.visual"):
+                radar_active, radar_score, radar_change_score, radar_center_score = (
+                    self._detect_radar_signal(radar)
+                )
+                modes_mask, mode_scores = self._detect_modes(modes)
+            text_features = self._detect_text_features(finder_roi)
 
-        debug = {
-            "radar_blue_score": radar_score,
-            "radar_change_score": radar_change_score,
-            "radar_center_blue_score": radar_center_score,
-            "mode_ore_score": mode_scores[0],
-            "mode_enmatter_score": mode_scores[1],
-            "mode_treasure_score": mode_scores[2],
-        }
-        return FinderFeatures(
-            radar_signal_active=radar_active,
-            modes_mask=modes_mask,
-            status_kind=text_features.status_kind,
-            raw_status_text=text_features.raw_status_text,
-            probes_per_drop=text_features.probes_per_drop,
-            ammo_per_drop=text_features.ammo_per_drop,
-            raw_units_text=text_features.raw_units_text,
-            raw_details_text=text_features.raw_details_text,
-            hit_size_label=text_features.hit_size_label,
-            hit_size_index=text_features.hit_size_index,
-            resource_name=text_features.resource_name,
-            range_m=text_features.range_m,
-            depth_m=text_features.depth_m,
-            debug=debug,
-        )
+            debug = {
+                "radar_blue_score": radar_score,
+                "radar_change_score": radar_change_score,
+                "radar_center_blue_score": radar_center_score,
+                "mode_ore_score": mode_scores[0],
+                "mode_enmatter_score": mode_scores[1],
+                "mode_treasure_score": mode_scores[2],
+            }
+            return FinderFeatures(
+                radar_signal_active=radar_active,
+                modes_mask=modes_mask,
+                status_kind=text_features.status_kind,
+                raw_status_text=text_features.raw_status_text,
+                probes_per_drop=text_features.probes_per_drop,
+                ammo_per_drop=text_features.ammo_per_drop,
+                raw_units_text=text_features.raw_units_text,
+                raw_details_text=text_features.raw_details_text,
+                hit_size_label=text_features.hit_size_label,
+                hit_size_index=text_features.hit_size_index,
+                resource_name=text_features.resource_name,
+                range_m=text_features.range_m,
+                depth_m=text_features.depth_m,
+                debug=debug,
+            )
 
     def close(self) -> None:
         self._previous_radar_blue_mask = None
@@ -167,30 +173,34 @@ class VisionFinderFeatureDetector:
             logger.debug("Finder text OCR failed for frame", exc_info=True)
             return FinderFeatures()
 
-        probes_per_drop, ammo_per_drop = parse_units_text(raw_units)
-        hit_size_label, hit_size_index = parse_hit_size(raw_status)
-        range_m, depth_m, resource_name = parse_details_text(raw_details)
+        with self._measure("finder.parse"):
+            probes_per_drop, ammo_per_drop = parse_units_text(raw_units)
+            hit_size_label, hit_size_index = parse_hit_size(raw_status)
+            range_m, depth_m, resource_name = parse_details_text(raw_details)
 
-        return FinderFeatures(
-            status_kind=classify_status(raw_status),
-            raw_status_text=clean_ocr_text(raw_status),
-            probes_per_drop=probes_per_drop,
-            ammo_per_drop=ammo_per_drop,
-            raw_units_text=clean_ocr_text(raw_units),
-            raw_details_text=clean_ocr_text(raw_details),
-            hit_size_label=hit_size_label,
-            hit_size_index=hit_size_index,
-            resource_name=resource_name,
-            range_m=range_m,
-            depth_m=depth_m,
-        )
+            return FinderFeatures(
+                status_kind=classify_status(raw_status),
+                raw_status_text=clean_ocr_text(raw_status),
+                probes_per_drop=probes_per_drop,
+                ammo_per_drop=ammo_per_drop,
+                raw_units_text=clean_ocr_text(raw_units),
+                raw_details_text=clean_ocr_text(raw_details),
+                hit_size_label=hit_size_label,
+                hit_size_index=hit_size_index,
+                resource_name=resource_name,
+                range_m=range_m,
+                depth_m=depth_m,
+            )
 
     def _recognize_relative(self, img: np.ndarray, rect: RelativeRect) -> str:
         if self._text_engine is None:
             return ""
-        roi = crop_relative(img, rect)
-        prepared = _prepare_text_ocr_image(roi, self._cfg.text_ocr_scale)
-        return self._text_engine.recognize_text(prepared, psm=6)
+        with self._measure("finder.crop"):
+            roi = crop_relative(img, rect)
+        with self._measure("finder.preprocess"):
+            prepared = _prepare_text_ocr_image(roi, self._cfg.text_ocr_scale)
+        with self._measure("finder.ocr"):
+            return self._text_engine.recognize_text(prepared, psm=6)
 
     def _detect_modes(self, modes_roi: np.ndarray) -> tuple[int, tuple[float, float, float]]:
         parts = np.array_split(modes_roi, 3, axis=1)
@@ -208,6 +218,11 @@ class VisionFinderFeatureDetector:
         if scores[2] >= self._cfg.mode_active_thresholds[2]:
             mask |= int(MiningMode.TREASURE)
         return mask, scores
+
+    def _measure(self, name: str):
+        if self._profiler is None:
+            return _NullMeasure()
+        return self._profiler.measure(name)
 
 
 def _blue_mask(img: np.ndarray) -> np.ndarray:
@@ -238,3 +253,11 @@ def _lit_icon_score(img: np.ndarray) -> float:
 
 def _prepare_text_ocr_image(img: np.ndarray, scale: int) -> np.ndarray:
     return upscale(to_gray_u8(img), scale, cv2.INTER_CUBIC)
+
+
+class _NullMeasure:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *args: object) -> None:
+        return None

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/position/pipeline.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/pipelines/position/pipeline.py
@@ -12,6 +12,7 @@ from zml_game_bridge.inputs.ocr.pipelines.position.preprocess import (
     DigitsPreprocessor,
 )
 from zml_game_bridge.inputs.ocr.pipelines.text import digits_only
+from zml_game_bridge.inputs.ocr.profiling import OcrProfiler
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,12 +29,14 @@ class PositionPipeline:
         engine: TesserDigitsEngine | None = None,
         pre_cfg: DigitsPreprocessConfig | None = None,
         cfg: PositionPipelineConfig | None = None,
+        profiler: OcrProfiler | None = None,
     ) -> None:
         self._rois = rois
         self._engine = engine or TesserDigitsEngine()
         self._pre_cfg = pre_cfg or DigitsPreprocessConfig()
         self._pre = DigitsPreprocessor(pre_cfg)
         self._cfg = cfg or PositionPipelineConfig()
+        self._profiler = profiler
 
         self._last_emitted: tuple[int, int] | None = None
 
@@ -41,46 +44,64 @@ class PositionPipeline:
         self._engine.close()
 
     def step(self, compass_roi: np.ndarray, ts_ms: int) -> OcrPosition | None:
-        lon_img = self._rois.lon.crop(compass_roi)
-        lat_img = self._rois.lat.crop(compass_roi)
+        with self._measure("position.step"):
+            with self._measure("position.crop"):
+                lon_img = self._rois.lon.crop(compass_roi)
+                lat_img = self._rois.lat.crop(compass_roi)
 
-        if lon_img is None or lat_img is None:
-            return None
-        lon = self._read_int(lon_img)
-        lat = self._read_int(lat_img)
-        # TODO range check lat/lon?
+            if lon_img is None or lat_img is None:
+                return None
+            lon = self._read_int(lon_img)
+            lat = self._read_int(lat_img)
+            # TODO range check lat/lon?
 
-        if lon is None or lat is None:
-            return None
-        if (lon, lat) == self._last_emitted:
-            return None
+            if lon is None or lat is None:
+                return None
+            if (lon, lat) == self._last_emitted:
+                return None
 
-        self._last_emitted = (lon, lat)
+            self._last_emitted = (lon, lat)
 
-        return OcrPosition(
-            ts_ms=ts_ms,
-            position=WorldPos(
-                planet_name="",  # fill later when planet OCR returns
-                x=lon,
-                y=lat,
-                z=None,
-            ),
-        )
+            return OcrPosition(
+                ts_ms=ts_ms,
+                position=WorldPos(
+                    planet_name="",  # fill later when planet OCR returns
+                    x=lon,
+                    y=lat,
+                    z=None,
+                ),
+            )
 
     def _read_int(self, img: np.ndarray) -> int | None:
-        pre = self._pre.process(img)
-        raw = self._engine.recognize_digits(pre)
+        with self._measure("position.preprocess"):
+            pre = self._pre.process(img)
+        with self._measure("position.ocr"):
+            raw = self._engine.recognize_digits(pre)
 
-        digits = digits_only(raw)
-        if not digits:
-            return None
+        with self._measure("position.parse"):
+            digits = digits_only(raw)
+            if not digits:
+                return None
 
-        try:
-            val = int(digits)
-        except ValueError:
-            return None
+            try:
+                val = int(digits)
+            except ValueError:
+                return None
 
-        if not (self._cfg.sanity_min <= val <= self._cfg.sanity_max):
-            return None
+            if not (self._cfg.sanity_min <= val <= self._cfg.sanity_max):
+                return None
 
-        return val
+            return val
+
+    def _measure(self, name: str):
+        if self._profiler is None:
+            return _NullMeasure()
+        return self._profiler.measure(name)
+
+
+class _NullMeasure:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *args: object) -> None:
+        return None

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/profiling.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/profiling.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class OcrProfilingConfig:
+    enabled: bool = False
+    interval_s: float = 10.0
+
+
+class OcrProfiler:
+    def __init__(self, *, config: OcrProfilingConfig) -> None:
+        self._config = config
+        self._lock = threading.Lock()
+        self._window_started_at = time.perf_counter()
+        self._metrics: dict[str, list[float]] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    @contextmanager
+    def measure(self, name: str) -> Generator[None]:
+        if not self.enabled:
+            yield
+            return
+
+        started_at = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.record_elapsed(name, started_at)
+
+    def record_elapsed(self, name: str, started_at: float) -> None:
+        if not self.enabled:
+            return
+        self.record(name, (time.perf_counter() - started_at) * 1000.0)
+
+    def record(self, name: str, value: float) -> None:
+        if not self.enabled:
+            return
+        with self._lock:
+            self._metrics.setdefault(name, []).append(value)
+
+    def maybe_log(self) -> None:
+        if not self.enabled:
+            return
+
+        now = time.perf_counter()
+        if now - self._window_started_at < self._config.interval_s:
+            return
+
+        with self._lock:
+            window_s = now - self._window_started_at
+            metrics = self._metrics
+            self._metrics = {}
+            self._window_started_at = now
+
+        if not metrics:
+            logger.info("ocr_profile_summary window_s=%.2f empty=true", window_s)
+            return
+
+        parts = [f"window_s={window_s:.2f}"]
+        for name in sorted(metrics):
+            values = metrics[name]
+            parts.append(_format_metric(name, values))
+        logger.info("ocr_profile_summary %s", " ".join(parts))
+
+
+def ocr_profiling_config_from_env(
+    *,
+    enabled: bool | None = None,
+    interval_s: float | None = None,
+) -> OcrProfilingConfig:
+    return OcrProfilingConfig(
+        enabled=enabled if enabled is not None else _env_bool("ZML_OCR_PROFILING", default=False),
+        interval_s=max(
+            0.1,
+            interval_s
+            if interval_s is not None
+            else _env_float("ZML_OCR_PROFILING_INTERVAL_S", default=10.0),
+        ),
+    )
+
+
+def _format_metric(name: str, values: list[float]) -> str:
+    count = len(values)
+    avg = sum(values) / count
+    maximum = max(values)
+    p95 = _percentile(values, 0.95)
+    return f"{name}_count={count} {name}_avg_ms={avg:.2f} {name}_p95_ms={p95:.2f} {name}_max_ms={maximum:.2f}"
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((len(ordered) - 1) * percentile)))
+    return ordered[index]
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_float(name: str, *, default: float) -> float:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/runner.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/runner.py
@@ -9,6 +9,8 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from ctypes import windll
 from pathlib import Path
 
+import numpy as np
+
 from zml_game_bridge.events.contracts import SignalSink
 from zml_game_bridge.inputs.ocr.capture.window_capturer import WindowCapturer
 from zml_game_bridge.inputs.ocr.config import OcrRoiProfile, load_ocr_roi_profile
@@ -32,6 +34,10 @@ from zml_game_bridge.inputs.ocr.pipelines.mining_finder.signals import (
 from zml_game_bridge.inputs.ocr.pipelines.mining_finder.vision import VisionFinderFeatureDetector
 from zml_game_bridge.inputs.ocr.pipelines.position.model import OcrPosition
 from zml_game_bridge.inputs.ocr.pipelines.position.pipeline import PositionPipeline
+from zml_game_bridge.inputs.ocr.profiling import (
+    OcrProfiler,
+    ocr_profiling_config_from_env,
+)
 
 PositionSink = Callable[[OcrPosition], None]
 logger = logging.getLogger(__name__)
@@ -48,6 +54,8 @@ def start_ocr_input(
     finder_recording_dir: Path | None = None,
     finder_recording_interval_s: float | None = None,
     finder_recording_low_confidence_interval_s: float | None = None,
+    ocr_profiling_enabled: bool | None = None,
+    ocr_profiling_interval_s: float | None = None,
     roi_profile_path: Path | None = None,
     roi_profile: OcrRoiProfile | None = None,
 ) -> None:
@@ -66,7 +74,18 @@ def start_ocr_input(
     period = 1.0 / target_hz
     next_t = time.perf_counter()
 
-    position_pipeline = PositionPipeline(roi_profile.position_rois.to_position_rois())
+    ocr_profiling_config = ocr_profiling_config_from_env(
+        enabled=ocr_profiling_enabled,
+        interval_s=ocr_profiling_interval_s,
+    )
+    profiler = OcrProfiler(config=ocr_profiling_config)
+    if profiler.enabled:
+        logger.info("ocr_profiling_enabled interval_s=%s", ocr_profiling_config.interval_s)
+
+    position_pipeline = PositionPipeline(
+        roi_profile.position_rois.to_position_rois(),
+        profiler=profiler,
+    )
     if finder_debug_logging is None:
         finder_debug_logging = _env_bool("ZML_FINDER_DEBUG", default=False)
     if finder_debug_logging:
@@ -97,7 +116,10 @@ def start_ocr_input(
         )
 
     finder_pipeline = MiningFinderPipeline(
-        detector=VisionFinderFeatureDetector(layout=roi_profile.finder_panel.to_panel_layout()),
+        detector=VisionFinderFeatureDetector(
+            layout=roi_profile.finder_panel.to_panel_layout(),
+            profiler=profiler,
+        ),
         cfg=MiningFinderPipelineConfig(debug_logging=finder_debug_logging),
         frame_observer=finder_recorder,
     )
@@ -124,11 +146,14 @@ def start_ocr_input(
             next_t += period
             tick += 1
 
+            capture_started_at = time.perf_counter()
             frame = cap.grab()
+            profiler.record_elapsed("capture", capture_started_at)
 
             ts_ms = time.time_ns() // 1_000_000
 
-            compass = roi_profile.screen_rois.compass.crop(frame)
+            with profiler.measure("position.screen_crop"):
+                compass = roi_profile.screen_rois.compass.crop(frame)
             if compass is not None:
                 pos = position_pipeline.step(compass, ts_ms)
                 if pos is not None:
@@ -142,29 +167,49 @@ def start_ocr_input(
                     logger.exception("finder_ocr_worker_crashed")
                 else:
                     if signal_sink is not None:
-                        for signal in signals:
-                            signal_sink(
-                                _to_finder_signal(
-                                    signal,
-                                    finder_position,
-                                    roi_name=roi_profile.screen_rois.finder.name,
+                        emit_started_at = time.perf_counter()
+                        try:
+                            emit_ts_ms = time.time_ns() // 1_000_000
+                            for signal in signals:
+                                latency_ms = max(0, emit_ts_ms - signal.ts_ms)
+                                profiler.record("finder.signal_latency", float(latency_ms))
+                                profiler.record(
+                                    f"finder.signal_latency.{signal.kind}",
+                                    float(latency_ms),
                                 )
-                            )
+                                signal_sink(
+                                    _to_finder_signal(
+                                        signal,
+                                        finder_position,
+                                        roi_name=roi_profile.screen_rois.finder.name,
+                                    )
+                                )
+                        finally:
+                            profiler.record_elapsed("emit.signal", emit_started_at)
                 finally:
                     finder_future = None
                     finder_position = None
 
             if tick % finder_every_n == 0 and finder_future is None:
-                finder = roi_profile.screen_rois.finder.crop(frame)
+                with profiler.measure("finder.screen_crop"):
+                    finder = roi_profile.screen_rois.finder.crop(frame)
                 if finder is not None:
                     finder_position = latest_position
-                    finder_future = finder_executor.submit(finder_pipeline.step, finder, ts_ms)
+                    finder_future = finder_executor.submit(
+                        _run_finder_step,
+                        finder_pipeline,
+                        finder,
+                        ts_ms,
+                        profiler,
+                        time.perf_counter(),
+                    )
 
             if tick % deeds_every_n == 0:
                 pass
                 # deeds = roi_profile.screen_rois.deeds.crop(frame)
                 # if deeds is not None:
                 #     deeds_pipeline.step(deeds, ts_ms)
+            profiler.maybe_log()
     except Exception:
         logger.exception("ocr_worker_crashed")
         raise
@@ -191,6 +236,21 @@ def _configure_finder_debug_logging() -> None:
     )
     logger.setLevel(logging.DEBUG)
     logging.getLogger("zml_game_bridge.inputs.ocr.pipelines.mining_finder").setLevel(logging.DEBUG)
+
+
+def _run_finder_step(
+    pipeline: MiningFinderPipeline,
+    finder_roi: np.ndarray,
+    ts_ms: int,
+    profiler: OcrProfiler,
+    submitted_at: float,
+) -> list[MiningFinderSignal]:
+    profiler.record_elapsed("finder.queue_wait", submitted_at)
+    step_started_at = time.perf_counter()
+    try:
+        return pipeline.step(finder_roi, ts_ms)
+    finally:
+        profiler.record_elapsed("finder.step", step_started_at)
 
 
 def _to_finder_signal(

--- a/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
@@ -105,7 +105,7 @@ class AppRuntime:
         logger.info(
             "app_started db_path=%s chat_log_path=%s mining_resource_catalog_path=%s "
             "mining_tools_path=%s ocr_profile_path=%s ocr_enabled=%s mock_inputs_enabled=%s "
-            "finder_recording_modes=%s",
+            "finder_recording_modes=%s ocr_profiling_enabled=%s",
             self._settings.db_path,
             self._settings.chat_log_path,
             self._settings.mining_resource_catalog_path,
@@ -114,6 +114,7 @@ class AppRuntime:
             self._settings.ocr_enabled,
             self._settings.mock_inputs_enabled,
             self._settings.finder_recording_modes,
+            self._settings.ocr_profiling_enabled,
         )
 
         self._supervisor.start_thread(
@@ -161,6 +162,8 @@ class AppRuntime:
                     "finder_recording_low_confidence_interval_s": (
                         self._settings.finder_recording_low_confidence_interval_s
                     ),
+                    "ocr_profiling_enabled": self._settings.ocr_profiling_enabled,
+                    "ocr_profiling_interval_s": self._settings.ocr_profiling_interval_s,
                 },
             )
 

--- a/apps/game-bridge/src/zml_game_bridge/settings.py
+++ b/apps/game-bridge/src/zml_game_bridge/settings.py
@@ -213,6 +213,14 @@ def _default_finder_recording_low_confidence_interval_s() -> float:
     return _env_float("ZML_FINDER_RECORDING_LOW_CONFIDENCE_INTERVAL_S", default=5.0)
 
 
+def _default_ocr_profiling_enabled() -> bool:
+    return _env_bool("ZML_OCR_PROFILING", default=False)
+
+
+def _default_ocr_profiling_interval_s() -> float:
+    return _env_float("ZML_OCR_PROFILING_INTERVAL_S", default=10.0)
+
+
 def configure_logging_from_env() -> None:
     logging_level = os.getenv("ZML_LOG_LEVEL", "INFO").strip().upper()
     log_format = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
@@ -299,3 +307,5 @@ class Settings:
     finder_recording_low_confidence_interval_s: float = field(
         default_factory=_default_finder_recording_low_confidence_interval_s
     )
+    ocr_profiling_enabled: bool = field(default_factory=_default_ocr_profiling_enabled)
+    ocr_profiling_interval_s: float = field(default_factory=_default_ocr_profiling_interval_s)

--- a/apps/game-bridge/tests/inputs/ocr/test_ocr_profiling.py
+++ b/apps/game-bridge/tests/inputs/ocr/test_ocr_profiling.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+import time
+
+from zml_game_bridge.inputs.ocr.profiling import (
+    OcrProfiler,
+    OcrProfilingConfig,
+    ocr_profiling_config_from_env,
+)
+
+
+def test_ocr_profiler_logs_window_summary(caplog) -> None:
+    profiler = OcrProfiler(config=OcrProfilingConfig(enabled=True, interval_s=0.1))
+    profiler.record("finder.ocr", 10.0)
+    profiler.record("finder.ocr", 30.0)
+
+    time.sleep(0.11)
+    with caplog.at_level(logging.INFO):
+        profiler.maybe_log()
+
+    assert "ocr_profile_summary" in caplog.text
+    assert "finder.ocr_count=2" in caplog.text
+    assert "finder.ocr_avg_ms=20.00" in caplog.text
+
+
+def test_ocr_profiler_ignores_metrics_when_disabled(caplog) -> None:
+    profiler = OcrProfiler(config=OcrProfilingConfig(enabled=False, interval_s=0.1))
+    profiler.record("finder.ocr", 10.0)
+
+    time.sleep(0.11)
+    with caplog.at_level(logging.INFO):
+        profiler.maybe_log()
+
+    assert "ocr_profile_summary" not in caplog.text
+
+
+def test_ocr_profiling_config_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("ZML_OCR_PROFILING", "1")
+    monkeypatch.setenv("ZML_OCR_PROFILING_INTERVAL_S", "2.5")
+
+    config = ocr_profiling_config_from_env()
+
+    assert config.enabled is True
+    assert config.interval_s == 2.5

--- a/apps/game-bridge/tests/test_dev_cli.py
+++ b/apps/game-bridge/tests/test_dev_cli.py
@@ -21,6 +21,8 @@ def test_apply_env_overrides_sets_mock_mode(monkeypatch, tmp_path: Path) -> None
     monkeypatch.delenv("ZML_FINDER_RECORDING", raising=False)
     monkeypatch.delenv("ZML_FINDER_RECORDING_DIR", raising=False)
     monkeypatch.delenv("ZML_FINDER_RECORDING_INTERVAL_S", raising=False)
+    monkeypatch.delenv("ZML_OCR_PROFILING", raising=False)
+    monkeypatch.delenv("ZML_OCR_PROFILING_INTERVAL_S", raising=False)
     monkeypatch.delenv("ZML_LOG_LEVEL", raising=False)
     monkeypatch.delenv("ZML_MOCK_MINING_INTERVAL_MS", raising=False)
 
@@ -33,6 +35,8 @@ def test_apply_env_overrides_sets_mock_mode(monkeypatch, tmp_path: Path) -> None
         finder_recording="state-change",
         finder_recording_dir=tmp_path / "finder-crops",
         finder_recording_interval_s=2.5,
+        ocr_profiling=True,
+        ocr_profiling_interval_s=1.5,
         log_level="debug",
         mock_interval_ms=1_250,
     )
@@ -46,6 +50,8 @@ def test_apply_env_overrides_sets_mock_mode(monkeypatch, tmp_path: Path) -> None
     assert os.environ["ZML_FINDER_RECORDING"] == "state-change"
     assert os.environ["ZML_FINDER_RECORDING_DIR"] == str(tmp_path / "finder-crops")
     assert os.environ["ZML_FINDER_RECORDING_INTERVAL_S"] == "2.5"
+    assert os.environ["ZML_OCR_PROFILING"] == "1"
+    assert os.environ["ZML_OCR_PROFILING_INTERVAL_S"] == "1.5"
     assert os.environ["ZML_LOG_LEVEL"] == "DEBUG"
     assert os.environ["ZML_MOCK_MINING_INTERVAL_MS"] == "1250"
 
@@ -66,3 +72,4 @@ def test_config_command_prints_resolved_settings(monkeypatch, tmp_path: Path) ->
     assert "ocr_enabled" in result.output
     assert "ocr_profile_path" in result.output
     assert "finder_recording_modes" in result.output
+    assert "ocr_profiling_enabled" in result.output


### PR DESCRIPTION
- add optional runtime OCR profiler with windowed timing summaries
- measure capture, crop, preprocess, OCR, parse, finder queue wait, emit, and signal latency
- expose profiling through env, settings, and dev CLI
- document profiling env vars and mark roadmap item done
- add focused profiler tests