### PR TITLE
refactor(ocr): add input source boundary

### DIFF
--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -54,8 +54,11 @@ Legend:
      - `packages/ocr-protocol` owns strict version 1 DTOs, NDJSON codec, and fixtures;
      - finder application signals no longer live under the OCR input implementation;
      - current OCR pipelines and startup behavior remain embedded and unchanged.
-   - Next: introduce an OCR input port and embedded adapter without moving pipelines.
-   - Then create the standalone OCR Agent, subprocess supervisor, config resync, restart policy,
+   - Embedded boundary done 2026-08-09:
+     - `AppRuntime` starts and stops only the `OcrInputSource` port;
+     - `EmbeddedOcrInputSource` wraps the current runner and converts positions at the boundary;
+     - OCR remains in-process and finder signals keep using `RuntimeInputChannel`.
+   - Next create the standalone OCR Agent, subprocess supervisor, config resync, restart policy,
      integration tests, real-game smoke validation, and two-executable packaging.
    - Keep the embedded rollback transport until agent mode survives gameplay and packaged release
      validation.

--- a/apps/game-bridge/src/zml_game_bridge/api/app.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/app.py
@@ -31,10 +31,11 @@ def create_app() -> FastAPI:
         loop = asyncio.get_running_loop()
         sse_hub = SseHub(loop)
         position_hub = PositionHub(loop)
+        supervisor = build_worker_supervisor(settings)
         runtime = AppRuntime(
             settings=settings,
-            components=build_runtime_components(settings),
-            supervisor=build_worker_supervisor(settings),
+            components=build_runtime_components(settings, supervisor=supervisor),
+            supervisor=supervisor,
             sse_hub=sse_hub,
             position_hub=position_hub,
         )

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/source.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/source.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Event
+from typing import Any
+
+from zml_game_bridge.application.position.model import PositionSnapshot
+from zml_game_bridge.events.contracts import SignalSink
+from zml_game_bridge.inputs.ocr.pipelines.position.model import OcrPosition
+from zml_game_bridge.inputs.ocr.runner import start_ocr_input
+from zml_game_bridge.inputs.ocr.tesserocr_runtime import (
+    preload_tesserocr_preserving_sigint_handler,
+)
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
+
+_OCR_WORKER_NAME = "ocr_worker"
+
+PositionSnapshotSink = Callable[[PositionSnapshot], None]
+OcrRunner = Callable[..., None]
+OcrPreloader = Callable[[], Any]
+ClockMs = Callable[[], int]
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddedOcrInputConfig:
+    enabled: bool
+    roi_profile_path: Path
+    finder_recording_modes: str
+    finder_recording_dir: Path
+    finder_recording_interval_s: float
+    finder_recording_max_samples: int
+    finder_presence_check_enabled: bool
+    position_roi_snapshot_enabled: bool
+    position_roi_snapshot_dir: Path
+    position_roi_snapshot_interval_s: float
+    position_roi_snapshot_max_samples: int
+    ocr_profiling_enabled: bool
+    ocr_profiling_interval_s: float
+
+
+class EmbeddedOcrInputSource:
+    """Run the current in-process OCR implementation behind the runtime port."""
+
+    def __init__(
+        self,
+        *,
+        config: EmbeddedOcrInputConfig,
+        supervisor: WorkerSupervisor,
+        position_sink: PositionSnapshotSink,
+        signal_sink: SignalSink,
+        runner: OcrRunner = start_ocr_input,
+        preloader: OcrPreloader = preload_tesserocr_preserving_sigint_handler,
+        clock_ms: ClockMs | None = None,
+    ) -> None:
+        self._config = config
+        self._supervisor = supervisor
+        self._position_sink = position_sink
+        self._signal_sink = signal_sink
+        self._runner = runner
+        self._preloader = preloader
+        self._clock_ms = clock_ms or _now_ms
+
+    def start(self, *, stop_event: Event) -> None:
+        if not self._config.enabled:
+            return
+
+        try:
+            # Keep the preload on the main thread so tesserocr cannot replace
+            # Uvicorn's SIGINT handler from the OCR worker thread.
+            self._preloader()
+        except Exception as exc:
+            self._supervisor.mark_crashed(_OCR_WORKER_NAME, exc)
+            raise
+
+        self._supervisor.start_thread(
+            name=_OCR_WORKER_NAME,
+            target=self._runner,
+            worker_kwargs={
+                "position_sink": self._on_position,
+                "signal_sink": self._signal_sink,
+                "capture_status_sink": self._on_capture_status,
+                "stop_event": stop_event,
+                "roi_profile_path": self._config.roi_profile_path,
+                "finder_recording_modes": self._config.finder_recording_modes,
+                "finder_recording_dir": self._config.finder_recording_dir,
+                "finder_recording_interval_s": self._config.finder_recording_interval_s,
+                "finder_recording_max_samples": self._config.finder_recording_max_samples,
+                "finder_presence_check_enabled": self._config.finder_presence_check_enabled,
+                "position_roi_snapshot_enabled": self._config.position_roi_snapshot_enabled,
+                "position_roi_snapshot_dir": self._config.position_roi_snapshot_dir,
+                "position_roi_snapshot_interval_s": (self._config.position_roi_snapshot_interval_s),
+                "position_roi_snapshot_max_samples": (
+                    self._config.position_roi_snapshot_max_samples
+                ),
+                "ocr_profiling_enabled": self._config.ocr_profiling_enabled,
+                "ocr_profiling_interval_s": self._config.ocr_profiling_interval_s,
+            },
+        )
+
+    def stop(self) -> None:
+        if self._config.enabled:
+            self._supervisor.join_thread(_OCR_WORKER_NAME)
+
+    def _on_position(self, position: OcrPosition) -> None:
+        self._position_sink(
+            PositionSnapshot(
+                observed_ts_ms=position.ts_ms,
+                received_ts_ms=self._clock_ms(),
+                position=position.position,
+                source="ocr",
+            )
+        )
+
+    def _on_capture_status(self, available: bool, error: str | None) -> None:
+        if available:
+            self._supervisor.mark_running(_OCR_WORKER_NAME)
+            return
+        self._supervisor.mark_degraded(
+            _OCR_WORKER_NAME,
+            error or "Entropia Universe window is unavailable",
+        )
+
+
+def _now_ms() -> int:
+    return time.time_ns() // 1_000_000

