### PR TITLE
feat: manage backend lifecycle from Electron

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       build_name:
-        description: Build name
-        required: true
+        description: Artifact name suffix
+        required: false
         default: snapshot
   push:
     tags:
@@ -13,10 +13,10 @@ on:
       - v*
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
-  group: package-windows
+  group: package-windows-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -25,24 +25,33 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8
-        with:
-          enable-cache: true
+      - name: Validate release tag version
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: pwsh
+        run: |
+          $package = Get-Content apps/electron-ui/package.json | ConvertFrom-Json
+          $expectedTag = "v$($package.version)"
+          if ($env:GITHUB_REF_NAME -ne $expectedTag) {
+            throw "Release tag $env:GITHUB_REF_NAME does not match desktop version $expectedTag"
+          }
 
-      - name: Install Python
+      - name: Set up bridge
+        uses: ./.github/actions/setup-bridge
+
+      - name: Verify bridge
         working-directory: apps/game-bridge
-        run: uv python install
+        run: just verify
 
-      - name: Install backend dependencies
+      - name: Package bridge
         working-directory: apps/game-bridge
-        run: uv sync --locked --all-extras --dev
+        run: just package
 
-      - name: Build backend executable
+      - name: Smoke test bridge executable
         working-directory: apps/game-bridge
-        run: uv run pyinstaller --noconfirm --onedir --name zml-game-bridge src/zml_game_bridge/main.py
+        run: .\dist\zml-game-bridge\zml-game-bridge.exe config
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -57,28 +66,45 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build shared contracts
-        run: pnpm --filter ./packages/shared build
+      - name: Stage backend in Electron resources
+        run: pnpm backend:stage
 
-      - name: Build electron-ui
-        run: pnpm --filter ./apps/electron-ui build
+      - name: Package Electron application
+        run: pnpm frontend:package
 
-      - name: Copy backend into Electron resources
+      - name: Smoke test bundled backend
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path apps/electron-ui/resources/backend | Out-Null
-          Copy-Item -Recurse -Force apps/game-bridge/dist/zml-game-bridge/* apps/electron-ui/resources/backend/
+          $backend = Get-ChildItem apps/electron-ui/release -Recurse -Filter zml-game-bridge.exe |
+            Where-Object { $_.FullName -match 'win-unpacked[\\/]+resources[\\/]+backend' } |
+            Select-Object -First 1
+          if ($null -eq $backend) {
+            throw "Bundled backend executable was not found in win-unpacked resources"
+          }
+          & $backend.FullName config
 
-      - name: Package Electron app
-        run: pnpm --filter ./apps/electron-ui electron:build
+      - name: Verify installer artifact
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem apps/electron-ui/release -Recurse -Filter 'Z-Mining-Log-Windows-*-Setup.exe' |
+            Select-Object -First 1
+          if ($null -eq $installer) {
+            throw "Windows installer was not produced"
+          }
+          Write-Host "Installer: $($installer.FullName)"
 
-      - name: Upload packaged app
-        uses: actions/upload-artifact@v5
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v6
         with:
-          name: zml-windows-${{ github.event.inputs.build_name || github.ref_name }}
-          path: |
-            apps/electron-ui/dist-electron
-            apps/electron-ui/release
-            apps/electron-ui/dist
-          if-no-files-found: warn
+          name: z-mining-log-windows-${{ github.event.inputs.build_name || github.ref_name }}
+          path: apps/electron-ui/release/**/Z-Mining-Log-Windows-*-Setup.exe
+          if-no-files-found: error
           retention-days: 14
+
+      - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: apps/electron-ui/release/**/Z-Mining-Log-Windows-*-Setup.exe

--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,7 @@ __marimo__/
 apps/game-bridge/build/
 apps/game-bridge/dist/
 apps/game-bridge/*.spec
+apps/electron-ui/resources/backend/
 
 # Python bridge local pytest/cache artifacts
 apps/game-bridge/.pytest-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,12 @@ The backend has three important flows:
    - runtime command through the input queue when it changes mining state
    - durable events through the DB writer when persistence is needed
 
+4. Desktop process lifecycle:
+   - Electron starts the default local backend from `.venv` in development
+   - packaged Electron starts `resources/backend/zml-game-bridge.exe`
+   - backend shutdown travels through the parent stdin pipe and FastAPI lifespan
+   - explicit/custom backends remain externally owned
+
 See `docs/architecture.md` for details.
 
 ## Core Naming Rules

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Local-first desktop mining assistant for **Entropia Universe**.
 
 Z Mining Log tracks mining activity by combining OCR, chat log parsing, a Python/FastAPI backend, SQLite persistence, and an Electron/React map UI. The goal is to turn noisy in-game signals into reliable drop, claim, loot, run, and position data without sending gameplay data to an external service.
 
-> Status: active work-in-progress prototype. Core backend and UI flows are working, but the app is not packaged as a public release yet.
+> Status: active work-in-progress prototype. Core backend/UI flows work and a Windows installer
+> pipeline is available; signing, application icon, and public release polish are still pending.
 
 ---
 
@@ -65,6 +66,8 @@ The main challenge is not just rendering a map. The harder part is coordinating 
 - WebSocket stream for high-frequency position updates.
 - Shared TypeScript DTO package for Electron main, renderer, and backend contracts.
 - Mock mining input for development without the game running.
+- Electron-managed Python backend lifecycle with bounded crash restart and graceful shutdown.
+- Windows NSIS packaging with the Python bridge bundled into one installer.
 
 ---
 
@@ -234,6 +237,34 @@ docs/
 AGENTS.md           Agent/developer handoff
 README.md           Main project overview
 ```
+
+---
+
+## Development And Packaging
+
+After installing Python and pnpm dependencies, start the desktop app from the repository root:
+
+```bash
+pnpm dev
+```
+
+Electron starts the backend automatically from `apps/game-bridge/.venv`. If Entropia is not
+open yet, the OCR worker remains alive in `degraded` state and checks again automatically.
+
+For a separately managed backend, set `ZML_MANAGE_BACKEND=0` before starting Electron. Setting
+an explicit `ZML_BACKEND_URL` also disables local process ownership unless management is
+explicitly re-enabled.
+
+Build the complete Windows package with:
+
+```bash
+pnpm package
+```
+
+This packages the Python bridge, stages it under Electron resources, and creates an NSIS
+installer under `apps/electron-ui/release/<version>/`. The GitHub Actions Windows packaging
+workflow uploads installers for manual/snapshot builds. A tag matching the desktop version,
+for example `v0.1.0`, additionally creates a GitHub Release.
 
 ---
 

--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -16,11 +16,15 @@ Legend:
 
 ## P0 - Correctness / Lifecycle
 
-1. **Electron/backend graceful lifecycle**
-   - No orphan `game-bridge` process after closing Electron.
-   - No hanging DB connection or `Waiting for background tasks to complete`.
-   - Electron should orchestrate backend start, restart, and shutdown cleanly.
-   - Surface backend health/error state clearly in UI.
+1. ~~**Electron/backend graceful lifecycle**~~
+   - Done 2026-08-09.
+   - Electron starts the local bridge in development and from bundled resources in production.
+   - An already-running/custom backend is not adopted or terminated.
+   - Unexpected exits use bounded automatic restart; app shutdown asks Uvicorn to exit through
+     the parent pipe so FastAPI lifespan can stop workers and the SQLite writer.
+   - Missing/lost Entropia window keeps OCR alive in `degraded` state and retries automatically.
+   - Windows packaging produces one installer containing Electron and the Python bridge; `v*`
+     tags publish it through GitHub Releases.
 
 2. ~~**Merged finder/chat claim result**~~
    - Done 2026-06-02.

--- a/apps/electron-ui/electron-builder.json5
+++ b/apps/electron-ui/electron-builder.json5
@@ -1,15 +1,27 @@
 // @see - https://www.electron.build/configuration/configuration
 {
   "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
-  "appId": "YourAppID",
+  "appId": "com.zmininglog.desktop",
   "asar": true,
-  "productName": "YourAppName",
+  // Required production code is pure JS. `ws` native peer addons are optional
+  // and use their JS fallback; revisit this if a required native module is added.
+  "npmRebuild": false,
+  "productName": "Z Mining Log",
   "directories": {
     "output": "release/${version}"
   },
   "files": [
     "dist",
     "dist-electron"
+  ],
+  "extraResources": [
+    {
+      "from": "resources/backend",
+      "to": "backend",
+      "filter": [
+        "**/*"
+      ]
+    }
   ],
   "mac": {
     "target": [
@@ -26,7 +38,7 @@
         ]
       }
     ],