--- a/apps/game-bridge/src/zml_game_bridge/runtime/bootstrap.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/bootstrap.py
@@ -10,8 +10,10 @@ from zml_game_bridge.application.mining.segments.session import (
 )
 from zml_game_bridge.application.mining.settings import default_id_factory
 from zml_game_bridge.application.position.input_processor import PositionInputProcessor
+from zml_game_bridge.application.position.model import PositionSnapshot
 from zml_game_bridge.application.position.tracking import PositionTrackingService
 from zml_game_bridge.events.in_memory_persisted_event_bus import InMemoryPersistedEventBus
+from zml_game_bridge.inputs.ocr.source import EmbeddedOcrInputConfig, EmbeddedOcrInputSource
 from zml_game_bridge.persistence.event_projector import CompositeEventProjector
 from zml_game_bridge.persistence.mining_claims import MiningClaimProjector
 from zml_game_bridge.persistence.mining_drops import MiningDropProjector
@@ -23,6 +25,7 @@ from zml_game_bridge.runtime.db_commands import DbCommandChannel
 from zml_game_bridge.runtime.db_writer import DbWriterWorker
 from zml_game_bridge.runtime.input_coordinator import InputCoordinator
 from zml_game_bridge.runtime.input_processor import CompositeInputProcessor
+from zml_game_bridge.runtime.ocr_input import OcrInputSource
 from zml_game_bridge.runtime.restore import MiningLifecycleRestorer
 from zml_game_bridge.runtime.supervisor import WorkerSupervisor
 from zml_game_bridge.settings import Settings
@@ -35,6 +38,7 @@ class RuntimeComponents:
     pending_db_commands: DbCommandChannel
     persisted_events: InMemoryPersistedEventBus
     position_service: PositionTrackingService
+    ocr_input_source: OcrInputSource
     mining_equipment_service: MiningEquipmentService
     run_session_service: RunSessionService
     mining_coordinator: MiningCoordinator
@@ -43,12 +47,40 @@ class RuntimeComponents:
     lifecycle_restorer: MiningLifecycleRestorer
 
 
-def build_runtime_components(settings: Settings) -> RuntimeComponents:
+def build_runtime_components(
+    settings: Settings,
+    *,
+    supervisor: WorkerSupervisor,
+) -> RuntimeComponents:
     pending_inputs = RuntimeInputChannel()
     pending_events = EventChannel()
     pending_db_commands = DbCommandChannel()
     persisted_events = InMemoryPersistedEventBus()
     position_service = PositionTrackingService()
+
+    def ingest_ocr_position(snapshot: PositionSnapshot) -> None:
+        position_service.ingest_snapshot(snapshot)
+
+    ocr_input_source = EmbeddedOcrInputSource(
+        config=EmbeddedOcrInputConfig(
+            enabled=settings.ocr_enabled,
+            roi_profile_path=settings.ocr_profile_path,
+            finder_recording_modes=settings.finder_recording_modes,
+            finder_recording_dir=settings.finder_recording_dir,
+            finder_recording_interval_s=settings.finder_recording_interval_s,
+            finder_recording_max_samples=settings.finder_recording_max_samples,
+            finder_presence_check_enabled=settings.finder_presence_check_enabled,
+            position_roi_snapshot_enabled=settings.position_roi_snapshot_enabled,
+            position_roi_snapshot_dir=settings.position_roi_snapshot_dir,
+            position_roi_snapshot_interval_s=settings.position_roi_snapshot_interval_s,
+            position_roi_snapshot_max_samples=settings.position_roi_snapshot_max_samples,
+            ocr_profiling_enabled=settings.ocr_profiling_enabled,
+            ocr_profiling_interval_s=settings.ocr_profiling_interval_s,
+        ),
+        supervisor=supervisor,
+        position_sink=ingest_ocr_position,
+        signal_sink=pending_inputs.emit,
+    )
     resource_catalog = MiningResourceCatalog(user_path=settings.mining_resource_catalog_path)
     mining_equipment_service = MiningEquipmentService(path=settings.mining_tools_path)
     run_session_service = RunSessionService(
@@ -114,6 +146,7 @@ def build_runtime_components(settings: Settings) -> RuntimeComponents:
         pending_db_commands=pending_db_commands,
         persisted_events=persisted_events,
         position_service=position_service,
+        ocr_input_source=ocr_input_source,
         mining_equipment_service=mining_equipment_service,
         run_session_service=run_session_service,
         mining_coordinator=mining_coordinator,

--- a/apps/game-bridge/src/zml_game_bridge/runtime/ocr_input.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/ocr_input.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from threading import Event
+from typing import Protocol
+
+
+class OcrInputSource(Protocol):
+    """Runtime boundary for an OCR observation source."""
+
+    def start(self, *, stop_event: Event) -> None:
+        """Start producing OCR positions and finder signals."""
+        ...
+
+    def stop(self) -> None:
+        """Wait for the OCR source to stop after the runtime stop signal is set."""
+        ...

--- a/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/runtime.py
@@ -13,15 +13,9 @@ from zml_game_bridge.application.mining.claims.commands import (
 )
 from zml_game_bridge.application.mining.equipment.service import MiningEquipmentService
 from zml_game_bridge.application.mining.segments.session import RunSessionService
-from zml_game_bridge.application.position.model import PositionSnapshot
 from zml_game_bridge.application.position.tracking import PositionTrackingService
 from zml_game_bridge.inputs.chat.runner import start_chat_input
 from zml_game_bridge.inputs.mock.mining import start_mock_mining_input
-from zml_game_bridge.inputs.ocr.pipelines.position.model import OcrPosition
-from zml_game_bridge.inputs.ocr.runner import start_ocr_input
-from zml_game_bridge.inputs.ocr.tesserocr_runtime import (
-    preload_tesserocr_preserving_sigint_handler,
-)
 from zml_game_bridge.runtime.bootstrap import RuntimeComponents
 from zml_game_bridge.runtime.channels import ChannelClosedError
 from zml_game_bridge.runtime.db_commands import DbCommand
@@ -174,40 +168,7 @@ class AppRuntime:
             },
         )
 