-    "artifactName": "${productName}-Windows-${version}-Setup.${ext}"
+    "artifactName": "Z-Mining-Log-Windows-${version}-Setup.${ext}"
   },
   "nsis": {
     "oneClick": false,

--- a/apps/electron-ui/electron/backend/backendProcessManager.test.ts
+++ b/apps/electron-ui/electron/backend/backendProcessManager.test.ts
@@ -1,0 +1,86 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  createBackendLaunchSpec,
+  shouldManageBackend,
+} from "./backendProcessManager.ts";
+
+describe("createBackendLaunchSpec", () => {
+  it("uses the bundled executable in a packaged app", () => {
+    const launch = createBackendLaunchSpec({
+      isPackaged: true,
+      resourcesPath: path.join("C:", "Z Mining Log", "resources"),
+      appRoot: path.join("C:", "repo", "apps", "electron-ui"),
+    });
+
+    expect(launch.command).toBe(
+      path.join("C:", "Z Mining Log", "resources", "backend", "zml-game-bridge.exe"),
+    );
+    expect(launch.args).toEqual(["serve", "--mode", "live"]);
+  });
+
+  it("uses the game bridge virtualenv in development", () => {
+    const appRoot = path.join("C:", "repo", "apps", "electron-ui");
+    const launch = createBackendLaunchSpec({
+      isPackaged: false,
+      resourcesPath: path.join("C:", "unused"),
+      appRoot,
+    });
+
+    expect(launch.cwd).toBe(path.resolve(appRoot, "..", "game-bridge"));
+    expect(launch.args).toEqual([
+      "-m",
+      "zml_game_bridge.dev_cli",
+      "serve",
+      "--mode",
+      "live",
+    ]);
+  });
+});
+
+describe("shouldManageBackend", () => {
+  it("manages the default local backend", () => {
+    expect(
+      shouldManageBackend({
+        mocksEnabled: false,
+        backendUrlOverridden: false,
+        explicitValue: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not manage mocks or an explicitly configured backend", () => {
+    expect(
+      shouldManageBackend({
+        mocksEnabled: true,
+        backendUrlOverridden: false,
+        explicitValue: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      shouldManageBackend({
+        mocksEnabled: false,
+        backendUrlOverridden: true,
+        explicitValue: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows an explicit lifecycle override", () => {
+    expect(
+      shouldManageBackend({
+        mocksEnabled: false,
+        backendUrlOverridden: true,
+        explicitValue: "true",
+      }),
+    ).toBe(true);
+    expect(
+      shouldManageBackend({
+        mocksEnabled: false,
+        backendUrlOverridden: false,
+        explicitValue: "false",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/electron-ui/electron/backend/backendProcessManager.ts
+++ b/apps/electron-ui/electron/backend/backendProcessManager.ts
@@ -1,0 +1,281 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+export type BackendLaunchSpec = {
+  command: string;
+  args: string[];
+  cwd: string;
+};
+
+type BackendProcessManagerOptions = {
+  baseUrl: string;
+  launch: BackendLaunchSpec;
+  startupTimeoutMs?: number;
+  shutdownTimeoutMs?: number;
+  maxRestartsPerMinute?: number;
+};
+
+const HEALTH_POLL_INTERVAL_MS = 250;
+const HEALTH_REQUEST_TIMEOUT_MS = 750;
+const RESTART_WINDOW_MS = 60_000;
+
+export class BackendProcessManager {
+  private readonly baseUrl: string;
+  private readonly launch: BackendLaunchSpec;
+  private readonly startupTimeoutMs: number;
+  private readonly shutdownTimeoutMs: number;
+  private readonly maxRestartsPerMinute: number;
+
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private restartTimer: NodeJS.Timeout | null = null;
+  private restartTimestamps: number[] = [];
+  private stopping = false;
+  private usingExternalBackend = false;
+
+  constructor({
+    baseUrl,
+    launch,
+    startupTimeoutMs = 60_000,
+    shutdownTimeoutMs = 30_000,
+    maxRestartsPerMinute = 3,
+  }: BackendProcessManagerOptions) {
+    this.baseUrl = baseUrl;
+    this.launch = launch;
+    this.startupTimeoutMs = startupTimeoutMs;
+    this.shutdownTimeoutMs = shutdownTimeoutMs;
+    this.maxRestartsPerMinute = maxRestartsPerMinute;
+  }
+
+  async start(): Promise<boolean> {
+    if (this.child !== null) return this.waitUntilReady(this.startupTimeoutMs);
+
+    this.stopping = false;
+    this.usingExternalBackend = false;
+    if (await checkBackendHealth(this.baseUrl)) {
+      this.usingExternalBackend = true;
+      console.info("[backend] using already running backend");
+      return true;
+    }
+    if (this.stopping) return false;
+
+    this.spawnBackend();
+    const ready = await this.waitUntilReady(this.startupTimeoutMs);
+    if (!ready) {
+      console.error(`[backend] health check timed out after ${this.startupTimeoutMs}ms`);
+    }
+    return ready;
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    this.clearRestartTimer();
+
+    if (this.usingExternalBackend) {
+      this.usingExternalBackend = false;
+      return;
+    }
+
+    const child = this.child;
+    if (child === null) return;
+
+    if (child.stdin.writable) {
+      try {
+        child.stdin.write("shutdown\n");
+      } catch (error) {
+        console.warn("[backend] failed to send graceful shutdown command", error);
+      }
+    }
+    const stoppedGracefully = await waitForChildClose(child, this.shutdownTimeoutMs);
+    if (!stoppedGracefully && this.child === child) {
+      console.warn("[backend] graceful shutdown timed out; terminating process");
+      child.kill();
+      await waitForChildClose(child, 1_000);
+    }
+    if (this.child === child) this.child = null;
+  }
+
+  private spawnBackend(): void {
+    if (!existsSync(this.launch.command)) {
+      throw new Error(`Backend executable not found: ${this.launch.command}`);
+    }
+
+    console.info(
+      `[backend] starting ${this.launch.command} ${this.launch.args.join(" ")}`,
+    );
+    const child = spawn(this.launch.command, this.launch.args, {
+      cwd: this.launch.cwd,
+      env: {
+        ...process.env,
+        PYTHONUNBUFFERED: "1",
+        ZML_PARENT_MANAGED: "1",
+      },
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    this.child = child;
+
+    forwardBackendOutput(child);
+    child.once("error", (error) => {
+      console.error("[backend] process error", error);
+    });
+    child.stdin.on("error", (error) => {
+      if (!this.stopping) console.error("[backend] stdin error", error);
+    });
+    child.once("close", (code, signal) => {
+      if (this.child !== child) return;
+      this.child = null;
+      if (this.stopping) return;
+
+      console.error(
+        `[backend] exited unexpectedly code=${String(code)} signal=${String(signal)}`,
+      );
+      this.scheduleRestart();
+    });
+  }
+
+  private scheduleRestart(): void {
+    if (this.stopping || this.restartTimer !== null) return;
+
+    const now = Date.now();
+    this.restartTimestamps = this.restartTimestamps.filter(
+      (timestamp) => now - timestamp < RESTART_WINDOW_MS,
+    );
+    if (this.restartTimestamps.length >= this.maxRestartsPerMinute) {
+      console.error("[backend] restart limit reached; leaving backend offline");
+      return;
+    }
+
+    this.restartTimestamps.push(now);
+    const restartNumber = this.restartTimestamps.length;
+    const delayMs = Math.min(4_000, 500 * 2 ** (restartNumber - 1));
+    console.warn(`[backend] restarting in ${delayMs}ms`);
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      if (this.stopping) return;
+      try {
+        this.spawnBackend();
+      } catch (error) {
+        console.error("[backend] restart failed", error);
+        this.scheduleRestart();
+      }
+    }, delayMs);
+  }
+
+  private async waitUntilReady(timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (!this.stopping && Date.now() < deadline) {
+      if (await checkBackendHealth(this.baseUrl)) {
+        console.info("[backend] health check passed");
+        return true;
+      }
+      await delay(HEALTH_POLL_INTERVAL_MS);
+    }
+    return false;
+  }
+
+  private clearRestartTimer(): void {
+    if (this.restartTimer !== null) clearTimeout(this.restartTimer);
+    this.restartTimer = null;
+  }
+}
+
+export function createBackendLaunchSpec({
+  isPackaged,
+  resourcesPath,
+  appRoot,
+}: {
+  isPackaged: boolean;
+  resourcesPath: string;
+  appRoot: string;
+}): BackendLaunchSpec {
+  if (isPackaged) {
+    const backendDir = path.join(resourcesPath, "backend");
+    return {
+      command: path.join(backendDir, "zml-game-bridge.exe"),
+      args: ["serve", "--mode", "live"],
+      cwd: backendDir,
+    };
+  }
+
+  const backendDir = path.resolve(appRoot, "..", "game-bridge");
+  const pythonExecutable =
+    process.platform === "win32"
+      ? path.join(backendDir, ".venv", "Scripts", "python.exe")
+      : path.join(backendDir, ".venv", "bin", "python");
+  return {
+    command: pythonExecutable,
+    args: ["-m", "zml_game_bridge.dev_cli", "serve", "--mode", "live"],
+    cwd: backendDir,
+  };
+}
+
+export function shouldManageBackend({
+  mocksEnabled,
+  backendUrlOverridden,
+  explicitValue,
+}: {
+  mocksEnabled: boolean;
+  backendUrlOverridden: boolean;
+  explicitValue: string | undefined;
+}): boolean {
+  if (mocksEnabled) return false;
+  if (explicitValue !== undefined) {
+    return ["1", "true", "yes", "on"].includes(explicitValue.trim().toLowerCase());
+  }
+  return !backendUrlOverridden;
+}
+
+async function checkBackendHealth(baseUrl: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), HEALTH_REQUEST_TIMEOUT_MS);
+  try {
+    const url = new URL("/health", normalizeBaseUrl(baseUrl));
+    const response = await fetch(url, { signal: controller.signal });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(baseUrl)) return baseUrl;
+  return `http://${baseUrl}`;
+}
+
+function forwardBackendOutput(child: ChildProcessWithoutNullStreams): void {
+  child.stdout.on("data", (chunk: Buffer) => {
+    const message = chunk.toString("utf8").trimEnd();
+    if (message) console.info(`[backend] ${message}`);
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    const message = chunk.toString("utf8").trimEnd();
+    if (message) console.error(`[backend] ${message}`);
+  });
+}
+
+function waitForChildClose(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    const onClose = () => {
+      clearTimeout(timeout);
+      resolve(true);
+    };
+    const timeout = setTimeout(() => {
+      child.removeListener("close", onClose);
+      resolve(false);
+    }, timeoutMs);
+    child.once("close", onClose);
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/electron-ui/electron/main.ts
+++ b/apps/electron-ui/electron/main.ts
@@ -24,6 +24,11 @@ import { pushPosition } from "./ipc/pushPosition.ts";
 import { pushStatePatch } from "./ipc/pushStatePatch.ts";
 import { applyMiningEvent, replaceMiningClaims, replaceMiningDrops } from "./mining/miningDropsState.ts";
 import {
+  BackendProcessManager,
+  createBackendLaunchSpec,
+  shouldManageBackend,
+} from "./backend/backendProcessManager.ts";
+import {
   applyMiningLootEvent,
   replaceMiningLoot,
   replaceMiningLootTotals,
@@ -43,6 +48,19 @@ process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL ? path.join(process.env.APP_ROOT, 
 
 const BACKEND_URL = process.env.ZML_BACKEND_URL ?? "http://127.0.0.1:17171";
 const UI_MOCKS_ENABLED = isUiMockMode();
+const MANAGE_BACKEND = shouldManageBackend({
+  mocksEnabled: UI_MOCKS_ENABLED,
+  backendUrlOverridden: process.env.ZML_BACKEND_URL !== undefined,
+  explicitValue: process.env.ZML_MANAGE_BACKEND,
+});
+const backendProcessManager = new BackendProcessManager({
+  baseUrl: BACKEND_URL,
+  launch: createBackendLaunchSpec({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    appRoot: process.env.APP_ROOT,
+  }),
+});
 const agentRestClient = UI_MOCKS_ENABLED
   ? new MockAgentRestClient()
   : new AgentRestClient({ baseUrl: BACKEND_URL });
@@ -53,6 +71,8 @@ let overlayWin: BrowserWindow | null = null;
 let stopPositionStream: StopPositionSource | null = null;
 let stopEventStream: StopAgentEventStream | null = null;
 let appIsQuitting = false;
+let backendShutdownComplete = false;
+let backendShutdownPromise: Promise<void> | null = null;
 
 function handlePositionStatus(status: PositionSourceStatus, err?: string) {
   runtime.agent.status = status;
@@ -271,9 +291,33 @@ async function createWindows() {
   void refreshMiningToolSnapshot();
 }
 
-app.on("before-quit", () => {
+async function startApplication(): Promise<void> {
+  const backendStartup = MANAGE_BACKEND
+    ? backendProcessManager.start().catch((error: unknown) => {
+        console.error("[backend] failed to start managed backend", error);
+        return false;
+      })
+    : Promise.resolve(false);
+  await createWindows();
+  await backendStartup;
+}
+
+app.on("before-quit", (event) => {
+  if (!MANAGE_BACKEND || backendShutdownComplete) {
+    appIsQuitting = true;
+    stopPositionStreamIfRunning();
+    return;
+  }
+
+  event.preventDefault();
   appIsQuitting = true;
   stopPositionStreamIfRunning();
+  if (backendShutdownPromise !== null) return;
+
+  backendShutdownPromise = backendProcessManager.stop().finally(() => {
+    backendShutdownComplete = true;
+    app.quit();
+  });
 });
 
 // Quit when all windows are closed, except on macOS. There, it's common
@@ -296,4 +340,7 @@ app.on('activate', () => {
   }
 })
 
-app.whenReady().then(createWindows)
+void app.whenReady().then(startApplication).catch((error: unknown) => {
+  console.error("Application startup failed", error);
+  app.quit();
+})

--- a/apps/electron-ui/package.json
+++ b/apps/electron-ui/package.json
@@ -1,20 +1,18 @@
 {
   "name": "@zml/electron-ui",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "description": "Local-first Entropia Universe mining tracker",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "dev:mocks": "node ./scripts/dev-with-mocks.mjs",
-
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
-
     "build:web": "vite build",
     "build:desktop": "tsc -p tsconfig.json",
     "build": "pnpm build:web && pnpm build:desktop",
-
     "package": "pnpm build && electron-builder"
   },
   "dependencies": {
@@ -24,10 +22,8 @@
     "@deck.gl/react": "^9.3.2",
     "@types/ws": "^8.18.1",
     "@zml/shared": "workspace:*",
-    "bufferutil": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "utf-8-validate": "^6.0.6",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/apps/electron-ui/src/widgets/map/layers/mapTileLayer.ts
+++ b/apps/electron-ui/src/widgets/map/layers/mapTileLayer.ts
@@ -7,6 +7,7 @@ import {
   type PlanetId,
   type PlanetMapConfig,
 } from "@zml/shared";
+import { buildMapTileUrl } from "../mapTileUrl";
 
 function getAvailableTileKeys(planet: PlanetMapConfig): Set<string> {
   if (planet.availableTiles) {
@@ -37,11 +38,6 @@ export function createMapTileLayer(planetId: PlanetId): TileLayer<string | null>
   const planet = MAP_CONFIG.planets[planetId];
   const { width, height } = getMapSizePx(MAP_CONFIG, planetId);
   const availableTileKeys = getAvailableTileKeys(planet);
-  const base = encodeURI(
-    planet.tileFolder.startsWith("/")
-      ? planet.tileFolder
-      : `/${planet.tileFolder}`,
-  );
 
   return new TileLayer<string | null>({
     id: `${planetId}-map-tiles`,
@@ -64,7 +60,12 @@ export function createMapTileLayer(planetId: PlanetId): TileLayer<string | null>
         return null;
       }
 
-      return `${base}/x${index.x}_y${index.y}.webp`;
+      return buildMapTileUrl(
+        import.meta.env.BASE_URL,
+        planet.tileFolder,
+        index.x,
+        index.y,
+      );
     },
     onTileError: () => undefined,
     renderSubLayers: ({ data, tile }) => {

--- a/apps/electron-ui/src/widgets/map/mapTileUrl.test.ts
+++ b/apps/electron-ui/src/widgets/map/mapTileUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMapTileUrl } from "./mapTileUrl";
+
+describe("buildMapTileUrl", () => {
+  it("uses the Vite public root during development", () => {
+    expect(buildMapTileUrl("/", "Maps/Calypso", 2, 4)).toBe(
+      "/Maps/Calypso/x2_y4.webp",
+    );
+  });
+
+  it("keeps assets relative to the packaged renderer document", () => {
+    expect(buildMapTileUrl("./", "Maps/Next Island", 0, 1)).toBe(
+      "./Maps/Next%20Island/x0_y1.webp",
+    );
+  });
+
+  it("normalizes slashes around the configured tile folder", () => {
+    expect(buildMapTileUrl(".", "/Maps/Calypso/", 8, 0)).toBe(
+      "./Maps/Calypso/x8_y0.webp",
+    );
+  });
+});

--- a/apps/electron-ui/src/widgets/map/mapTileUrl.ts
+++ b/apps/electron-ui/src/widgets/map/mapTileUrl.ts
@@ -1,0 +1,11 @@
+export function buildMapTileUrl(
+  appBaseUrl: string,
+  tileFolder: string,
+  x: number,
+  y: number,
+): string {
+  const baseUrl = appBaseUrl.endsWith("/") ? appBaseUrl : `${appBaseUrl}/`;
+  const folder = tileFolder.replace(/^\/+|\/+$/g, "");
+
+  return encodeURI(`${baseUrl}${folder}/x${x}_y${y}.webp`);
+}

--- a/apps/game-bridge/src/zml_game_bridge/api/routes/events.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/routes/events.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncIterator
+from contextlib import suppress
 from typing import Annotated
 
 from fastapi import APIRouter, Query, Request
@@ -61,19 +62,26 @@ async def events_stream(request: Request, runtime: RuntimeDep) -> StreamingRespo
     client = hub.register()
 
     async def gen() -> AsyncIterator[str]:
+        event_task = asyncio.create_task(client.queue.get())
+        shutdown_task = asyncio.create_task(runtime.shutdown_signal.wait())
         try:
             yield ": connected\n\n"
 
             while True:
-                if await request.is_disconnected():
+                done, _ = await asyncio.wait(
+                    (event_task, shutdown_task),
+                    timeout=15.0,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if shutdown_task in done:
+                    await shutdown_task
                     break
-
-                try:
-                    env: EventEnvelope = await asyncio.wait_for(client.queue.get(), timeout=15.0)
-                except TimeoutError:
+                if event_task not in done:
                     yield ": keep-alive\n\n"
                     continue
 
+                env: EventEnvelope = event_task.result()
+                event_task = asyncio.create_task(client.queue.get())
                 dto = _to_dto(env)
                 data = dto.model_dump_json(exclude={"event_id", "event_type"})
 
@@ -86,6 +94,12 @@ async def events_stream(request: Request, runtime: RuntimeDep) -> StreamingRespo
                 yield f"event: {dto.event_type}\n"
                 yield f"data: {data}\n\n"
         finally:
+            for task in (event_task, shutdown_task):
+                if not task.done():
+                    task.cancel()
+            for task in (event_task, shutdown_task):
+                with suppress(asyncio.CancelledError):
+                    await task
             hub.unregister(client.client_id)
 
     headers = {

--- a/apps/game-bridge/src/zml_game_bridge/api/routes/ws_position.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/routes/ws_position.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import cast
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -20,12 +21,27 @@ async def ws_position(ws: WebSocket) -> None:
     hub = runtime.position_hub  # property -> never None
 
     q, last = hub.subscribe()
+    position_task = asyncio.create_task(q.get())
+    disconnect_task = asyncio.create_task(_wait_for_disconnect(ws))
+    shutdown_task = asyncio.create_task(runtime.shutdown_signal.wait())
     try:
         if last is not None:
             await ws.send_json(PositionDto.from_domain(last).model_dump())
 
         while True:
-            pos = await q.get()
+            done, _ = await asyncio.wait(
+                (position_task, disconnect_task, shutdown_task),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if shutdown_task in done:
+                await shutdown_task
+                break
+            if disconnect_task in done:
+                await disconnect_task
+                break
+
+            pos = position_task.result()
+            position_task = asyncio.create_task(q.get())
             await ws.send_json(PositionDto.from_domain(pos).model_dump())
 
     except WebSocketDisconnect:
@@ -33,4 +49,17 @@ async def ws_position(ws: WebSocket) -> None:
     except asyncio.CancelledError:
         raise
     finally:
+        for task in (position_task, disconnect_task, shutdown_task):
+            if not task.done():
+                task.cancel()
+        for task in (position_task, disconnect_task, shutdown_task):
+            with suppress(asyncio.CancelledError, WebSocketDisconnect):
+                await task
         hub.unsubscribe(q)
+
+
+async def _wait_for_disconnect(ws: WebSocket) -> None:
+    while True:
+        message = await ws.receive()
+        if message["type"] == "websocket.disconnect":
+            return

--- a/apps/game-bridge/src/zml_game_bridge/application/mining/claims/lifecycle.py
+++ b/apps/game-bridge/src/zml_game_bridge/application/mining/claims/lifecycle.py
@@ -75,7 +75,10 @@ class ClaimLifecycleCorrelator:
 
     def process_event(self, event: EventBase) -> list[EventBase]:
         if isinstance(event, MiningDropEvent):
-            stale_results = self._resolve_stale_pending_drops(event.observed_ts_ms)
+            stale_results: list[EventBase] = []
+            stale_results.extend(
+                self._resolve_stale_pending_drops(event.observed_ts_ms)
+            )
             self._drops_by_id[event.drop_id] = event
             return stale_results
 

--- a/apps/game-bridge/src/zml_game_bridge/application/mining/claims/lifecycle.py
+++ b/apps/game-bridge/src/zml_game_bridge/application/mining/claims/lifecycle.py
@@ -511,25 +511,21 @@ def _distance_xy(left: WorldPos, right: WorldPos) -> float:
 def _same_context(drop: MiningDropEvent, deed: MiningClaimDeedReceivedEvent) -> bool:
     if drop.run_id is not None and deed.run_id is not None and drop.run_id != deed.run_id:
         return False
-    if (
+    return not (
         drop.segment_id is not None
         and deed.segment_id is not None
         and drop.segment_id != deed.segment_id
-    ):
-        return False
-    return True
+    )
 
 
 def _same_claim_context(claim: ActiveClaim, deed: MiningClaimDeedReceivedEvent) -> bool:
     if claim.run_id is not None and deed.run_id is not None and claim.run_id != deed.run_id:
         return False
-    if (
+    return not (
         claim.segment_id is not None
         and deed.segment_id is not None
         and claim.segment_id != deed.segment_id
-    ):
-        return False
-    return True
+    )
 
 
 def _same_or_missing_resource(left: str | None, right: str | None) -> bool:

--- a/apps/game-bridge/src/zml_game_bridge/application/mining/claims/lifecycle.py
+++ b/apps/game-bridge/src/zml_game_bridge/application/mining/claims/lifecycle.py
@@ -76,9 +76,7 @@ class ClaimLifecycleCorrelator:
     def process_event(self, event: EventBase) -> list[EventBase]:
         if isinstance(event, MiningDropEvent):
             stale_results: list[EventBase] = []
-            stale_results.extend(
-                self._resolve_stale_pending_drops(event.observed_ts_ms)
-            )
+            stale_results.extend(self._resolve_stale_pending_drops(event.observed_ts_ms))
             self._drops_by_id[event.drop_id] = event
             return stale_results
 

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/capture/window_capturer.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/capture/window_capturer.py
@@ -12,6 +12,10 @@ PW_CLIENTONLY = 0x00000001
 PW_RENDERFULLCONTENT = 0x00000002
 
 
+class WindowCaptureUnavailableError(RuntimeError):
+    """The target window cannot be captured right now, but may appear again."""
+
+
 def _find_window_by_title_contains(title_substr: str) -> int:
     found: list[int] = []
 
@@ -24,7 +28,7 @@ def _find_window_by_title_contains(title_substr: str) -> int:
 
     win32gui.EnumWindows(enum_cb, 0)
     if not found:
-        raise RuntimeError(f"Window not found (title contains): {title_substr!r}")
+        raise WindowCaptureUnavailableError(f"Window not found (title contains): {title_substr!r}")
     return found[0]
 
 
@@ -46,7 +50,6 @@ class WindowCapturer:
         self._title_contains = title_contains
         self._flags = flags
         self._state: _GdiState | None = None
-        self._ensure_open()
 
     def close(self) -> None:
         st = self._state
@@ -78,7 +81,7 @@ class WindowCapturer:
             # Fallback: some apps hate FULLCONTENT; try client-only
             ok2 = windll.user32.PrintWindow(st.hwnd, st.save_dc.GetSafeHdc(), PW_CLIENTONLY)
             if ok2 != 1:
-                raise RuntimeError(f"PrintWindow failed: {ok} / fallback {ok2}")
+                raise WindowCaptureUnavailableError(f"PrintWindow failed: {ok} / fallback {ok2}")
 
         bmpinfo = cast(dict[str, int], st.bitmap.GetInfo())
         bmpstr = cast(bytes, st.bitmap.GetBitmapBits(True))
@@ -87,11 +90,13 @@ class WindowCapturer:
         width = int(bmpinfo.get("bmWidth", 0))
 
         if width <= 0 or height <= 0:
-            raise RuntimeError("Window has non-positive client size.")
+            raise WindowCaptureUnavailableError("Window has non-positive client size.")
 
         expected = width * height * 4
         if len(bmpstr) < expected:
-            raise RuntimeError(f"Bitmap has non-positive size.: {len(bmpstr)} < {expected}")
+            raise WindowCaptureUnavailableError(
+                f"Bitmap buffer is too small: {len(bmpstr)} < {expected}"
+            )
 
         img = np.frombuffer(bmpstr, dtype=np.uint8).reshape((height, width, 4))
         # PrintWindow returns BGRA; drop alpha.
@@ -106,6 +111,8 @@ class WindowCapturer:
 
         hwnd = _find_window_by_title_contains(self._title_contains)
         w, h = self._get_client_size(hwnd)
+        if w <= 0 or h <= 0:
+            raise WindowCaptureUnavailableError(f"Window has non-positive client size: {w}x{h}")
 
         hwnd_dc: int = win32gui.GetWindowDC(hwnd)
         mfc_dc: Any = win32ui.CreateDCFromHandle(hwnd_dc)

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/runner.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/runner.py
@@ -12,7 +12,10 @@ from pathlib import Path
 import numpy as np
 
 from zml_game_bridge.events.contracts import SignalSink
-from zml_game_bridge.inputs.ocr.capture.window_capturer import WindowCapturer
+from zml_game_bridge.inputs.ocr.capture.window_capturer import (
+    WindowCapturer,
+    WindowCaptureUnavailableError,
+)
 from zml_game_bridge.inputs.ocr.config import OcrRoiProfile, load_ocr_roi_profile
 from zml_game_bridge.inputs.ocr.pipelines.mining_finder.model import MiningFinderSignal
 from zml_game_bridge.inputs.ocr.pipelines.mining_finder.pipeline import (
@@ -45,13 +48,17 @@ from zml_game_bridge.inputs.ocr.profiling import (
 )
 
 PositionSink = Callable[[OcrPosition], None]
+CaptureStatusSink = Callable[[bool, str | None], None]
 logger = logging.getLogger(__name__)
+
+_TARGET_WINDOW_RETRY_INTERVAL_S = 1.0
 
 
 def start_ocr_input(
     *,
     position_sink: PositionSink,
     signal_sink: SignalSink | None = None,
+    capture_status_sink: CaptureStatusSink | None = None,
     stop_event: threading.Event,
     target_hz: float = 10.0,
     finder_debug_logging: bool | None = None,
@@ -165,6 +172,7 @@ def start_ocr_input(
     tick = 0
     finder_future: Future[list[MiningFinderSignal]] | None = None
     finder_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="zml-finder-ocr")
+    target_window_available: bool | None = None
 
     try:
         while not stop_event.is_set():
@@ -179,8 +187,22 @@ def start_ocr_input(
             tick += 1
 
             capture_started_at = time.perf_counter()
-            frame = cap.grab()
+            frame, capture_error = _try_grab_frame(cap)
             profiler.record_elapsed("capture", capture_started_at)
+            if frame is None:
+                if target_window_available is not False:
+                    logger.info("ocr_target_window_waiting error=%s", capture_error)
+                    if capture_status_sink is not None:
+                        capture_status_sink(False, capture_error)
+                target_window_available = False
+                stop_event.wait(_TARGET_WINDOW_RETRY_INTERVAL_S)
+                next_t = time.perf_counter()
+                continue
+            if target_window_available is not True:
+                logger.info("ocr_target_window_available")
+                if capture_status_sink is not None:
+                    capture_status_sink(True, None)
+            target_window_available = True
 
             ts_ms = time.time_ns() // 1_000_000
 
@@ -268,6 +290,16 @@ def start_ocr_input(
         cap.close()
         position_pipeline.close()
         finder_pipeline.close()
+
+
+def _try_grab_frame(
+    capturer: WindowCapturer,
+) -> tuple[np.ndarray | None, str | None]:
+    try:
+        return capturer.grab(), None
+    except WindowCaptureUnavailableError as exc:
+        capturer.close()
+        return None, str(exc)
 
 
 def _env_bool(name: str, *, default: bool) -> bool:

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/tesserocr_runtime.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/tesserocr_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import signal
 from typing import Any
 
 
@@ -9,3 +10,13 @@ def preload_tesserocr() -> Any:
         return importlib.import_module("tesserocr")
     except Exception as exc:
         raise RuntimeError(f"tesserocr import failed: {exc}") from exc
+
+
+def preload_tesserocr_preserving_sigint_handler() -> Any:
+    """Import tesserocr on the main thread without replacing Uvicorn's Ctrl+C handler."""
+    previous_handler = signal.getsignal(signal.SIGINT)
+    try:
+        return preload_tesserocr()
+    finally:
+        if previous_handler is not None:
+            signal.signal(signal.SIGINT, previous_handler)

--- a/apps/game-bridge/src/zml_game_bridge/main.py
+++ b/apps/game-bridge/src/zml_game_bridge/main.py
@@ -1,21 +1,143 @@
 from __future__ import annotations
 
+import logging
+import os
+import sys
+import threading
+import time
+from typing import TextIO
+
 import uvicorn
 
+from zml_game_bridge.runtime.shutdown_signal import (
+    RuntimeShutdownSignal,
+    process_shutdown_signal,
+)
 from zml_game_bridge.settings import Settings, configure_logging_from_env
+
+logger = logging.getLogger(__name__)
+
+_PARENT_MANAGED_ENV = "ZML_PARENT_MANAGED"
+_SHUTDOWN_COMMAND = "shutdown"
+_PARENT_PIPE_POLL_INTERVAL_S = 0.05
+_PARENT_PIPE_READ_SIZE = 4096
+_GRACEFUL_SHUTDOWN_TIMEOUT_S = 15
 
 
 def main() -> None:
     configure_logging_from_env()
+    process_shutdown_signal.reset()
     s = Settings()
-    # Uvicorn factory: module:function + factory=True
-    uvicorn.run(
+    if not _parent_managed():
+        # Uvicorn factory: module:function + factory=True
+        uvicorn.run(
+            "zml_game_bridge.api.app:create_app",
+            factory=True,
+            host=s.host,
+            port=s.port,
+            reload=s.reload,
+            timeout_graceful_shutdown=_GRACEFUL_SHUTDOWN_TIMEOUT_S,
+        )
+        return
+
+    config = uvicorn.Config(
         "zml_game_bridge.api.app:create_app",
         factory=True,
         host=s.host,
         port=s.port,
-        reload=s.reload,
+        reload=False,
+        timeout_graceful_shutdown=_GRACEFUL_SHUTDOWN_TIMEOUT_S,
     )
+    server = uvicorn.Server(config)
+    parent_watcher = threading.Thread(
+        target=_watch_parent_commands,
+        kwargs={"server": server, "stream": sys.stdin},
+        name="zml-parent-watch",
+        daemon=True,
+    )
+    parent_watcher.start()
+    logger.info("backend_parent_management_enabled")
+    server.run()
+
+
+def _parent_managed() -> bool:
+    value = os.getenv(_PARENT_MANAGED_ENV)
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _watch_parent_commands(*, server: uvicorn.Server, stream: TextIO) -> None:
+    _watch_parent_commands_with_signal(
+        server=server,
+        stream=stream,
+        shutdown_signal=process_shutdown_signal,
+    )
+
+
+def _watch_parent_commands_with_signal(
+    *,
+    server: uvicorn.Server,
+    stream: TextIO,
+    shutdown_signal: RuntimeShutdownSignal,
+) -> None:
+    try:
+        fd = stream.fileno()
+        os.set_blocking(fd, False)
+    except (AttributeError, OSError, ValueError):
+        _watch_parent_text_stream(
+            server=server,
+            stream=stream,
+            shutdown_signal=shutdown_signal,
+        )
+        return
+
+    pending = b""
+    while not server.should_exit:
+        try:
+            chunk = os.read(fd, _PARENT_PIPE_READ_SIZE)
+        except BlockingIOError:
+            time.sleep(_PARENT_PIPE_POLL_INTERVAL_S)
+            continue
+        except OSError as exc:
+            logger.info("backend_parent_pipe_closed error=%s", exc)
+            shutdown_signal.request()
+            server.should_exit = True
+            return
+
+        if not chunk:
+            logger.info("backend_parent_pipe_closed")
+            shutdown_signal.request()
+            server.should_exit = True
+            return
+
+        pending += chunk
+        lines = pending.split(b"\n")
+        pending = lines.pop()
+        for line in lines:
+            if line.strip().lower() != _SHUTDOWN_COMMAND.encode("ascii"):
+                continue
+            logger.info("backend_shutdown_requested_by_parent")
+            shutdown_signal.request()
+            server.should_exit = True
+            return
+
+
+def _watch_parent_text_stream(
+    *,
+    server: uvicorn.Server,
+    stream: TextIO,
+    shutdown_signal: RuntimeShutdownSignal,
+) -> None:
+    for line in stream:
+        if line.strip().lower() != _SHUTDOWN_COMMAND:
+            continue
+        logger.info("backend_shutdown_requested_by_parent")
+        shutdown_signal.request()
+        server.should_exit = True
+        return
+
+    logger.info("backend_parent_pipe_closed")
+    shutdown_signal.request()
+    server.should_exit = True
 
 
 if __name__ == "__main__":

--- a/apps/game-bridge/src/zml_game_bridge/persistence/schema.py
+++ b/apps/game-bridge/src/zml_game_bridge/persistence/schema.py
@@ -307,17 +307,13 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_mining_claims_expired ON mining_claims(expired_event_id)"
     )
-    if user_version < 14 and not _column_exists(
-        conn, "mining_drops", "total_tt_cost_mpec"
-    ):
+    if user_version < 14 and not _column_exists(conn, "mining_drops", "total_tt_cost_mpec"):
         conn.execute(
             "ALTER TABLE mining_drops ADD COLUMN total_tt_cost_mpec INTEGER NOT NULL DEFAULT 0"
         )
         # Legacy drops only persisted the effective cost. Preserve that value as
         # the safest available TT fallback; all new drops store the exact split.
-        conn.execute(
-            "UPDATE mining_drops SET total_tt_cost_mpec = total_cost_mpec"
-        )
+        conn.execute("UPDATE mining_drops SET total_tt_cost_mpec = total_cost_mpec")
     if user_version < SCHEMA_VERSION:
         conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
     conn.commit()

--- a/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
@@ -19,11 +19,17 @@ from zml_game_bridge.inputs.chat.runner import start_chat_input
 from zml_game_bridge.inputs.mock.mining import start_mock_mining_input
 from zml_game_bridge.inputs.ocr.pipelines.position.model import OcrPosition
 from zml_game_bridge.inputs.ocr.runner import start_ocr_input
-from zml_game_bridge.inputs.ocr.tesserocr_runtime import preload_tesserocr
+from zml_game_bridge.inputs.ocr.tesserocr_runtime import (
+    preload_tesserocr_preserving_sigint_handler,
+)
 from zml_game_bridge.runtime.bootstrap import RuntimeComponents
 from zml_game_bridge.runtime.channels import ChannelClosedError
 from zml_game_bridge.runtime.db_commands import DbCommand
 from zml_game_bridge.runtime.runtime_commands import RuntimeCommand, RuntimeCommandRequest
+from zml_game_bridge.runtime.shutdown_signal import (
+    RuntimeShutdownSignal,
+    process_shutdown_signal,
+)
 from zml_game_bridge.runtime.supervisor import WorkerSupervisor
 from zml_game_bridge.settings import Settings
 
@@ -39,6 +45,7 @@ class AppRuntime:
         supervisor: WorkerSupervisor,
         sse_hub: SseHub | None = None,
         position_hub: PositionHub | None = None,
+        shutdown_signal: RuntimeShutdownSignal = process_shutdown_signal,
     ) -> None:
         self._settings = settings
         self._components = components
@@ -47,6 +54,7 @@ class AppRuntime:
         self._sub_sse = None
         self._sse_hub = sse_hub
         self._position_hub = position_hub
+        self._shutdown_signal = shutdown_signal
         self._started = False
         self._components.position_service.set_publisher(
             None if position_hub is None else position_hub.publish_threadsafe
@@ -65,6 +73,10 @@ class AppRuntime:
     @property
     def sse_hub(self) -> SseHub | None:
         return self._sse_hub
+
+    @property
+    def shutdown_signal(self) -> RuntimeShutdownSignal:
+        return self._shutdown_signal
 
     @property
     def position_service(self) -> PositionTrackingService:
@@ -106,6 +118,7 @@ class AppRuntime:
     def start(self) -> None:
         if self._started:
             return
+        self._shutdown_signal.install_signal_forwarders()
         if self._components.pending_inputs.is_closed():
             raise RuntimeError("Runtime cannot be restarted after shutdown")
         if self._settings.chat_log_path is None:
@@ -164,7 +177,7 @@ class AppRuntime:
         if self._settings.ocr_enabled:
             try:
                 # Needed for 'tesserocr import failed: signal only works in main thread of the main interpreter'
-                preload_tesserocr()
+                preload_tesserocr_preserving_sigint_handler()
             except Exception as exc:
                 self._supervisor.mark_crashed("ocr_worker", exc)
                 raise
@@ -175,6 +188,7 @@ class AppRuntime:
                 worker_kwargs={
                     "position_sink": self._on_position,
                     "signal_sink": self._components.pending_inputs.emit,
+                    "capture_status_sink": self._on_ocr_capture_status,
                     "stop_event": self._stop_event,
                     "roi_profile_path": self._settings.ocr_profile_path,
                     "finder_recording_modes": self._settings.finder_recording_modes,
@@ -217,6 +231,15 @@ class AppRuntime:
                 position=position.position,
                 source="ocr",
             )
+        )
+
+    def _on_ocr_capture_status(self, available: bool, error: str | None) -> None:
+        if available:
+            self._supervisor.mark_running("ocr_worker")
+            return
+        self._supervisor.mark_degraded(
+            "ocr_worker",
+            error or "Entropia Universe window is unavailable",
         )
 
     def _run_claim_expiration_maintenance(self, *, stop_event: threading.Event) -> None:

--- a/apps/game-bridge/src/zml_game_bridge/runtime/shutdown_signal.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/shutdown_signal.py
@@ -4,7 +4,10 @@ import asyncio
 import signal
 import sys
 import threading
+from collections.abc import Callable
 from types import FrameType
+
+_SignalHandler = Callable[[int, FrameType | None], object]
 
 
 class RuntimeShutdownSignal:
@@ -39,15 +42,20 @@ class RuntimeShutdownSignal:
             if not callable(previous_handler):
                 continue
 
-            def forward_signal(
-                received_signal: int,
-                frame: FrameType | None,
-                previous_handler=previous_handler,
-            ) -> None:
-                self.request()
-                previous_handler(received_signal, frame)
+            signal.signal(
+                signal_number,
+                self._build_signal_forwarder(previous_handler),
+            )
 
-            signal.signal(signal_number, forward_signal)
+    def _build_signal_forwarder(
+        self,
+        previous_handler: _SignalHandler,
+    ) -> _SignalHandler:
+        def forward_signal(received_signal: int, frame: FrameType | None) -> None:
+            self.request()
+            previous_handler(received_signal, frame)
+
+        return forward_signal
 
 
 process_shutdown_signal = RuntimeShutdownSignal()

--- a/apps/game-bridge/src/zml_game_bridge/runtime/shutdown_signal.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/shutdown_signal.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+import signal
+import sys
+import threading
+from types import FrameType
+
+
+class RuntimeShutdownSignal:
+    """Process-wide shutdown notification for long-lived API streams."""
+
+    def __init__(self) -> None:
+        self._requested = threading.Event()
+
+    def request(self) -> None:
+        self._requested.set()
+
+    def reset(self) -> None:
+        self._requested.clear()
+
+    def is_requested(self) -> bool:
+        return self._requested.is_set()
+
+    async def wait(self) -> None:
+        while not self._requested.is_set():
+            await asyncio.sleep(0.05)
+
+    def install_signal_forwarders(self) -> None:
+        if threading.current_thread() is not threading.main_thread():
+            return
+
+        handled_signals = [signal.SIGINT, signal.SIGTERM]
+        if sys.platform == "win32":
+            handled_signals.append(signal.SIGBREAK)
+
+        for signal_number in handled_signals:
+            previous_handler = signal.getsignal(signal_number)
+            if not callable(previous_handler):
+                continue
+
+            def forward_signal(
+                received_signal: int,
+                frame: FrameType | None,
+                previous_handler=previous_handler,
+            ) -> None:
+                self.request()
+                previous_handler(received_signal, frame)
+
+            signal.signal(signal_number, forward_signal)
+
+
+process_shutdown_signal = RuntimeShutdownSignal()

--- a/apps/game-bridge/src/zml_game_bridge/runtime/supervisor.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/supervisor.py
@@ -26,6 +26,9 @@ class WorkerSupervisor:
     def mark_crashed(self, name: str, exc: BaseException) -> None:
         self._health.mark_crashed(name, exc)
 
+    def mark_running(self, name: str) -> None:
+        self._health.mark_running(name)
+
     def mark_degraded(self, name: str, message: str) -> None:
         self._health.mark_degraded(name, message)
 

--- a/apps/game-bridge/tests/api/test_events_stream.py
+++ b/apps/game-bridge/tests/api/test_events_stream.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+from fastapi import Request
+
+from zml_game_bridge.api.channels.sse_hub import SseClient
+from zml_game_bridge.api.routes.events import events_stream
+from zml_game_bridge.runtime.runtime import AppRuntime
+from zml_game_bridge.runtime.shutdown_signal import RuntimeShutdownSignal
+
+
+class _FakeSseHub:
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[Any] = asyncio.Queue()
+        self.unregistered = False
+
+    def register(self) -> SseClient:
+        return SseClient(client_id=1, queue=self.queue)
+
+    def unregister(self, client_id: int) -> None:
+        assert client_id == 1
+        self.unregistered = True
+
+
+def test_event_stream_exits_promptly_when_runtime_stops() -> None:
+    async def scenario() -> None:
+        hub = _FakeSseHub()
+        shutdown_signal = RuntimeShutdownSignal()
+        runtime = cast(
+            AppRuntime,
+            type(
+                "Runtime",
+                (),
+                {"sse_hub": hub, "shutdown_signal": shutdown_signal},
+            )(),
+        )
+        response = await events_stream(cast(Request, object()), runtime)
+        iterator = response.body_iterator.__aiter__()
+
+        assert await anext(iterator) == ": connected\n\n"
+        next_chunk = asyncio.create_task(anext(iterator))
+        shutdown_signal.request()
+
+        try:
+            await asyncio.wait_for(next_chunk, timeout=1.0)
+        except StopAsyncIteration:
+            pass
+        else:
+            raise AssertionError("SSE iterator should stop after runtime shutdown")
+
+        assert hub.unregistered is True
+
+    asyncio.run(scenario())

--- a/apps/game-bridge/tests/api/test_ws_position.py
+++ b/apps/game-bridge/tests/api/test_ws_position.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+from fastapi import WebSocket
+
+from zml_game_bridge.api.routes.ws_position import ws_position
+from zml_game_bridge.runtime.shutdown_signal import RuntimeShutdownSignal
+
+
+class _FakePositionHub:
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=1)
+        self.unsubscribed = False
+
+    def subscribe(self) -> tuple[asyncio.Queue[Any], None]:
+        return self.queue, None
+
+    def unsubscribe(self, queue: asyncio.Queue[Any]) -> None:
+        assert queue is self.queue
+        self.unsubscribed = True
+
+
+class _FakeWebSocket:
+    def __init__(self, hub: _FakePositionHub) -> None:
+        runtime = SimpleNamespace(
+            position_hub=hub,
+            shutdown_signal=RuntimeShutdownSignal(),
+        )
+        self.app = SimpleNamespace(state=SimpleNamespace(runtime=runtime))
+        self.incoming: asyncio.Queue[dict[str, str]] = asyncio.Queue()
+        self.accepted = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive(self) -> dict[str, str]:
+        return await self.incoming.get()
+
+    async def send_json(self, _data: object) -> None:
+        return
+
+
+def test_position_websocket_exits_when_client_disconnects() -> None:
+    async def scenario() -> None:
+        hub = _FakePositionHub()
+        websocket = _FakeWebSocket(hub)
+        handler = asyncio.create_task(ws_position(cast(WebSocket, websocket)))
+
+        while not websocket.accepted:
+            await asyncio.sleep(0)
+        await websocket.incoming.put({"type": "websocket.disconnect"})
+        await asyncio.wait_for(handler, timeout=1.0)
+
+        assert hub.unsubscribed is True
+
+    asyncio.run(scenario())

--- a/apps/game-bridge/tests/inputs/ocr/test_ocr_capture_retry.py
+++ b/apps/game-bridge/tests/inputs/ocr/test_ocr_capture_retry.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+
+from zml_game_bridge.inputs.ocr.capture.window_capturer import (
+    WindowCapturer,
+    WindowCaptureUnavailableError,
+)
+from zml_game_bridge.inputs.ocr.runner import _try_grab_frame
+
+
+class _RecoveringCapturer:
+    def __init__(self) -> None:
+        self.attempts = 0
+        self.close_calls = 0
+
+    def grab(self) -> np.ndarray:
+        self.attempts += 1
+        if self.attempts == 1:
+            raise WindowCaptureUnavailableError("Entropia window is missing")
+        return np.zeros((2, 3, 3), dtype=np.uint8)
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def test_capture_retry_recovers_after_target_window_appears() -> None:
+    fake_capturer = _RecoveringCapturer()
+    capturer = cast(WindowCapturer, fake_capturer)
+
+    missing_frame, error = _try_grab_frame(capturer)
+    recovered_frame, recovered_error = _try_grab_frame(capturer)
+
+    assert missing_frame is None
+    assert error == "Entropia window is missing"
+    assert fake_capturer.close_calls == 1
+    assert recovered_frame is not None
+    assert recovered_frame.shape == (2, 3, 3)
+    assert recovered_error is None

--- a/apps/game-bridge/tests/inputs/ocr/test_tesserocr_runtime.py
+++ b/apps/game-bridge/tests/inputs/ocr/test_tesserocr_runtime.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import signal
+
+from zml_game_bridge.inputs.ocr import tesserocr_runtime
+
+
+def test_main_thread_preload_restores_sigint_handler(monkeypatch) -> None:
+    original_handler = signal.getsignal(signal.SIGINT)
+
+    def uvicorn_handler(_signal_number, _frame) -> None:
+        return
+
+    def cysignals_handler(_signal_number, _frame) -> None:
+        return
+
+    sentinel = object()
+
+    def fake_import_module(name: str):
+        assert name == "tesserocr"
+        signal.signal(signal.SIGINT, cysignals_handler)
+        return sentinel
+
+    try:
+        signal.signal(signal.SIGINT, uvicorn_handler)
+        monkeypatch.setattr(tesserocr_runtime.importlib, "import_module", fake_import_module)
+
+        result = tesserocr_runtime.preload_tesserocr_preserving_sigint_handler()
+
+        assert result is sentinel
+        assert signal.getsignal(signal.SIGINT) is uvicorn_handler
+    finally:
+        if original_handler is not None:
+            signal.signal(signal.SIGINT, original_handler)

--- a/apps/game-bridge/tests/runtime/test_worker_health.py
+++ b/apps/game-bridge/tests/runtime/test_worker_health.py
@@ -55,3 +55,17 @@ def test_worker_supervisor_marks_worker_stopped_after_clean_return() -> None:
     snapshot = supervisor.health()
     workers = cast(dict[str, dict[str, Any]], snapshot["workers"])
     assert workers["worker"]["state"] == "stopped"
+
+
+def test_worker_supervisor_can_recover_degraded_worker() -> None:
+    supervisor = WorkerSupervisor()
+    supervisor.register("ocr_worker", enabled=True)
+
+    supervisor.mark_degraded("ocr_worker", "target window unavailable")
+    supervisor.mark_running("ocr_worker")
+
+    snapshot = supervisor.health()
+    workers = cast(dict[str, dict[str, Any]], snapshot["workers"])
+    assert snapshot["status"] == "running"
+    assert workers["ocr_worker"]["state"] == "running"
+    assert workers["ocr_worker"]["last_error"] is None

--- a/apps/game-bridge/tests/test_main.py
+++ b/apps/game-bridge/tests/test_main.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+import threading
+from io import StringIO
+from typing import cast
+
+import uvicorn
+
+from zml_game_bridge.main import _watch_parent_commands_with_signal
+from zml_game_bridge.runtime.shutdown_signal import RuntimeShutdownSignal
+
+
+class _FakeServer:
+    should_exit = False
+
+
+def test_parent_shutdown_command_requests_graceful_server_exit() -> None:
+    server = _FakeServer()
+    shutdown_signal = RuntimeShutdownSignal()
+
+    _watch_parent_commands_with_signal(
+        server=cast(uvicorn.Server, server),
+        stream=StringIO("ignored\nshutdown\n"),
+        shutdown_signal=shutdown_signal,
+    )
+
+    assert server.should_exit is True
+    assert shutdown_signal.is_requested() is True
+
+
+def test_closed_parent_pipe_requests_graceful_server_exit() -> None:
+    server = _FakeServer()
+    shutdown_signal = RuntimeShutdownSignal()
+
+    _watch_parent_commands_with_signal(
+        server=cast(uvicorn.Server, server),
+        stream=StringIO(""),
+        shutdown_signal=shutdown_signal,
+    )
+
+    assert server.should_exit is True
+    assert shutdown_signal.is_requested() is True
+
+
+def test_parent_pipe_is_polled_without_blocking_the_interpreter() -> None:
+    server = _FakeServer()
+    shutdown_signal = RuntimeShutdownSignal()
+    read_fd, write_fd = os.pipe()
+
+    try:
+        with os.fdopen(read_fd, "r", encoding="utf-8") as stream:
+            watcher = threading.Thread(
+                target=_watch_parent_commands_with_signal,
+                kwargs={
+                    "server": cast(uvicorn.Server, server),
+                    "stream": stream,
+                    "shutdown_signal": shutdown_signal,
+                },
+                daemon=True,
+            )
+            watcher.start()
+            os.write(write_fd, b"shutdown\n")
+            watcher.join(timeout=1.0)
+
+            assert watcher.is_alive() is False
+            assert server.should_exit is True
+            assert shutdown_signal.is_requested() is True
+    finally:
+        os.close(write_fd)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Updated: 2026-06-01
+Updated: 2026-08-09
 
 Z Mining Log is a local desktop application. The Python backend observes the
 game, derives durable mining facts, persists them to SQLite, and streams live
@@ -182,6 +182,39 @@ Main Electron windows:
 The map uses deck.gl with raster tile layers and custom overlays for player,
 drops, claims, hexgrid, context menu, and follow mode.
 
+## Desktop Process Lifecycle
+
+Electron main owns the default local Python backend process:
+
+```mermaid
+sequenceDiagram
+    participant Electron as Electron main
+    participant Bridge as Python bridge
+    participant API as FastAPI lifespan
+    Electron->>Bridge: spawn serve --mode live
+    Electron->>API: poll GET /health
+    API-->>Electron: ready (running or degraded)
+    Electron->>Bridge: shutdown via stdin pipe
+    Bridge->>API: request RuntimeShutdownSignal + uvicorn should_exit
+    API->>API: close long-lived WS/SSE handlers
+    API->>API: AppRuntime.stop()
+    Bridge-->>Electron: process closed
+```
+
+- Development resolves `apps/game-bridge/.venv` directly.
+- Packaged builds resolve `resources/backend/zml-game-bridge.exe`.
+- `ZML_MANAGE_BACKEND=0` leaves lifecycle ownership to the developer.
+- An explicit `ZML_BACKEND_URL` is treated as external by default.
+- If a managed backend exits unexpectedly, Electron retries with bounded backoff.
+- The parent pipe is polled in non-blocking mode. Closing it also requests backend shutdown,
+  covering abrupt Electron exits without blocking Python startup.
+- `RuntimeShutdownSignal` lets WS/SSE handlers finish before Uvicorn waits for active
+  connections, avoiding a circular graceful-shutdown wait.
+- The main-thread `tesserocr` preload preserves Uvicorn's `SIGINT` handler; otherwise
+  bundled `cysignals` replaces it and a single Ctrl+C ends in `KeyboardInterrupt`.
+- Absence of the Entropia window is not a process failure. OCR reports `degraded`, retries
+  capture, and returns to `running` when the window becomes available.
+
 ## Read/Write Split
 
 - Writes: one writer thread via `DbWriterWorker`.
@@ -199,4 +232,3 @@ drops, claims, hexgrid, context menu, and follow mode.
 - Segment correctness is still being refined: segment should be a setup bucket
   inside a run, and same setup should reuse the same segment in that run.
 - OCR ROI calibration is not yet user-driven.
-

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,6 +1,6 @@
 # Current State
 
-Updated: 2026-06-01
+Updated: 2026-08-09
 
 This file is a compact handoff for future conversations. It should be updated
 when a branch lands a meaningful architecture or product change.
@@ -54,52 +54,41 @@ Z Mining Log is now a working local mining tracker prototype:
 - OCR backend:
   - finder OCR migrated toward `tesserocr` wrapper;
   - profiling and finder crop recording hooks exist;
-  - position outlier filtering exists.
-
-## Current Worktree Note
-
-At the time this document was added, there was a pre-existing local modification
-in:
-
-```text
-apps/electron-ui/src/windows/mapWindow.tsx
-```
-
-Treat it as user work unless proven otherwise.
+  - position outlier filtering exists;
+  - missing/lost Entropia window degrades health and retries instead of crashing OCR.
+- Desktop lifecycle and packaging:
+  - Electron starts the local backend from `.venv` in development;
+  - packaged Electron starts the bundled PyInstaller backend;
+  - backend exits through FastAPI lifespan when Electron sends `shutdown` on the parent pipe;
+  - parent-pipe reads are non-blocking and Ctrl+C retains Uvicorn's handler despite
+    `tesserocr`/`cysignals` initialization;
+  - a runtime shutdown signal releases long-lived WS/SSE streams before connection drain;
+  - unexpected backend exits use a bounded restart policy;
+  - Windows release workflow builds and smoke-tests one NSIS installer.
+- Run accounting and utilities:
+  - drop costs distinguish TT from markup-adjusted totals;
+  - duplicate drop observations have a five-second lock;
+  - run loot can be copied as Excel-ready TSV;
+  - `/pos` planet information remains sticky across planet-less OCR positions.
 
 ## Important Open Problems
 
 See `ROADMAP_2025-05-26.md` for the ordered roadmap. The highest-value items are:
 
-1. Backend/Electron shutdown:
-   - no orphan backend process;
-   - no hanging DB connection;
-   - clean close/restart from Electron.
+1. Runtime config and live settings:
+   - move safe OCR/runtime options beyond env-only configuration;
+   - expose controlled apply/restart behavior from UI.
 
-2. Drop + segment correctness:
-   - segment is a setup bucket, not just a chronological episode;
-   - same setup inside one run should reuse the existing segment;
-   - segment should be created/reused on valid drop, not on noisy finder changes;
-   - `ammo_per_drop = 0` should be invalid/fallback, not a real zero-cost drop.
+2. ROI calibration:
+   - finish finder calibration UX;
+   - add separate compass/Lon/Lat calibration and presets.
 
-3. Event context completeness:
-   - mining events need `run_id` / `segment_id` where possible;
-   - event log should support emergency reconstruction.
+3. Debug/operator UX:
+   - replace the JSON-heavy debug tab with worker, OCR, run, event, and warning panels.
 
-4. Claim hardening:
-   - active claims should expire automatically after expected expiry;
-   - maintenance should run inside runtime through DbWriter, not an external cron.
-
-5. Loot aggregation:
-   - raw `MiningItemReceivedEvent` spam is too noisy long term;
-   - target is run/segment item totals with debounced UI updates.
-
-6. OCR stability:
-   - FinderPresenceCheck before expensive finder OCR;
-   - treasure mode classifier states;
-   - compass latest-wins;
-   - manual ROI calibration for finder and compass;
-   - `/pos` chat event support.
+4. Persistence cleanup:
+   - decide whether unused 3D claim fields should remain;
+   - keep the event journal focused on durable reconstruction facts.
 
 ## What Not To Rebuild Lightly
 
@@ -125,6 +114,7 @@ These decisions were made after several design turns and real-game testing:
 ## Current UI Entry Points
 
 - `apps/electron-ui/electron/main.ts`
+- `apps/electron-ui/electron/backend/backendProcessManager.ts`
 - `apps/electron-ui/electron/runtime.ts`
 - `apps/electron-ui/electron/ipc/registerIpc.ts`
 - `apps/electron-ui/electron/agent/restClient.ts`
@@ -138,4 +128,3 @@ These decisions were made after several design turns and real-game testing:
 The user prefers not to spend local time/tokens on broad lint/pyright runs
 unless requested. Use focused tests for touched backend behavior and TypeScript
 checks for touched UI contracts/components. Full verification is expected in CI.
-

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "concurrently -n bridge,web -c cyan,magenta \"cd apps/game-bridge && just ocr\" \"pnpm --filter @zml/electron-ui dev\"",
+    "dev": "pnpm --filter @zml/electron-ui dev",
 
     "bridge:format": "cd apps/game-bridge && just format",
+    "bridge:package": "cd apps/game-bridge && just package",
     "bridge:verify": "cd apps/game-bridge && just verify",
+
+    "backend:stage": "node scripts/stage-backend.mjs",
 
     "shared:verify": "pnpm --filter @zml/shared typecheck && pnpm --filter @zml/shared build",
 
@@ -20,7 +23,7 @@
 
     "verify": "pnpm bridge:verify && pnpm frontend:verify",
     "build": "pnpm frontend:build",
-    "package": "pnpm frontend:package",
+    "package": "pnpm bridge:package && pnpm backend:stage && pnpm frontend:package",
     "lint": "cd apps/game-bridge && just lint && pnpm --filter @zml/electron-ui lint"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,18 +44,12 @@ importers:
       '@zml/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-      bufferutil:
-        specifier: ^4.1.0
-        version: 4.1.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
-      utf-8-validate:
-        specifier: ^6.0.6
-        version: 6.0.6
       ws:
         specifier: ^8.19.0
         version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -4569,6 +4563,7 @@ snapshots:
   bufferutil@4.1.0:
     dependencies:
       node-gyp-build: 4.8.4
+    optional: true
 
   builder-util-runtime@9.2.4:
     dependencies:
@@ -5671,7 +5666,8 @@ snapshots:
   node-addon-api@1.7.2:
     optional: true
 
-  node-gyp-build@4.8.4: {}
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-releases@2.0.27: {}
 
@@ -6134,6 +6130,7 @@ snapshots:
   utf-8-validate@6.0.6:
     dependencies:
       node-gyp-build: 4.8.4
+    optional: true
 
   utf8-byte-length@1.0.5: {}
 

--- a/scripts/stage-backend.mjs
+++ b/scripts/stage-backend.mjs
@@ -1,0 +1,21 @@
+import { access, cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const source = path.join(repoRoot, "apps", "game-bridge", "dist", "zml-game-bridge");
+const target = path.join(repoRoot, "apps", "electron-ui", "resources", "backend");
+
+try {
+  await access(path.join(source, "zml-game-bridge.exe"));
+} catch {
+  throw new Error(
+    `Packaged backend was not found at ${source}. Run the bridge package step first.`,
+  );
+}
+
+await rm(target, { recursive: true, force: true });
+await mkdir(path.dirname(target), { recursive: true });
+await cp(source, target, { recursive: true });
+
+console.info(`Staged backend: ${source} -> ${target}`);


### PR DESCRIPTION
start and health-check the local or bundled Python backend

restart crashed backend processes with bounded backoff

preserve Uvicorn signal handlers during tesserocr initialization

release WebSocket and SSE streams before graceful shutdown

stop the backend through the FastAPI lifespan

keep OCR alive while the Entropia window is unavailable

bundle the PyInstaller backend in the Windows installer

publish tagged Windows releases through GitHub Actions