-        if self._settings.ocr_enabled:
-            try:
-                # Needed for 'tesserocr import failed: signal only works in main thread of the main interpreter'
-                preload_tesserocr_preserving_sigint_handler()
-            except Exception as exc:
-                self._supervisor.mark_crashed("ocr_worker", exc)
-                raise
-
-            self._supervisor.start_thread(
-                name="ocr_worker",
-                target=start_ocr_input,
-                worker_kwargs={
-                    "position_sink": self._on_position,
-                    "signal_sink": self._components.pending_inputs.emit,
-                    "capture_status_sink": self._on_ocr_capture_status,
-                    "stop_event": self._stop_event,
-                    "roi_profile_path": self._settings.ocr_profile_path,
-                    "finder_recording_modes": self._settings.finder_recording_modes,
-                    "finder_recording_dir": self._settings.finder_recording_dir,
-                    "finder_recording_interval_s": self._settings.finder_recording_interval_s,
-                    "finder_recording_max_samples": self._settings.finder_recording_max_samples,
-                    "finder_presence_check_enabled": (self._settings.finder_presence_check_enabled),
-                    "position_roi_snapshot_enabled": self._settings.position_roi_snapshot_enabled,
-                    "position_roi_snapshot_dir": self._settings.position_roi_snapshot_dir,
-                    "position_roi_snapshot_interval_s": (
-                        self._settings.position_roi_snapshot_interval_s
-                    ),
-                    "position_roi_snapshot_max_samples": (
-                        self._settings.position_roi_snapshot_max_samples
-                    ),
-                    "ocr_profiling_enabled": self._settings.ocr_profiling_enabled,
-                    "ocr_profiling_interval_s": self._settings.ocr_profiling_interval_s,
-                },
-            )
+        self._components.ocr_input_source.start(stop_event=self._stop_event)
 
         if self._settings.mock_inputs_enabled:
             self._supervisor.start_thread(
@@ -222,25 +183,6 @@ class AppRuntime:
 
         if self._sse_hub is not None:
             self._sub_sse = self._components.persisted_events.subscribe(self._sse_hub.on_envelope)
-
-    def _on_position(self, position: OcrPosition) -> None:
-        self._components.position_service.ingest_snapshot(
-            PositionSnapshot(
-                observed_ts_ms=position.ts_ms,
-                received_ts_ms=time.time_ns() // 1_000_000,
-                position=position.position,
-                source="ocr",
-            )
-        )
-
-    def _on_ocr_capture_status(self, available: bool, error: str | None) -> None:
-        if available:
-            self._supervisor.mark_running("ocr_worker")
-            return
-        self._supervisor.mark_degraded(
-            "ocr_worker",
-            error or "Entropia Universe window is unavailable",
-        )
 
     def _run_claim_expiration_maintenance(self, *, stop_event: threading.Event) -> None:
         interval_s = max(1.0, self._settings.claim_expiration_maintenance_interval_s)
@@ -291,7 +233,7 @@ class AppRuntime:
             self._sub_sse = None
 
         self._supervisor.join_thread("chat_tail")
-        self._supervisor.join_thread("ocr_worker")
+        self._components.ocr_input_source.stop()
         self._supervisor.join_thread("mock_mining_input")
         self._supervisor.join_thread("claim_expiration_maintenance")
 

--- a/apps/game-bridge/tests/inputs/ocr/test_embedded_source.py
+++ b/apps/game-bridge/tests/inputs/ocr/test_embedded_source.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from threading import Event, Thread
+from typing import Any, cast
+
+import pytest
+
+from zml_game_bridge.application.mining.signals.finder import ProbeFiredSignal
+from zml_game_bridge.application.position.model import PositionSnapshot
+from zml_game_bridge.domain.position import WorldPos
+from zml_game_bridge.events.base import SignalBase
+from zml_game_bridge.inputs.ocr.pipelines.position.model import OcrPosition
+from zml_game_bridge.inputs.ocr.source import EmbeddedOcrInputConfig, EmbeddedOcrInputSource
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
+
+
+class _Supervisor:
+    def __init__(self) -> None:
+        self.start_calls: list[tuple[str, Callable[..., None], dict[str, Any]]] = []
+        self.join_calls: list[str] = []
+        self.crashed: list[tuple[str, BaseException]] = []
+        self.running: list[str] = []
+        self.degraded: list[tuple[str, str]] = []
+
+    def start_thread(
+        self,
+        *,
+        name: str,
+        target: Callable[..., None],
+        worker_kwargs: dict[str, Any],
+    ) -> Thread:
+        self.start_calls.append((name, target, worker_kwargs))
+        return cast(Thread, object())
+
+    def join_thread(self, name: str, *, timeout_s: float = 5.0) -> bool:
+        del timeout_s
+        self.join_calls.append(name)
+        return True
+
+    def mark_crashed(self, name: str, exc: BaseException) -> None:
+        self.crashed.append((name, exc))
+
+    def mark_running(self, name: str) -> None:
+        self.running.append(name)
+
+    def mark_degraded(self, name: str, message: str) -> None:
+        self.degraded.append((name, message))
+
+
+def test_embedded_source_wraps_runner_and_maps_outputs() -> None:
+    supervisor = _Supervisor()
+    positions: list[PositionSnapshot] = []
+    signals: list[SignalBase] = []
+    preload_calls = 0
+
+    def preload() -> object:
+        nonlocal preload_calls
+        preload_calls += 1
+        return object()
+
+    def runner(**_kwargs: object) -> None:
+        pass
+
+    source = EmbeddedOcrInputSource(
+        config=_config(),
+        supervisor=cast(WorkerSupervisor, supervisor),
+        position_sink=positions.append,
+        signal_sink=signals.append,
+        runner=runner,
+        preloader=preload,
+        clock_ms=lambda: 2_000,
+    )
+    stop_event = Event()
+
+    source.start(stop_event=stop_event)
+
+    assert preload_calls == 1
+    assert len(supervisor.start_calls) == 1
+    worker_name, worker_target, worker_kwargs = supervisor.start_calls[0]
+    assert worker_name == "ocr_worker"
+    assert worker_target is runner
+    assert worker_kwargs["stop_event"] is stop_event
+    assert worker_kwargs["roi_profile_path"] == Path("ocr-profile.json")
+
+    position_sink = cast(Callable[[OcrPosition], None], worker_kwargs["position_sink"])
+    position_sink(
+        OcrPosition(
+            ts_ms=1_000,
+            position=WorldPos(planet_name="Calypso", x=58_000, y=84_000, z=None),
+        )
+    )
+    assert positions == [
+        PositionSnapshot(
+            observed_ts_ms=1_000,
+            received_ts_ms=2_000,
+            position=WorldPos(planet_name="Calypso", x=58_000, y=84_000, z=None),
+            source="ocr",
+        )
+    ]
+
+    signal = ProbeFiredSignal(
+        ts_ms=1_500,
+        position=None,
+        modes_mask=1,
+        probes_per_drop=1,
+        ammo_per_drop=None,
+        raw_status_text="Searching",
+        roi_name="finder",
+    )
+    signal_sink = cast(Callable[[SignalBase], None], worker_kwargs["signal_sink"])
+    signal_sink(signal)
+    assert signals == [signal]
+
+    capture_status_sink = cast(
+        Callable[[bool, str | None], None], worker_kwargs["capture_status_sink"]
+    )
+    capture_status_sink(False, "window missing")
+    capture_status_sink(True, None)
+    assert supervisor.degraded == [("ocr_worker", "window missing")]
+    assert supervisor.running == ["ocr_worker"]
+
+    source.stop()
+    assert supervisor.join_calls == ["ocr_worker"]
+
+
+def test_embedded_source_is_noop_when_disabled() -> None:
+    supervisor = _Supervisor()
+    source = EmbeddedOcrInputSource(
+        config=_config(enabled=False),
+        supervisor=cast(WorkerSupervisor, supervisor),
+        position_sink=lambda _snapshot: None,
+        signal_sink=lambda _signal: None,
+        preloader=lambda: pytest.fail("disabled source must not preload tesserocr"),
+    )
+
+    source.start(stop_event=Event())
+    source.stop()
+
+    assert supervisor.start_calls == []
+    assert supervisor.join_calls == []
+
+
+def test_embedded_source_marks_preload_failure_as_crashed() -> None:
+    supervisor = _Supervisor()
+    error = RuntimeError("tesserocr unavailable")
+
+    def fail_preload() -> object:
+        raise error
+
+    source = EmbeddedOcrInputSource(
+        config=_config(),
+        supervisor=cast(WorkerSupervisor, supervisor),
+        position_sink=lambda _snapshot: None,
+        signal_sink=lambda _signal: None,
+        preloader=fail_preload,
+    )
+
+    with pytest.raises(RuntimeError, match="tesserocr unavailable"):
+        source.start(stop_event=Event())
+
+    assert supervisor.crashed == [("ocr_worker", error)]
+    assert supervisor.start_calls == []
+
+
+def _config(*, enabled: bool = True) -> EmbeddedOcrInputConfig:
+    return EmbeddedOcrInputConfig(
+        enabled=enabled,
+        roi_profile_path=Path("ocr-profile.json"),
+        finder_recording_modes="off",
+        finder_recording_dir=Path("finder-recordings"),
+        finder_recording_interval_s=1.5,
+        finder_recording_max_samples=50,
+        finder_presence_check_enabled=True,
+        position_roi_snapshot_enabled=False,
+        position_roi_snapshot_dir=Path("position-snapshots"),
+        position_roi_snapshot_interval_s=2.5,
+        position_roi_snapshot_max_samples=25,
+        ocr_profiling_enabled=True,
+        ocr_profiling_interval_s=10.0,
+    )

--- a/apps/game-bridge/tests/runtime/test_runtime_ocr_input.py
+++ b/apps/game-bridge/tests/runtime/test_runtime_ocr_input.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Event
+from typing import Any, cast
+
+from zml_game_bridge.runtime.bootstrap import RuntimeComponents
+from zml_game_bridge.runtime.runtime import AppRuntime
+from zml_game_bridge.runtime.shutdown_signal import RuntimeShutdownSignal
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
+from zml_game_bridge.settings import Settings
+
+
+class _OcrInputSource:
+    def __init__(self) -> None:
+        self.stop_event: Event | None = None
+        self.stop_calls = 0
+
+    def start(self, *, stop_event: Event) -> None:
+        self.stop_event = stop_event
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+
+class _PositionService:
+    def set_publisher(self, _publisher: object) -> None:
+        pass
+
+
+class _Channel:
+    def __init__(self) -> None:
+        self.closed = False
+        self.items: list[object] = []
+
+    def emit(self, item: object) -> None:
+        self.items.append(item)
+
+    def is_closed(self) -> bool:
+        return self.closed
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _Worker:
+    def run(self, *, stop_event: Event) -> None:
+        del stop_event
+
+
+class _Restorer:
+    def __init__(self) -> None:
+        self.restore_calls = 0
+
+    def restore(self) -> None:
+        self.restore_calls += 1
+
+
+class _Supervisor:
+    def __init__(self) -> None:
+        self.started: list[str] = []
+        self.joined: list[str] = []
+
+    def start_thread(self, *, name: str, target: object, worker_kwargs: dict[str, Any]) -> None:
+        del target, worker_kwargs
+        self.started.append(name)
+
+    def join_thread(self, name: str, *, timeout_s: float = 5.0) -> bool:
+        del timeout_s
+        self.joined.append(name)
+        return True
+
+    def health(self) -> dict[str, object]:
+        return {}
+
+
+class _ShutdownSignal:
+    def __init__(self) -> None:
+        self.install_calls = 0
+
+    def install_signal_forwarders(self) -> None:
+        self.install_calls += 1
+
+
+def test_app_runtime_delegates_ocr_lifecycle_to_input_source() -> None:
+    ocr_source = _OcrInputSource()
+    pending_inputs = _Channel()
+    pending_events = _Channel()
+    pending_db_commands = _Channel()
+    restorer = _Restorer()
+    components = cast(
+        RuntimeComponents,
+        _Components(
+            ocr_source=ocr_source,
+            pending_inputs=pending_inputs,
+            pending_events=pending_events,
+            pending_db_commands=pending_db_commands,
+            restorer=restorer,
+        ),
+    )
+    supervisor = _Supervisor()
+    shutdown_signal = _ShutdownSignal()
+    runtime = AppRuntime(
+        settings=Settings(
+            chat_log_path=Path("chat.log"),
+            ocr_enabled=True,
+            mock_inputs_enabled=False,
+            claim_expiration_maintenance_enabled=False,
+        ),
+        components=components,
+        supervisor=cast(WorkerSupervisor, supervisor),
+        shutdown_signal=cast(RuntimeShutdownSignal, shutdown_signal),
+    )
+
+    runtime.start()
+
+    assert ocr_source.stop_event is not None
+    assert not ocr_source.stop_event.is_set()
+    assert "ocr_worker" not in supervisor.started
+    assert restorer.restore_calls == 1
+    assert shutdown_signal.install_calls == 1
+
+    runtime.stop()
+
+    assert ocr_source.stop_event.is_set()
+    assert ocr_source.stop_calls == 1
+    assert "ocr_worker" not in supervisor.joined
+    assert pending_inputs.closed
+    assert pending_events.closed
+    assert pending_db_commands.closed
+
+
+class _Components:
+    def __init__(
+        self,
+        *,
+        ocr_source: _OcrInputSource,
+        pending_inputs: _Channel,
+        pending_events: _Channel,
+        pending_db_commands: _Channel,
+        restorer: _Restorer,
+    ) -> None:
+        self.pending_inputs = pending_inputs
+        self.pending_events = pending_events
+        self.pending_db_commands = pending_db_commands
+        self.persisted_events = object()
+        self.position_service = _PositionService()
+        self.ocr_input_source = ocr_source
+        self.mining_equipment_service = object()
+        self.run_session_service = object()
+        self.mining_coordinator = object()
+        self.input_coordinator = _Worker()
+        self.db_writer_worker = _Worker()
+        self.lifecycle_restorer = restorer

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -58,6 +58,9 @@ Z Mining Log is now a working local mining tracker prototype:
   - missing/lost Entropia window degrades health and retries instead of crashing OCR;
   - OCR still runs in-process, but `packages/ocr-protocol` now defines the
     strict version 1 DTO and NDJSON boundary for the planned OCR Agent;
+  - `AppRuntime` owns only the `OcrInputSource` lifecycle while
+    `EmbeddedOcrInputSource` adapts the current runner, position snapshots,
+    finder signals, preload, and worker health without changing behavior;
   - finder application signals live under `application.mining.signals.finder`,
     so mining logic no longer imports signal types from `inputs.ocr`.
 - Desktop lifecycle and packaging:
@@ -81,7 +84,7 @@ See `ROADMAP_2025-05-26.md` for the ordered roadmap. The highest-value items are
 
 1. Managed OCR Agent migration:
    - create the standalone OCR Agent application;
-   - add the embedded adapter and then subprocess supervisor behind a rollback flag;
+   - add the subprocess supervisor behind a rollback flag;
    - synchronize full configuration snapshots and validate real-game behavior;
    - package both executables before removing embedded OCR.
 


### PR DESCRIPTION
## What changed

- introduce the runtime `OcrInputSource` lifecycle port
- add `EmbeddedOcrInputSource` around the existing in-process OCR runner
- move tesserocr preload, OCR runner arguments, capture health mapping, and `OcrPosition` conversion into the embedded adapter
- build the input source in `runtime/bootstrap.py`
- make `AppRuntime` start and stop only the abstract OCR source
- keep OCR positions on the existing ephemeral `PositionTrackingService` path
- keep finder signals on `RuntimeInputChannel`
- update current-state and roadmap documentation

## Why

This removes OCR implementation knowledge from `AppRuntime` and creates the seam needed for the standalone OCR Agent and subprocess transport in later migration PRs.

## Runtime impact

OCR still runs in-process with the same runner, worker name, preload behavior, configuration values, capture degradation reporting, position mapping, and finder signal path. No OCR pipeline has moved.

## Validation

- focused new boundary tests: 5 passed
- Game Bridge runtime + application position + OCR regression suite: 70 passed
- Ruff check passed for touched Python files
- Ruff format check passed
- Pyright passed with 0 errors and 0 warnings
- `AppRuntime` boundary scan contains no OCR implementation imports or models
- `git diff --check` passed
