### PR TITLE
PR 4: Add managed OCR Agent subprocess supervisor

### DIFF
--- a/ROADMAP_2025-05-26.md
+++ b/ROADMAP_2025-05-26.md
@@ -63,7 +63,12 @@ Legend:
      - its runner emits protocol DTOs and has independent `--version`, `doctor`, and `stdio`
        entrypoints;
      - protocol mode emits `hello`, accepts `shutdown`, and the agent imports no Game Bridge code.
-   - Next add the subprocess supervisor, config resync, restart policy, integration tests,
+   - Managed subprocess done 2026-08-09:
+     - `ZML_OCR_TRANSPORT=agent` selects a child process while `embedded` remains the default;
+     - Game Bridge validates `hello`, drains stdout/stderr, monitors heartbeat, maps position and
+       finder messages, and restarts failures with bounded exponential backoff;
+     - worker health distinguishes process/restart failures from an unavailable capture window.
+   - Next add revisioned config resync, deterministic process integration coverage,
      real-game smoke validation, and two-executable packaging.
    - Keep the embedded rollback transport until agent mode survives gameplay and packaged release
      validation.

--- a/apps/game-bridge/README.md
+++ b/apps/game-bridge/README.md
@@ -57,6 +57,9 @@ Input modes:
 - `ZML_MINING_RESOURCE_CATALOG_PATH`: optional override for learned/user mining resources JSON.
 - `ZML_CHAT_START_AT_END`: start tailing from the end of the file, defaults to `true`.
 - `ZML_OCR_ENABLED`: enable live OCR input.
+- `ZML_OCR_TRANSPORT`: `embedded` (default rollback path) or `agent` (managed child process).
+- `ZML_OCR_AGENT_PATH`: optional path to a standalone OCR Agent executable; source runs use the
+  current Python environment and `python -m zml_ocr_agent stdio` when this is unset.
 - `ZML_MOCK_INPUTS`: enable mock mining input.
 - `ZML_MOCK_MINING_INTERVAL_MS`: mock drop interval.
 - `ZML_FINDER_DEBUG`: enable detailed finder OCR debug logging.

--- a/apps/game-bridge/src/zml_game_bridge/api/schemas/health.py
+++ b/apps/game-bridge/src/zml_game_bridge/api/schemas/health.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 WorkerStateDto = Literal["running", "degraded", "crashed", "stopped"]
+HealthDetailDto = str | int | float | bool | None
 
 
 class WorkerHealthDto(BaseModel):
@@ -12,6 +13,7 @@ class WorkerHealthDto(BaseModel):
     enabled: bool
     last_error: str | None
     last_seen_ts_ms: int
+    details: dict[str, HealthDetailDto] = Field(default_factory=dict)
 
 
 class HealthDto(BaseModel):

--- a/apps/game-bridge/src/zml_game_bridge/dev_cli.py
+++ b/apps/game-bridge/src/zml_game_bridge/dev_cli.py
@@ -130,6 +130,8 @@ def _settings_table(settings: Settings) -> Table:
     )
     table.add_row("chat_start_at_end", _format_bool(settings.chat_start_at_end))
     table.add_row("ocr_enabled", _format_bool(settings.ocr_enabled))
+    table.add_row("ocr_transport", settings.ocr_transport)
+    table.add_row("ocr_agent_path", _format_path(settings.ocr_agent_path))
     table.add_row("mock_inputs_enabled", _format_bool(settings.mock_inputs_enabled))
     table.add_row("mock_mining_interval_ms", str(settings.mock_mining_interval_ms))
     table.add_row(

--- a/apps/game-bridge/src/zml_game_bridge/inputs/ocr/source.py
+++ b/apps/game-bridge/src/zml_game_bridge/inputs/ocr/source.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,18 +15,9 @@ from zml_ocr_protocol import (
     StatusMessage,
 )
 
-from zml_game_bridge.application.mining.signals.finder import (
-    FinderHitHintSignal,
-    FinderModeInvalidatedSignal,
-    FinderModesChangedSignal,
-    FinderNoResourcesSignal,
-    FinderUnitsChangedSignal,
-    ProbeFiredSignal,
-)
 from zml_game_bridge.application.position.model import PositionSnapshot
-from zml_game_bridge.domain.position import WorldPos
-from zml_game_bridge.events.base import SignalBase
 from zml_game_bridge.events.contracts import SignalSink
+from zml_game_bridge.runtime.ocr_agent.message_mapper import OcrAgentMessageMapper
 from zml_game_bridge.runtime.supervisor import WorkerSupervisor
 
 _OCR_WORKER_NAME = "ocr_worker"
@@ -71,11 +61,13 @@ class EmbeddedOcrInputSource:
     ) -> None:
         self._config = config
         self._supervisor = supervisor
-        self._position_sink = position_sink
-        self._signal_sink = signal_sink
+        self._mapper = OcrAgentMessageMapper(
+            position_sink=position_sink,
+            signal_sink=signal_sink,
+            clock_ms=clock_ms,
+        )
         self._runner = runner
         self._preloader = preloader
-        self._clock_ms = clock_ms or _now_ms
 
     def start(self, *, stop_event: Event) -> None:
         if not self._config.enabled:
@@ -118,29 +110,13 @@ class EmbeddedOcrInputSource:
 
     def _on_message(self, message: AgentToBridgeMessage) -> None:
         if isinstance(message, PositionMessage):
-            self._on_position(message)
+            self._mapper.map_position(message)
             return
         if isinstance(message, FinderSignalMessage):
-            self._signal_sink(_to_finder_signal(message))
+            self._mapper.map_finder(message)
             return
         if isinstance(message, StatusMessage):
             self._on_status(message)
-
-    def _on_position(self, message: PositionMessage) -> None:
-        position = message.payload.position
-        self._position_sink(
-            PositionSnapshot(
-                observed_ts_ms=message.observed_ts_ms,
-                received_ts_ms=self._clock_ms(),
-                position=WorldPos(
-                    planet_name=position.planet_name,
-                    x=position.x,
-                    y=position.y,
-                    z=position.z,
-                ),
-                source="ocr",
-            )
-        )
 
     def _on_status(self, message: StatusMessage) -> None:
         if message.payload.state == "running":
@@ -150,65 +126,3 @@ class EmbeddedOcrInputSource:
             _OCR_WORKER_NAME,
             message.payload.detail or "Entropia Universe window is unavailable",
         )
-
-
-def _now_ms() -> int:
-    return time.time_ns() // 1_000_000
-
-
-def _to_finder_signal(message: FinderSignalMessage) -> SignalBase:
-    payload = message.payload
-    match payload.kind:
-        case "probe_fired":
-            return ProbeFiredSignal(
-                ts_ms=message.observed_ts_ms,
-                # The runtime coordinator snapshots current position through PositionProvider.
-                position=None,
-                modes_mask=payload.modes_mask,
-                probes_per_drop=payload.probes_per_drop,
-                ammo_per_drop=payload.ammo_per_drop,
-                raw_status_text=payload.raw_status_text,
-                roi_name=payload.roi_name,
-                debug=payload.debug,
-            )
-        case "finder_modes_changed":
-            return FinderModesChangedSignal(
-                ts_ms=message.observed_ts_ms,
-                modes_mask=payload.modes_mask,
-                previous_modes_mask=payload.previous_modes_mask,
-                roi_name=payload.roi_name,
-                debug=payload.debug,
-            )
-        case "finder_mode_invalidated":
-            return FinderModeInvalidatedSignal(
-                ts_ms=message.observed_ts_ms,
-                previous_modes_mask=payload.previous_modes_mask,
-                roi_name=payload.roi_name,
-                debug=payload.debug,
-            )
-        case "finder_units_changed":
-            return FinderUnitsChangedSignal(
-                ts_ms=message.observed_ts_ms,
-                probes_per_drop=payload.probes_per_drop,
-                ammo_per_drop=payload.ammo_per_drop,
-                raw_text=payload.raw_units_text,
-                roi_name=payload.roi_name,
-            )
-        case "finder_hit_hint":
-            return FinderHitHintSignal(
-                ts_ms=message.observed_ts_ms,
-                size_label=payload.size_label,
-                size_index=payload.size_index,
-                resource_name=payload.resource_name,
-                range_m=payload.range_m,
-                depth_m=payload.depth_m,
-                raw_status_text=payload.raw_status_text,
-                raw_details_text=payload.raw_details_text,
-                roi_name=payload.roi_name,
-            )
-        case "finder_no_resources":
-            return FinderNoResourcesSignal(
-                ts_ms=message.observed_ts_ms,
-                raw_status_text=payload.raw_status_text,
-                roi_name=payload.roi_name,
-            )

--- a/apps/game-bridge/src/zml_game_bridge/runtime/bootstrap.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/bootstrap.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from zml_game_bridge.application.mining import MiningCoordinator
@@ -12,6 +14,7 @@ from zml_game_bridge.application.mining.settings import default_id_factory
 from zml_game_bridge.application.position.input_processor import PositionInputProcessor
 from zml_game_bridge.application.position.model import PositionSnapshot
 from zml_game_bridge.application.position.tracking import PositionTrackingService
+from zml_game_bridge.events.contracts import SignalSink
 from zml_game_bridge.events.in_memory_persisted_event_bus import InMemoryPersistedEventBus
 from zml_game_bridge.inputs.ocr.source import EmbeddedOcrInputConfig, EmbeddedOcrInputSource
 from zml_game_bridge.persistence.event_projector import CompositeEventProjector
@@ -25,6 +28,11 @@ from zml_game_bridge.runtime.db_commands import DbCommandChannel
 from zml_game_bridge.runtime.db_writer import DbWriterWorker
 from zml_game_bridge.runtime.input_coordinator import InputCoordinator
 from zml_game_bridge.runtime.input_processor import CompositeInputProcessor
+from zml_game_bridge.runtime.ocr_agent.process_transport import OcrAgentProcessConfig
+from zml_game_bridge.runtime.ocr_agent.supervisor import (
+    OcrAgentSupervisor,
+    OcrAgentSupervisorConfig,
+)
 from zml_game_bridge.runtime.ocr_input import OcrInputSource
 from zml_game_bridge.runtime.restore import MiningLifecycleRestorer
 from zml_game_bridge.runtime.supervisor import WorkerSupervisor
@@ -61,22 +69,8 @@ def build_runtime_components(
     def ingest_ocr_position(snapshot: PositionSnapshot) -> None:
         position_service.ingest_snapshot(snapshot)
 
-    ocr_input_source = EmbeddedOcrInputSource(
-        config=EmbeddedOcrInputConfig(
-            enabled=settings.ocr_enabled,
-            roi_profile_path=settings.ocr_profile_path,
-            finder_recording_modes=settings.finder_recording_modes,
-            finder_recording_dir=settings.finder_recording_dir,
-            finder_recording_interval_s=settings.finder_recording_interval_s,
-            finder_recording_max_samples=settings.finder_recording_max_samples,
-            finder_presence_check_enabled=settings.finder_presence_check_enabled,
-            position_roi_snapshot_enabled=settings.position_roi_snapshot_enabled,
-            position_roi_snapshot_dir=settings.position_roi_snapshot_dir,
-            position_roi_snapshot_interval_s=settings.position_roi_snapshot_interval_s,
-            position_roi_snapshot_max_samples=settings.position_roi_snapshot_max_samples,
-            ocr_profiling_enabled=settings.ocr_profiling_enabled,
-            ocr_profiling_interval_s=settings.ocr_profiling_interval_s,
-        ),
+    ocr_input_source = build_ocr_input_source(
+        settings,
         supervisor=supervisor,
         position_sink=ingest_ocr_position,
         signal_sink=pending_inputs.emit,
@@ -154,6 +148,75 @@ def build_runtime_components(
         db_writer_worker=db_writer_worker,
         lifecycle_restorer=lifecycle_restorer,
     )
+
+
+def build_ocr_input_source(
+    settings: Settings,
+    *,
+    supervisor: WorkerSupervisor,
+    position_sink: Callable[[PositionSnapshot], None],
+    signal_sink: SignalSink,
+) -> OcrInputSource:
+    if settings.ocr_transport == "agent":
+        command = (
+            (str(settings.ocr_agent_path), "stdio")
+            if settings.ocr_agent_path is not None
+            else (sys.executable, "-m", "zml_ocr_agent", "stdio")
+        )
+        return OcrAgentSupervisor(
+            config=OcrAgentSupervisorConfig(
+                enabled=settings.ocr_enabled,
+                process=OcrAgentProcessConfig(
+                    command=command,
+                    environment=_ocr_agent_environment(settings),
+                ),
+            ),
+            supervisor=supervisor,
+            position_sink=position_sink,
+            signal_sink=signal_sink,
+        )
+
+    return EmbeddedOcrInputSource(
+        config=EmbeddedOcrInputConfig(
+            enabled=settings.ocr_enabled,
+            roi_profile_path=settings.ocr_profile_path,
+            finder_recording_modes=settings.finder_recording_modes,
+            finder_recording_dir=settings.finder_recording_dir,
+            finder_recording_interval_s=settings.finder_recording_interval_s,
+            finder_recording_max_samples=settings.finder_recording_max_samples,
+            finder_presence_check_enabled=settings.finder_presence_check_enabled,
+            position_roi_snapshot_enabled=settings.position_roi_snapshot_enabled,
+            position_roi_snapshot_dir=settings.position_roi_snapshot_dir,
+            position_roi_snapshot_interval_s=settings.position_roi_snapshot_interval_s,
+            position_roi_snapshot_max_samples=settings.position_roi_snapshot_max_samples,
+            ocr_profiling_enabled=settings.ocr_profiling_enabled,
+            ocr_profiling_interval_s=settings.ocr_profiling_interval_s,
+        ),
+        supervisor=supervisor,
+        position_sink=position_sink,
+        signal_sink=signal_sink,
+    )
+
+
+def _ocr_agent_environment(settings: Settings) -> dict[str, str]:
+    return {
+        "ZML_OCR_PROFILE_PATH": str(settings.ocr_profile_path),
+        "ZML_FINDER_RECORDING": settings.finder_recording_modes,
+        "ZML_FINDER_RECORDING_DIR": str(settings.finder_recording_dir),
+        "ZML_FINDER_RECORDING_INTERVAL_S": str(settings.finder_recording_interval_s),
+        "ZML_FINDER_RECORDING_MAX_SAMPLES": str(settings.finder_recording_max_samples),
+        "ZML_FINDER_PRESENCE_CHECK": _env_bool(settings.finder_presence_check_enabled),
+        "ZML_POSITION_ROI_SNAPSHOTS": _env_bool(settings.position_roi_snapshot_enabled),
+        "ZML_POSITION_ROI_SNAPSHOT_DIR": str(settings.position_roi_snapshot_dir),
+        "ZML_POSITION_ROI_SNAPSHOT_INTERVAL_S": str(settings.position_roi_snapshot_interval_s),
+        "ZML_POSITION_ROI_SNAPSHOT_MAX_SAMPLES": str(settings.position_roi_snapshot_max_samples),
+        "ZML_OCR_PROFILING": _env_bool(settings.ocr_profiling_enabled),
+        "ZML_OCR_PROFILING_INTERVAL_S": str(settings.ocr_profiling_interval_s),
+    }
+
+
+def _env_bool(value: bool) -> str:
+    return "1" if value else "0"
 
 
 def build_worker_supervisor(settings: Settings) -> WorkerSupervisor:

--- a/apps/game-bridge/src/zml_game_bridge/runtime/ocr_agent/__init__.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/ocr_agent/__init__.py
@@ -1,0 +1,1 @@
+"""Managed OCR Agent process transport and protocol mapping."""

--- a/apps/game-bridge/src/zml_game_bridge/runtime/ocr_agent/message_mapper.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/ocr_agent/message_mapper.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+from zml_ocr_protocol import FinderSignalMessage, PositionMessage
+
+from zml_game_bridge.application.mining.signals.finder import (
+    FinderHitHintSignal,
+    FinderModeInvalidatedSignal,
+    FinderModesChangedSignal,
+    FinderNoResourcesSignal,
+    FinderUnitsChangedSignal,
+    ProbeFiredSignal,
+)
+from zml_game_bridge.application.position.model import PositionSnapshot
+from zml_game_bridge.domain.position import WorldPos
+from zml_game_bridge.events.base import SignalBase
+from zml_game_bridge.events.contracts import SignalSink
+
+PositionSnapshotSink = Callable[[PositionSnapshot], None]
+ClockMs = Callable[[], int]
+
+
+class OcrAgentMessageMapper:
+    def __init__(
+        self,
+        *,
+        position_sink: PositionSnapshotSink,
+        signal_sink: SignalSink,
+        clock_ms: ClockMs | None = None,
+    ) -> None:
+        self._position_sink = position_sink
+        self._signal_sink = signal_sink
+        self._clock_ms = clock_ms or _now_ms
+
+    def map_position(self, message: PositionMessage) -> None:
+        position = message.payload.position
+        self._position_sink(
+            PositionSnapshot(
+                observed_ts_ms=message.observed_ts_ms,
+                received_ts_ms=self._clock_ms(),
+                position=WorldPos(
+                    planet_name=position.planet_name,
+                    x=position.x,
+                    y=position.y,
+                    z=position.z,
+                ),
+                source="ocr",
+            )
+        )
+
+    def map_finder(self, message: FinderSignalMessage) -> None:
+        self._signal_sink(_to_finder_signal(message))
+
+
+def _to_finder_signal(message: FinderSignalMessage) -> SignalBase:
+    payload = message.payload
+    match payload.kind:
+        case "probe_fired":
+            return ProbeFiredSignal(
+                ts_ms=message.observed_ts_ms,
+                # The runtime coordinator snapshots current position through PositionProvider.
+                position=None,
+                modes_mask=payload.modes_mask,
+                probes_per_drop=payload.probes_per_drop,
+                ammo_per_drop=payload.ammo_per_drop,
+                raw_status_text=payload.raw_status_text,
+                roi_name=payload.roi_name,
+                debug=payload.debug,
+            )
+        case "finder_modes_changed":
+            return FinderModesChangedSignal(
+                ts_ms=message.observed_ts_ms,
+                modes_mask=payload.modes_mask,
+                previous_modes_mask=payload.previous_modes_mask,
+                roi_name=payload.roi_name,
+                debug=payload.debug,
+            )
+        case "finder_mode_invalidated":
+            return FinderModeInvalidatedSignal(
+                ts_ms=message.observed_ts_ms,
+                previous_modes_mask=payload.previous_modes_mask,
+                roi_name=payload.roi_name,
+                debug=payload.debug,
+            )
+        case "finder_units_changed":
+            return FinderUnitsChangedSignal(
+                ts_ms=message.observed_ts_ms,
+                probes_per_drop=payload.probes_per_drop,
+                ammo_per_drop=payload.ammo_per_drop,
+                raw_text=payload.raw_units_text,
+                roi_name=payload.roi_name,
+            )
+        case "finder_hit_hint":
+            return FinderHitHintSignal(
+                ts_ms=message.observed_ts_ms,
+                size_label=payload.size_label,
+                size_index=payload.size_index,
+                resource_name=payload.resource_name,
+                range_m=payload.range_m,
+                depth_m=payload.depth_m,
+                raw_status_text=payload.raw_status_text,
+                raw_details_text=payload.raw_details_text,
+                roi_name=payload.roi_name,
+            )
+        case "finder_no_resources":
+            return FinderNoResourcesSignal(
+                ts_ms=message.observed_ts_ms,
+                raw_status_text=payload.raw_status_text,
+                roi_name=payload.roi_name,
+            )
+
+
+def _now_ms() -> int:
+    return time.time_ns() // 1_000_000

--- a/apps/game-bridge/src/zml_game_bridge/runtime/ocr_agent/process_transport.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/ocr_agent/process_transport.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from zml_ocr_protocol import BridgeToAgentMessage, encode_message
+
+
+class OcrProcessTransport(Protocol):
+    @property
+    def pid(self) -> int: ...
+
+    def start(self) -> None: ...
+
+    def read_stdout_line(self) -> bytes: ...
+
+    def read_stderr_line(self) -> bytes: ...
+
+    def send(self, message: BridgeToAgentMessage) -> None: ...
+
+    def poll(self) -> int | None: ...
+
+    def wait(self, *, timeout_s: float) -> int | None: ...
+
+    def close_stdin(self) -> None: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class OcrAgentProcessConfig:
+    command: tuple[str, ...]
+    environment: Mapping[str, str]
+    cwd: Path | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "command", normalize_command(self.command))
+
+
+class StdioOcrProcessTransport:
+    def __init__(self, config: OcrAgentProcessConfig) -> None:
+        self._config = config
+        self._process: subprocess.Popen[bytes] | None = None
+        self._write_lock = threading.Lock()
+
+    @property
+    def pid(self) -> int:
+        return self._require_process().pid
+
+    def start(self) -> None:
+        if self._process is not None:
+            raise RuntimeError("OCR Agent transport is already started")
+        if not self._config.command:
+            raise ValueError("OCR Agent command cannot be empty")
+
+        environment = dict(os.environ)
+        environment.update(self._config.environment)
+        self._process = subprocess.Popen(
+            list(self._config.command),
+            cwd=self._config.cwd,
+            env=environment,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+
+    def read_stdout_line(self) -> bytes:
+        process = self._require_process()
+        if process.stdout is None:
+            raise RuntimeError("OCR Agent stdout pipe is unavailable")
+        return process.stdout.readline()
+
+    def read_stderr_line(self) -> bytes:
+        process = self._require_process()
+        if process.stderr is None:
+            raise RuntimeError("OCR Agent stderr pipe is unavailable")
+        return process.stderr.readline()
+
+    def send(self, message: BridgeToAgentMessage) -> None:
+        process = self._require_process()
+        if process.stdin is None:
+            raise RuntimeError("OCR Agent stdin pipe is unavailable")
+        encoded = encode_message(message)
+        with self._write_lock:
+            process.stdin.write(encoded)
+            process.stdin.flush()
+
+    def poll(self) -> int | None:
+        return self._require_process().poll()
+
+    def wait(self, *, timeout_s: float) -> int | None:
+        try:
+            return self._require_process().wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            return None
+
+    def close_stdin(self) -> None:
+        process = self._require_process()
+        if process.stdin is not None and not process.stdin.closed:
+            process.stdin.close()
+
+    def terminate(self) -> None:
+        process = self._require_process()
+        if process.poll() is None:
+            process.terminate()
+
+    def kill(self) -> None:
+        process = self._require_process()
+        if process.poll() is None:
+            process.kill()
+
+    def _require_process(self) -> subprocess.Popen[bytes]:
+        if self._process is None:
+            raise RuntimeError("OCR Agent transport is not started")
+        return self._process
+
+
+def normalize_command(command: Sequence[str]) -> tuple[str, ...]:
+    normalized = tuple(part for part in command if part.strip())
+    if not normalized:
+        raise ValueError("OCR Agent command cannot be empty")
+    return normalized

--- a/apps/game-bridge/src/zml_game_bridge/runtime/ocr_agent/supervisor.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/ocr_agent/supervisor.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from zml_ocr_protocol import (
+    AgentToBridgeMessage,
+    FinderSignalMessage,
+    HeartbeatMessage,
+    HelloMessage,
+    OcrProtocolError,
+    PositionMessage,
+    ShutdownCommand,
+    ShutdownPayload,
+    StatusMessage,
+    decode_agent_message,
+)
+from zml_ocr_protocol.messages import AgentStatusState
+
+from zml_game_bridge.events.contracts import SignalSink
+from zml_game_bridge.runtime.ocr_agent.message_mapper import (
+    ClockMs,
+    OcrAgentMessageMapper,
+    PositionSnapshotSink,
+)
+from zml_game_bridge.runtime.ocr_agent.process_transport import (
+    OcrAgentProcessConfig,
+    OcrProcessTransport,
+    StdioOcrProcessTransport,
+)
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
+
+logger = logging.getLogger(__name__)
+
+_OCR_WORKER_NAME = "ocr_worker"
+_REQUIRED_CAPABILITIES = frozenset({"position", "finder", "status", "heartbeat"})
+_FATAL_AGENT_STATUS_CODES = frozenset({"ocr_preload_failed", "ocr_runner_crashed"})
+
+MonotonicClock = Callable[[], float]
+TransportFactory = Callable[[], OcrProcessTransport]
+
+
+class OcrAgentProcessError(RuntimeError):
+    """The child process or its protocol stream became unusable."""
+
+
+@dataclass(frozen=True, slots=True)
+class RestartPolicy:
+    delays_s: tuple[float, ...] = (0.5, 1.0, 2.0, 4.0)
+    max_restarts_per_window: int = 4
+    window_s: float = 60.0
+    stable_reset_s: float = 30.0
+
+    def __post_init__(self) -> None:
+        if not self.delays_s or any(delay < 0 for delay in self.delays_s):
+            raise ValueError("restart delays must contain non-negative values")
+        if self.max_restarts_per_window < 1:
+            raise ValueError("max_restarts_per_window must be positive")
+        if self.window_s <= 0 or self.stable_reset_s <= 0:
+            raise ValueError("restart windows must be positive")
+
+    def delay_after_failure(
+        self,
+        *,
+        failure_times: list[float],
+        now: float,
+        consecutive_failures: int,
+    ) -> float:
+        failure_times[:] = [value for value in failure_times if now - value < self.window_s]
+        failure_times.append(now)
+        if len(failure_times) > self.max_restarts_per_window:
+            return max(0.0, self.window_s - (now - failure_times[0]))
+        index = min(max(0, consecutive_failures - 1), len(self.delays_s) - 1)
+        return self.delays_s[index]
+
+
+@dataclass(frozen=True, slots=True)
+class OcrAgentSupervisorConfig:
+    enabled: bool
+    process: OcrAgentProcessConfig
+    handshake_timeout_s: float = 5.0
+    heartbeat_timeout_s: float = 8.0
+    monitor_interval_s: float = 0.05
+    restart: RestartPolicy = field(default_factory=RestartPolicy)
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessRunResult:
+    error: BaseException | None
+    uptime_s: float
+
+
+class OcrAgentSupervisor:
+    """Run OCR Agent as a restartable child while implementing OcrInputSource."""
+
+    def __init__(
+        self,
+        *,
+        config: OcrAgentSupervisorConfig,
+        supervisor: WorkerSupervisor,
+        position_sink: PositionSnapshotSink,
+        signal_sink: SignalSink,
+        transport_factory: TransportFactory | None = None,
+        monotonic: MonotonicClock | None = None,
+        clock_ms: ClockMs | None = None,
+    ) -> None:
+        self._config = config
+        self._supervisor = supervisor
+        self._mapper = OcrAgentMessageMapper(
+            position_sink=position_sink,
+            signal_sink=signal_sink,
+            clock_ms=clock_ms,
+        )
+        self._transport_factory = transport_factory or (
+            lambda: StdioOcrProcessTransport(config.process)
+        )
+        self._monotonic = monotonic or time.monotonic
+
+    @property
+    def config(self) -> OcrAgentSupervisorConfig:
+        return self._config
+
+    def start(self, *, stop_event: threading.Event) -> None:
+        if not self._config.enabled:
+            return
+        self._supervisor.start_thread(
+            name=_OCR_WORKER_NAME,
+            target=self._run,
+            worker_kwargs={"stop_event": stop_event},
+        )
+
+    def stop(self) -> None:
+        if self._config.enabled:
+            self._supervisor.join_thread(_OCR_WORKER_NAME)
+
+    def _run(self, *, stop_event: threading.Event) -> None:
+        failure_times: list[float] = []
+        consecutive_failures = 0
+        restart_count = 0
+        self._supervisor.update_details(
+            _OCR_WORKER_NAME,
+            transport="agent",
+            process_state="starting",
+            restart_count=0,
+        )
+
+        while not stop_event.is_set():
+            result = self._run_process_once(
+                stop_event=stop_event,
+                restart_count=restart_count,
+            )
+            if stop_event.is_set() or result.error is None:
+                break
+
+            if result.uptime_s >= self._config.restart.stable_reset_s:
+                consecutive_failures = 0
+                failure_times.clear()
+            consecutive_failures += 1
+            restart_count += 1
+            failure_at = self._monotonic()
+            delay_s = self._config.restart.delay_after_failure(
+                failure_times=failure_times,
+                now=failure_at,
+                consecutive_failures=consecutive_failures,
+            )
+            error_text = f"{type(result.error).__name__}: {result.error}"
+            self._supervisor.update_details(
+                _OCR_WORKER_NAME,
+                process_state="restart_backoff",
+                failure_kind="process",
+                restart_count=restart_count,
+                restart_delay_s=delay_s,
+                last_process_error=error_text,
+            )
+            self._supervisor.mark_degraded(
+                _OCR_WORKER_NAME,
+                f"OCR Agent process failed; restart {restart_count} in {delay_s:.2f}s: {error_text}",
+            )
+            logger.warning(
+                "ocr_agent_restart_scheduled restart_count=%s delay_s=%.2f error=%s",
+                restart_count,
+                delay_s,
+                error_text,
+            )
+            stop_event.wait(delay_s)
+
+        self._supervisor.update_details(
+            _OCR_WORKER_NAME,
+            process_state="stopped",
+            pid=None,
+            restart_count=restart_count,
+        )
+
+    def _run_process_once(
+        self,
+        *,
+        stop_event: threading.Event,
+        restart_count: int,
+    ) -> _ProcessRunResult:
+        transport = self._transport_factory()
+        started_at = self._monotonic()
+        try:
+            transport.start()
+        except Exception as exc:
+            return _ProcessRunResult(
+                error=OcrAgentProcessError(f"failed to start child: {exc}"),
+                uptime_s=0.0,
+            )
+
+        self._supervisor.update_details(
+            _OCR_WORKER_NAME,
+            process_state="handshake",
+            failure_kind=None,
+            pid=transport.pid,
+            restart_count=restart_count,
+        )
+        self._supervisor.mark_degraded(_OCR_WORKER_NAME, "OCR Agent handshake pending")
+
+        failures: queue.Queue[BaseException] = queue.Queue()
+        session = _ProtocolSession(
+            mapper=self._mapper,
+            supervisor=self._supervisor,
+            monotonic=self._monotonic,
+        )
+        stdout_thread = threading.Thread(
+            name="ocr-agent-stdout",
+            target=_read_stdout,
+            kwargs={"transport": transport, "session": session, "failures": failures},
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            name="ocr-agent-stderr",
+            target=_drain_stderr,
+            kwargs={"transport": transport},
+            daemon=True,
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+
+        error: BaseException | None = None
+        try:
+            error = self._wait_for_handshake(
+                transport=transport,
+                session=session,
+                failures=failures,
+                stop_event=stop_event,
+            )
+            if error is None and not stop_event.is_set():
+                error = self._monitor_process(
+                    transport=transport,
+                    session=session,
+                    failures=failures,
+                    stop_event=stop_event,
+                )
+
+            if stop_event.is_set():
+                _stop_process_gracefully(transport)
+                error = None
+            elif error is not None:
+                _force_stop_process(transport)
+        finally:
+            if transport.poll() is None:
+                _force_stop_process(transport)
+            stdout_thread.join(timeout=1.0)
+            stderr_thread.join(timeout=1.0)
+
+        return _ProcessRunResult(
+            error=error,
+            uptime_s=max(0.0, self._monotonic() - started_at),
+        )
+
+    def _wait_for_handshake(
+        self,
+        *,
+        transport: OcrProcessTransport,
+        session: _ProtocolSession,
+        failures: queue.Queue[BaseException],
+        stop_event: threading.Event,
+    ) -> BaseException | None:
+        deadline = self._monotonic() + self._config.handshake_timeout_s
+        while not stop_event.is_set():
+            failure = _take_failure(failures)
+            if failure is not None:
+                return failure
+            exit_code = transport.poll()
+            if exit_code is not None:
+                return OcrAgentProcessError(f"child exited before hello with code {exit_code}")
+            if session.handshake_complete.is_set():
+                return None
+            if self._monotonic() >= deadline:
+                return OcrAgentProcessError("hello handshake timed out")
+            stop_event.wait(self._config.monitor_interval_s)
+        return None
+
+    def _monitor_process(
+        self,
+        *,
+        transport: OcrProcessTransport,
+        session: _ProtocolSession,
+        failures: queue.Queue[BaseException],
+        stop_event: threading.Event,
+    ) -> BaseException | None:
+        while not stop_event.is_set():
+            failure = _take_failure(failures)
+            if failure is not None:
+                return failure
+            exit_code = transport.poll()
+            if exit_code is not None:
+                return OcrAgentProcessError(f"child exited unexpectedly with code {exit_code}")
+            heartbeat_age_s = session.heartbeat_age_s()
+            if heartbeat_age_s > self._config.heartbeat_timeout_s:
+                return OcrAgentProcessError(f"heartbeat timed out after {heartbeat_age_s:.2f}s")
+            stop_event.wait(self._config.monitor_interval_s)
+        return None
+
+
+class _ProtocolSession:
+    def __init__(
+        self,
+        *,
+        mapper: OcrAgentMessageMapper,
+        supervisor: WorkerSupervisor,
+        monotonic: MonotonicClock,
+    ) -> None:
+        self._mapper = mapper
+        self._supervisor = supervisor
+        self._monotonic = monotonic
+        self._lock = threading.Lock()
+        self._hello_received = False
+        self._last_sequence_id = -1
+        self._last_heartbeat_at = monotonic()
+        self.handshake_complete = threading.Event()
+
+    def handle(self, message: AgentToBridgeMessage) -> None:
+        with self._lock:
+            if not self._hello_received:
+                if not isinstance(message, HelloMessage):
+                    raise OcrAgentProcessError("first OCR Agent message must be hello")
+                missing = _REQUIRED_CAPABILITIES.difference(message.payload.capabilities)
+                if missing:
+                    missing_text = ", ".join(sorted(missing))
+                    raise OcrAgentProcessError(
+                        f"OCR Agent is missing required capabilities: {missing_text}"
+                    )
+                self._hello_received = True
+                self._last_sequence_id = message.sequence_id
+                self._last_heartbeat_at = self._monotonic()
+                self._supervisor.update_details(
+                    _OCR_WORKER_NAME,
+                    process_state="connected",
+                    protocol_version=message.protocol_version,
+                    agent_version=message.payload.agent_version,
+                    agent_pid=message.payload.pid,
+                    last_sequence_id=message.sequence_id,
+                )
+                self.handshake_complete.set()
+                return
+
+            if isinstance(message, HelloMessage):
+                raise OcrAgentProcessError("OCR Agent emitted duplicate hello")
+            if message.sequence_id <= self._last_sequence_id:
+                raise OcrAgentProcessError(
+                    "OCR Agent sequence_id must increase monotonically "
+                    f"({message.sequence_id} <= {self._last_sequence_id})"
+                )
+            self._last_sequence_id = message.sequence_id
+            self._supervisor.update_details(
+                _OCR_WORKER_NAME,
+                last_sequence_id=message.sequence_id,
+            )
+
+            if isinstance(message, PositionMessage):
+                self._mapper.map_position(message)
+                return
+            if isinstance(message, FinderSignalMessage):
+                self._mapper.map_finder(message)
+                return
+            if isinstance(message, StatusMessage):
+                self._apply_agent_state(
+                    state=message.payload.state,
+                    detail=message.payload.detail,
+                    code=message.payload.code,
+                )
+                return
+            if isinstance(message, HeartbeatMessage):
+                self._last_heartbeat_at = self._monotonic()
+                self._supervisor.update_details(
+                    _OCR_WORKER_NAME,
+                    last_heartbeat_ts_ms=message.emitted_ts_ms,
+                )
+                self._apply_agent_state(
+                    state=message.payload.state,
+                    detail=None,
+                    code=None,
+                )
+                return
+            return
+
+    def heartbeat_age_s(self) -> float:
+        with self._lock:
+            return max(0.0, self._monotonic() - self._last_heartbeat_at)
+
+    def _apply_agent_state(
+        self,
+        *,
+        state: AgentStatusState,
+        detail: str | None,
+        code: str | None,
+    ) -> None:
+        if code in _FATAL_AGENT_STATUS_CODES:
+            message = detail or f"OCR Agent reported fatal status {code}"
+            self._supervisor.update_details(
+                _OCR_WORKER_NAME,
+                process_state="agent_failed",
+                failure_kind="process",
+                agent_status_code=code,
+            )
+            raise OcrAgentProcessError(message)
+        if state == "running":
+            self._supervisor.update_details(
+                _OCR_WORKER_NAME,
+                process_state="running",
+                failure_kind=None,
+                agent_status_code=code,
+            )
+            self._supervisor.mark_running(_OCR_WORKER_NAME)
+            return
+        if state == "waiting_for_window":
+            message = detail or "Entropia Universe window is unavailable"
+            self._supervisor.update_details(
+                _OCR_WORKER_NAME,
+                process_state="window_unavailable",
+                failure_kind="capture",
+                agent_status_code=code,
+            )
+            self._supervisor.mark_degraded(_OCR_WORKER_NAME, message)
+            return
+
+        message = detail or "OCR Agent reported degraded state"
+        self._supervisor.update_details(
+            _OCR_WORKER_NAME,
+            process_state="degraded",
+            failure_kind="agent",
+            agent_status_code=code,
+        )
+        self._supervisor.mark_degraded(_OCR_WORKER_NAME, message)
+
+
+def _read_stdout(
+    *,
+    transport: OcrProcessTransport,
+    session: _ProtocolSession,
+    failures: queue.Queue[BaseException],
+) -> None:
+    try:
+        while True:
+            line = transport.read_stdout_line()
+            if not line:
+                failures.put(OcrAgentProcessError("OCR Agent stdout closed"))
+                return
+            try:
+                message = decode_agent_message(line)
+                session.handle(message)
+            except (OcrProtocolError, OcrAgentProcessError, ValueError) as exc:
+                failures.put(exc)
+                return
+    except Exception as exc:
+        failures.put(OcrAgentProcessError(f"stdout reader failed: {exc}"))
+
+
+def _drain_stderr(*, transport: OcrProcessTransport) -> None:
+    try:
+        while True:
+            line = transport.read_stderr_line()
+            if not line:
+                return
+            logger.info(
+                "ocr_agent_stderr line=%s",
+                line.decode("utf-8", errors="replace").rstrip(),
+            )
+    except Exception:
+        logger.warning("ocr_agent_stderr_reader_failed", exc_info=True)
+
+
+def _take_failure(failures: queue.Queue[BaseException]) -> BaseException | None:
+    try:
+        return failures.get_nowait()
+    except queue.Empty:
+        return None
+
+
+def _stop_process_gracefully(transport: OcrProcessTransport) -> None:
+    try:
+        transport.send(
+            ShutdownCommand(
+                protocol_version=1,
+                type="shutdown",
+                command_id=uuid.uuid4().hex,
+                sent_ts_ms=time.time_ns() // 1_000_000,
+                payload=ShutdownPayload(reason="backend_shutdown"),
+            )
+        )
+    except Exception:
+        logger.debug("ocr_agent_shutdown_command_failed", exc_info=True)
+    if transport.wait(timeout_s=3.0) is not None:
+        return
+    _force_stop_process(transport)
+
+
+def _force_stop_process(transport: OcrProcessTransport) -> None:
+    try:
+        transport.close_stdin()
+    except Exception:
+        logger.debug("ocr_agent_close_stdin_failed", exc_info=True)
+    if transport.wait(timeout_s=0.5) is not None:
+        return
+    try:
+        transport.terminate()
+    except Exception:
+        logger.debug("ocr_agent_terminate_failed", exc_info=True)
+    if transport.wait(timeout_s=1.0) is not None:
+        return
+    try:
+        transport.kill()
+    except Exception:
+        logger.warning("ocr_agent_kill_failed", exc_info=True)
+    transport.wait(timeout_s=1.0)

--- a/apps/game-bridge/src/zml_game_bridge/runtime/supervisor.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/supervisor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from threading import Thread
 from typing import Any
 
-from zml_game_bridge.runtime.worker_health import WorkerHealthRegistry
+from zml_game_bridge.runtime.worker_health import HealthDetail, WorkerHealthRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,9 @@ class WorkerSupervisor:
 
     def mark_degraded(self, name: str, message: str) -> None:
         self._health.mark_degraded(name, message)
+
+    def update_details(self, name: str, **details: HealthDetail) -> None:
+        self._health.update_details(name, **details)
 
     def start_thread(
         self,

--- a/apps/game-bridge/src/zml_game_bridge/runtime/worker_health.py
+++ b/apps/game-bridge/src/zml_game_bridge/runtime/worker_health.py
@@ -6,6 +6,7 @@ from dataclasses import asdict, dataclass
 from typing import Literal
 
 WorkerState = Literal["running", "degraded", "crashed", "stopped"]
+HealthDetail = str | int | float | bool | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,6 +15,7 @@ class WorkerHealthSnapshot:
     enabled: bool
     last_error: str | None
     last_seen_ts_ms: int
+    details: dict[str, HealthDetail]
 
 
 class WorkerHealthRegistry:
@@ -30,6 +32,7 @@ class WorkerHealthRegistry:
                 enabled=enabled,
                 last_error=None,
                 last_seen_ts_ms=_now_ms(),
+                details={},
             )
 
     def mark_running(self, name: str) -> None:
@@ -43,6 +46,27 @@ class WorkerHealthRegistry:
 
     def mark_crashed(self, name: str, error: BaseException) -> None:
         self._set_state(name, state="crashed", last_error=f"{type(error).__name__}: {error}")
+
+    def update_details(self, name: str, **details: HealthDetail) -> None:
+        with self._lock:
+            previous = self._workers.get(name)
+            if previous is None:
+                previous = WorkerHealthSnapshot(
+                    state="stopped",
+                    enabled=True,
+                    last_error=None,
+                    last_seen_ts_ms=_now_ms(),
+                    details={},
+                )
+            merged = dict(previous.details)
+            merged.update(details)
+            self._workers[name] = WorkerHealthSnapshot(
+                state=previous.state,
+                enabled=previous.enabled,
+                last_error=previous.last_error,
+                last_seen_ts_ms=_now_ms(),
+                details=merged,
+            )
 
     def snapshot(self) -> dict[str, WorkerHealthSnapshot]:
         with self._lock:
@@ -65,11 +89,13 @@ class WorkerHealthRegistry:
         with self._lock:
             previous = self._workers.get(name)
             enabled = previous.enabled if previous is not None else True
+            details = dict(previous.details) if previous is not None else {}
             self._workers[name] = WorkerHealthSnapshot(
                 state=state,
                 enabled=enabled,
                 last_error=last_error,
                 last_seen_ts_ms=_now_ms(),
+                details=details,
             )
 
 

--- a/apps/game-bridge/src/zml_game_bridge/settings.py
+++ b/apps/game-bridge/src/zml_game_bridge/settings.py
@@ -8,8 +8,11 @@ from dataclasses import dataclass, field
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from types import TracebackType
+from typing import Literal, cast
 
 from zml_game_bridge.paths import get_app_data_dir
+
+OcrTransport = Literal["embedded", "agent"]
 
 
 def get_documents_dir() -> Path:
@@ -157,6 +160,17 @@ def _default_chat_start_at_end() -> bool:
 
 def _default_ocr_enabled() -> bool:
     return _env_bool("ZML_OCR_ENABLED", default=True)
+
+
+def _default_ocr_transport() -> OcrTransport:
+    value = os.getenv("ZML_OCR_TRANSPORT", "embedded").strip().lower()
+    if value not in {"embedded", "agent"}:
+        raise ValueError("ZML_OCR_TRANSPORT must be 'embedded' or 'agent'")
+    return cast(OcrTransport, value)
+
+
+def _default_ocr_agent_path() -> Path | None:
+    return _env_path("ZML_OCR_AGENT_PATH")
 
 
 def _default_mock_inputs_enabled() -> bool:
@@ -325,6 +339,8 @@ class Settings:
 
     chat_start_at_end: bool = field(default_factory=_default_chat_start_at_end)
     ocr_enabled: bool = field(default_factory=_default_ocr_enabled)
+    ocr_transport: OcrTransport = field(default_factory=_default_ocr_transport)
+    ocr_agent_path: Path | None = field(default_factory=_default_ocr_agent_path)
     mock_inputs_enabled: bool = field(default_factory=_default_mock_inputs_enabled)
     mock_mining_interval_ms: int = field(default_factory=_default_mock_mining_interval_ms)
     claim_expiration_maintenance_enabled: bool = field(

--- a/apps/game-bridge/tests/runtime/ocr_agent/test_process_transport.py
+++ b/apps/game-bridge/tests/runtime/ocr_agent/test_process_transport.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+from zml_ocr_protocol import ShutdownCommand, ShutdownPayload, decode_bridge_message
+
+from zml_game_bridge.runtime.ocr_agent.process_transport import (
+    OcrAgentProcessConfig,
+    StdioOcrProcessTransport,
+    normalize_command,
+)
+
+
+@pytest.mark.timeout(2)
+def test_stdio_transport_writes_and_reads_protocol_lines() -> None:
+    transport = StdioOcrProcessTransport(
+        OcrAgentProcessConfig(
+            command=(
+                sys.executable,
+                "-c",
+                "import sys; line=sys.stdin.buffer.readline(); "
+                "sys.stdout.buffer.write(line); sys.stdout.buffer.flush()",
+            ),
+            environment={"ZML_TRANSPORT_TEST": "1"},
+        )
+    )
+    command = ShutdownCommand(
+        protocol_version=1,
+        type="shutdown",
+        command_id="a" * 32,
+        sent_ts_ms=1,
+        payload=ShutdownPayload(reason="backend_shutdown"),
+    )
+
+    transport.start()
+    transport.send(command)
+    echoed = decode_bridge_message(transport.read_stdout_line())
+
+    assert echoed == command
+    assert transport.wait(timeout_s=1.0) == 0
+
+
+def test_normalize_command_rejects_an_empty_command() -> None:
+    assert normalize_command(["python", "", "  ", "-m", "zml_ocr_agent"]) == (
+        "python",
+        "-m",
+        "zml_ocr_agent",
+    )
+    with pytest.raises(ValueError, match="cannot be empty"):
+        normalize_command(["", "  "])

--- a/apps/game-bridge/tests/runtime/ocr_agent/test_supervisor.py
+++ b/apps/game-bridge/tests/runtime/ocr_agent/test_supervisor.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+from zml_ocr_protocol import (
+    AgentToBridgeMessage,
+    FinderSignalMessage,
+    HeartbeatMessage,
+    HelloMessage,
+    PositionMessage,
+    encode_message,
+)
+from zml_ocr_protocol.messages import (
+    AgentStatusState,
+    FinderNoResourcesPayload,
+    HeartbeatPayload,
+    HelloPayload,
+    PositionObservationPayload,
+    StatusMessage,
+    StatusPayload,
+    WorldPositionPayload,
+)
+
+from zml_game_bridge.application.mining.signals.finder import FinderNoResourcesSignal
+from zml_game_bridge.application.position.model import PositionSnapshot
+from zml_game_bridge.events.base import SignalBase
+from zml_game_bridge.runtime.ocr_agent.message_mapper import OcrAgentMessageMapper
+from zml_game_bridge.runtime.ocr_agent.process_transport import (
+    OcrAgentProcessConfig,
+    OcrProcessTransport,
+)
+from zml_game_bridge.runtime.ocr_agent.supervisor import (
+    OcrAgentProcessError,
+    OcrAgentSupervisor,
+    OcrAgentSupervisorConfig,
+    RestartPolicy,
+    _ProtocolSession,
+)
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
+
+
+def test_protocol_session_requires_hello_before_observations() -> None:
+    session, _, _, _ = _session()
+
+    with pytest.raises(OcrAgentProcessError, match="first OCR Agent message must be hello"):
+        session.handle(_position(sequence_id=0))
+
+
+def test_protocol_session_maps_observations_and_distinguishes_window_health() -> None:
+    session, supervisor, positions, signals = _session(clock_ms=lambda: 2_000)
+
+    session.handle(_hello())
+    session.handle(_status_waiting(sequence_id=1))
+
+    worker = _worker_health(supervisor)
+    assert worker["state"] == "degraded"
+    assert worker["last_error"] == "window missing"
+    assert worker["details"]["process_state"] == "window_unavailable"
+    assert worker["details"]["failure_kind"] == "capture"
+
+    session.handle(_position(sequence_id=2))
+    session.handle(_finder(sequence_id=3))
+    session.handle(_heartbeat(sequence_id=4, state="running", capture_available=True))
+
+    assert positions[0].observed_ts_ms == 1_000
+    assert positions[0].received_ts_ms == 2_000
+    assert positions[0].position.x == 58_000
+    assert signals == [
+        FinderNoResourcesSignal(
+            ts_ms=1_500,
+            raw_status_text="No resources found",
+            roi_name="finder",
+        )
+    ]
+    worker = _worker_health(supervisor)
+    assert worker["state"] == "running"
+    assert worker["details"]["process_state"] == "running"
+    assert worker["details"]["failure_kind"] is None
+
+
+def test_protocol_session_rejects_fatal_agent_status_and_non_monotonic_sequence() -> None:
+    session, _, _, _ = _session()
+    session.handle(_hello())
+
+    with pytest.raises(OcrAgentProcessError, match="tesserocr unavailable"):
+        session.handle(
+            StatusMessage(
+                protocol_version=1,
+                type="status",
+                message_id="f" * 32,
+                sequence_id=1,
+                emitted_ts_ms=1_001,
+                payload=StatusPayload(
+                    state="degraded",
+                    capture_available=False,
+                    applied_revision=None,
+                    code="ocr_preload_failed",
+                    detail="tesserocr unavailable",
+                ),
+            )
+        )
+
+    session, _, _, _ = _session()
+    session.handle(_hello())
+    session.handle(_heartbeat(sequence_id=2, state="running", capture_available=True))
+    with pytest.raises(OcrAgentProcessError, match="increase monotonically"):
+        session.handle(_position(sequence_id=1))
+
+
+@pytest.mark.timeout(2)
+def test_supervisor_restarts_agent_and_accepts_position_and_finder_after_restart() -> None:
+    stop_event = threading.Event()
+    positions: list[PositionSnapshot] = []
+    signals: list[SignalBase] = []
+    transports = [
+        _FakeTransport([_hello()], exit_after_messages=True, pid=100),
+        _FakeTransport(
+            [
+                _hello(pid=101),
+                _status_waiting(sequence_id=1),
+                _heartbeat(sequence_id=2, state="waiting_for_window", capture_available=False),
+                _position(sequence_id=3),
+                _finder(sequence_id=4),
+            ],
+            exit_after_messages=False,
+            pid=101,
+        ),
+    ]
+    created: list[_FakeTransport] = []
+
+    def transport_factory() -> OcrProcessTransport:
+        transport = transports[len(created)]
+        created.append(transport)
+        return transport
+
+    def signal_sink(signal: SignalBase) -> None:
+        signals.append(signal)
+        stop_event.set()
+
+    supervisor = WorkerSupervisor()
+    supervisor.register("ocr_worker", enabled=True)
+    source = OcrAgentSupervisor(
+        config=OcrAgentSupervisorConfig(
+            enabled=True,
+            process=OcrAgentProcessConfig(command=("fake-agent",), environment={}),
+            handshake_timeout_s=0.5,
+            heartbeat_timeout_s=0.5,
+            monitor_interval_s=0.001,
+            restart=RestartPolicy(delays_s=(0.0,), stable_reset_s=1.0),
+        ),
+        supervisor=supervisor,
+        position_sink=positions.append,
+        signal_sink=signal_sink,
+        transport_factory=transport_factory,
+    )
+
+    source.start(stop_event=stop_event)
+    assert stop_event.wait(timeout=1.0)
+    source.stop()
+
+    assert len(created) == 2
+    assert created[0].pid == 100
+    assert created[1].pid == 101
+    assert len(positions) == 1
+    assert positions[0].position.x == 58_000
+    assert isinstance(signals[0], FinderNoResourcesSignal)
+    assert created[1].sent_shutdown
+    worker = _worker_health(supervisor)
+    assert worker["details"]["restart_count"] == 1
+    assert worker["details"]["failure_kind"] == "capture"
+
+
+def _session(
+    *,
+    clock_ms: Callable[[], int] | None = None,
+) -> tuple[_ProtocolSession, WorkerSupervisor, list[PositionSnapshot], list[SignalBase]]:
+    positions: list[PositionSnapshot] = []
+    signals: list[SignalBase] = []
+    supervisor = WorkerSupervisor()
+    supervisor.register("ocr_worker", enabled=True)
+    mapper = OcrAgentMessageMapper(
+        position_sink=positions.append,
+        signal_sink=signals.append,
+        clock_ms=clock_ms,
+    )
+    session = _ProtocolSession(
+        mapper=mapper,
+        supervisor=supervisor,
+        monotonic=time.monotonic,
+    )
+    return session, supervisor, positions, signals
+
+
+def _worker_health(supervisor: WorkerSupervisor) -> dict[str, object]:
+    workers = cast(dict[str, dict[str, object]], supervisor.health()["workers"])
+    return workers["ocr_worker"]
+
+
+def _hello(*, pid: int = 123) -> HelloMessage:
+    return HelloMessage(
+        protocol_version=1,
+        type="hello",
+        message_id="a" * 32,
+        sequence_id=0,
+        emitted_ts_ms=1_000,
+        payload=HelloPayload(
+            agent_version="0.1.0",
+            pid=pid,
+            started_ts_ms=999,
+            capabilities=["stdio", "position", "finder", "status", "heartbeat"],
+        ),
+    )
+
+
+def _position(*, sequence_id: int) -> PositionMessage:
+    return PositionMessage(
+        protocol_version=1,
+        type="position",
+        message_id="b" * 32,
+        sequence_id=sequence_id,
+        emitted_ts_ms=1_001,
+        observed_ts_ms=1_000,
+        payload=PositionObservationPayload(
+            position=WorldPositionPayload(
+                planet_name="Calypso",
+                x=58_000,
+                y=84_000,
+                z=None,
+            ),
+            confidence=None,
+            roi_name="compass",
+        ),
+    )
+
+
+def _finder(*, sequence_id: int) -> FinderSignalMessage:
+    return FinderSignalMessage(
+        protocol_version=1,
+        type="finder_signal",
+        message_id="c" * 32,
+        sequence_id=sequence_id,
+        emitted_ts_ms=1_501,
+        observed_ts_ms=1_500,
+        payload=FinderNoResourcesPayload(
+            kind="finder_no_resources",
+            raw_status_text="No resources found",
+            roi_name="finder",
+            debug={},
+        ),
+    )
+
+
+def _status_waiting(*, sequence_id: int) -> StatusMessage:
+    return StatusMessage(
+        protocol_version=1,
+        type="status",
+        message_id="d" * 32,
+        sequence_id=sequence_id,
+        emitted_ts_ms=1_002,
+        payload=StatusPayload(
+            state="waiting_for_window",
+            capture_available=False,
+            applied_revision=None,
+            code="window_unavailable",
+            detail="window missing",
+        ),
+    )
+
+
+def _heartbeat(
+    *,
+    sequence_id: int,
+    state: AgentStatusState,
+    capture_available: bool,
+) -> HeartbeatMessage:
+    return HeartbeatMessage(
+        protocol_version=1,
+        type="heartbeat",
+        message_id="e" * 32,
+        sequence_id=sequence_id,
+        emitted_ts_ms=1_003,
+        payload=HeartbeatPayload(
+            state=state,
+            capture_available=capture_available,
+            applied_revision=None,
+        ),
+    )
+
+
+_EOF = object()
+
+
+class _FakeTransport:
+    def __init__(
+        self,
+        messages: list[AgentToBridgeMessage],
+        *,
+        exit_after_messages: bool,
+        pid: int,
+    ) -> None:
+        self.pid = pid
+        self._messages = messages
+        self._exit_after_messages = exit_after_messages
+        self._stdout: queue.Queue[bytes | object] = queue.Queue()
+        self._stderr: queue.Queue[bytes | object] = queue.Queue()
+        self._exit_event = threading.Event()
+        self._returncode: int | None = None
+        self.sent_shutdown = False
+
+    def start(self) -> None:
+        for message in self._messages:
+            self._stdout.put(encode_message(message))
+        if self._exit_after_messages:
+            self._stdout.put(_EOF)
+
+    def read_stdout_line(self) -> bytes:
+        item = self._stdout.get(timeout=1.0)
+        if item is _EOF:
+            self._exit(1)
+            return b""
+        return cast(bytes, item)
+
+    def read_stderr_line(self) -> bytes:
+        item = self._stderr.get(timeout=1.0)
+        return b"" if item is _EOF else cast(bytes, item)
+
+    def send(self, message: object) -> None:
+        self.sent_shutdown = getattr(message, "type", None) == "shutdown"
+        self._exit(0)
+
+    def poll(self) -> int | None:
+        return self._returncode
+
+    def wait(self, *, timeout_s: float) -> int | None:
+        self._exit_event.wait(timeout_s)
+        return self._returncode
+
+    def close_stdin(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        self._exit(-15)
+
+    def kill(self) -> None:
+        self._exit(-9)
+
+    def _exit(self, returncode: int) -> None:
+        if self._returncode is not None:
+            return
+        self._returncode = returncode
+        self._exit_event.set()
+        self._stdout.put(_EOF)
+        self._stderr.put(_EOF)

--- a/apps/game-bridge/tests/runtime/test_ocr_bootstrap.py
+++ b/apps/game-bridge/tests/runtime/test_ocr_bootstrap.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from zml_game_bridge.inputs.ocr.source import EmbeddedOcrInputSource
+from zml_game_bridge.runtime.bootstrap import build_ocr_input_source
+from zml_game_bridge.runtime.ocr_agent.supervisor import OcrAgentSupervisor
+from zml_game_bridge.runtime.supervisor import WorkerSupervisor
+from zml_game_bridge.settings import Settings
+
+
+def test_embedded_transport_remains_the_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ZML_OCR_TRANSPORT", raising=False)
+    settings = Settings(ocr_enabled=False)
+
+    source = build_ocr_input_source(
+        settings,
+        supervisor=_supervisor(settings),
+        position_sink=lambda _snapshot: None,
+        signal_sink=lambda _signal: None,
+    )
+
+    assert settings.ocr_transport == "embedded"
+    assert isinstance(source, EmbeddedOcrInputSource)
+
+
+def test_agent_transport_uses_current_python_or_configured_executable() -> None:
+    default_settings = Settings(ocr_enabled=False, ocr_transport="agent")
+    configured_settings = Settings(
+        ocr_enabled=False,
+        ocr_transport="agent",
+        ocr_agent_path=Path("C:/ZML/zml-ocr-agent.exe"),
+    )
+
+    default_source = build_ocr_input_source(
+        default_settings,
+        supervisor=_supervisor(default_settings),
+        position_sink=lambda _snapshot: None,
+        signal_sink=lambda _signal: None,
+    )
+    configured_source = build_ocr_input_source(
+        configured_settings,
+        supervisor=_supervisor(configured_settings),
+        position_sink=lambda _snapshot: None,
+        signal_sink=lambda _signal: None,
+    )
+
+    assert isinstance(default_source, OcrAgentSupervisor)
+    assert default_source.config.process.command == (sys.executable, "-m", "zml_ocr_agent", "stdio")
+    assert isinstance(configured_source, OcrAgentSupervisor)
+    assert configured_source.config.process.command == ("C:\\ZML\\zml-ocr-agent.exe", "stdio")
+    assert configured_source.config.process.environment["ZML_OCR_PROFILE_PATH"] == str(
+        configured_settings.ocr_profile_path
+    )
+
+
+def test_invalid_ocr_transport_environment_fails_fast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ZML_OCR_TRANSPORT", "sidecar-ish")
+
+    with pytest.raises(ValueError, match="ZML_OCR_TRANSPORT"):
+        Settings()
+
+
+def _supervisor(settings: Settings) -> WorkerSupervisor:
+    supervisor = WorkerSupervisor()
+    supervisor.register("ocr_worker", enabled=settings.ocr_enabled)
+    return supervisor

--- a/apps/game-bridge/tests/runtime/test_worker_health.py
+++ b/apps/game-bridge/tests/runtime/test_worker_health.py
@@ -69,3 +69,26 @@ def test_worker_supervisor_can_recover_degraded_worker() -> None:
     assert snapshot["status"] == "running"
     assert workers["ocr_worker"]["state"] == "running"
     assert workers["ocr_worker"]["last_error"] is None
+
+
+def test_worker_health_preserves_structured_details_across_state_changes() -> None:
+    registry = WorkerHealthRegistry()
+    registry.register("ocr_worker", enabled=True)
+
+    registry.update_details(
+        "ocr_worker",
+        transport="agent",
+        process_state="window_unavailable",
+        failure_kind="capture",
+        pid=123,
+    )
+    registry.mark_degraded("ocr_worker", "window missing")
+
+    snapshot = registry.as_dict()
+    workers = cast(dict[str, dict[str, Any]], snapshot["workers"])
+    assert workers["ocr_worker"]["details"] == {
+        "transport": "agent",
+        "process_state": "window_unavailable",
+        "failure_kind": "capture",
+        "pid": 123,
+    }

--- a/apps/ocr-agent/README.md
+++ b/apps/ocr-agent/README.md
@@ -3,9 +3,9 @@
 Standalone Windows screen-capture and OCR component for Z Mining Log.
 
 The agent owns the native OCR stack and emits versioned NDJSON messages on
-stdout. Logs are written to stderr. Game Bridge currently also imports the same
-runner through a temporary embedded adapter while subprocess supervision is
-introduced incrementally.
+stdout. Logs are written to stderr. Game Bridge can run the agent as a managed
+child with `ZML_OCR_TRANSPORT=agent`; the temporary embedded adapter remains the
+default rollback path during migration.
 
 ```powershell
 uv run zml-ocr-agent --version
@@ -14,4 +14,6 @@ uv run zml-ocr-agent stdio
 ```
 
 In `stdio` mode the first stdout line is a protocol `hello` message. The process
-accepts protocol commands on stdin and exits on a `shutdown` command or EOF.
+emits periodic heartbeats, accepts protocol commands on stdin, and exits on a
+`shutdown` command or EOF. `ZML_OCR_PROFILE_PATH` selects the startup ROI profile;
+revisioned live configuration is handled in the next migration step.

--- a/apps/ocr-agent/src/zml_ocr_agent/message_factory.py
+++ b/apps/ocr-agent/src/zml_ocr_agent/message_factory.py
@@ -20,6 +20,8 @@ from zml_ocr_protocol.messages import (
     FinderObservationPayload,
     FinderSignalMessage,
     FinderUnitsChangedPayload,
+    HeartbeatMessage,
+    HeartbeatPayload,
     HelloMessage,
     HelloPayload,
     PositionMessage,
@@ -70,7 +72,7 @@ class AgentMessageFactory:
                 agent_version=self._agent_version,
                 pid=self._pid,
                 started_ts_ms=self._started_ts_ms,
-                capabilities=["stdio", "position", "finder", "status"],
+                capabilities=["stdio", "position", "finder", "status", "heartbeat"],
             ),
         )
 
@@ -135,6 +137,26 @@ class AgentMessageFactory:
                 applied_revision=None,
                 code=code,
                 detail=detail,
+            ),
+        )
+
+    def heartbeat(
+        self,
+        *,
+        state: AgentStatusState,
+        capture_available: bool,
+    ) -> HeartbeatMessage:
+        message_id, sequence_id, emitted_ts_ms = self._metadata()
+        return HeartbeatMessage(
+            protocol_version=PROTOCOL_VERSION,
+            type="heartbeat",
+            message_id=message_id,
+            sequence_id=sequence_id,
+            emitted_ts_ms=emitted_ts_ms,
+            payload=HeartbeatPayload(
+                state=state,
+                capture_available=capture_available,
+                applied_revision=None,
             ),
         )
 

--- a/apps/ocr-agent/src/zml_ocr_agent/stdio.py
+++ b/apps/ocr-agent/src/zml_ocr_agent/stdio.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import threading
 from io import BufferedReader, BufferedWriter
+from pathlib import Path
 from typing import BinaryIO, cast
 
 from zml_ocr_protocol import (
@@ -11,7 +13,12 @@ from zml_ocr_protocol import (
     decode_bridge_message,
     encode_message,
 )
-from zml_ocr_protocol.messages import AgentToBridgeMessage, BridgeToAgentMessage
+from zml_ocr_protocol.messages import (
+    AgentStatusState,
+    AgentToBridgeMessage,
+    BridgeToAgentMessage,
+    StatusMessage,
+)
 
 from zml_ocr_agent.message_factory import AgentMessageFactory
 from zml_ocr_agent.runner import start_ocr_input
@@ -19,15 +26,40 @@ from zml_ocr_agent.tesserocr_runtime import preload_tesserocr_preserving_sigint_
 
 logger = logging.getLogger(__name__)
 
+_HEARTBEAT_INTERVAL_S = 2.0
+
+
+class AgentRuntimeState:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state: AgentStatusState = "degraded"
+        self._capture_available = False
+
+    def observe(self, message: AgentToBridgeMessage) -> None:
+        if not isinstance(message, StatusMessage):
+            return
+        with self._lock:
+            self._state = message.payload.state
+            self._capture_available = message.payload.capture_available
+
+    def snapshot(self) -> tuple[AgentStatusState, bool]:
+        with self._lock:
+            return self._state, self._capture_available
+
 
 class ProtocolWriter:
-    def __init__(self, output: BinaryIO) -> None:
+    def __init__(self, output: BinaryIO, *, runtime_state: AgentRuntimeState) -> None:
         self._output = output
+        self._runtime_state = runtime_state
         self._lock = threading.Lock()
+        self._next_sequence_id = 0
 
     def write(self, message: AgentToBridgeMessage) -> None:
-        encoded = encode_message(message)
         with self._lock:
+            wire_message = message.model_copy(update={"sequence_id": self._next_sequence_id})
+            self._next_sequence_id += 1
+            self._runtime_state.observe(wire_message)
+            encoded = encode_message(wire_message)
             self._output.write(encoded)
             self._output.flush()
 
@@ -35,11 +67,24 @@ class ProtocolWriter:
 def run_stdio(*, stdin: BinaryIO | None = None, stdout: BinaryIO | None = None) -> int:
     input_stream = stdin or cast(BufferedReader, sys.stdin.buffer)
     output_stream = stdout or cast(BufferedWriter, sys.stdout.buffer)
-    writer = ProtocolWriter(output_stream)
+    runtime_state = AgentRuntimeState()
+    writer = ProtocolWriter(output_stream, runtime_state=runtime_state)
     factory = AgentMessageFactory()
     stop_event = threading.Event()
 
     writer.write(factory.hello())
+    heartbeat_thread = threading.Thread(
+        name="zml-ocr-heartbeat",
+        target=_run_heartbeat,
+        kwargs={
+            "writer": writer,
+            "factory": factory,
+            "runtime_state": runtime_state,
+            "stop_event": stop_event,
+        },
+        daemon=True,
+    )
+    heartbeat_thread.start()
 
     runner_thread: threading.Thread | None = None
     try:
@@ -62,6 +107,7 @@ def run_stdio(*, stdin: BinaryIO | None = None, stdout: BinaryIO | None = None) 
                 "writer": writer,
                 "factory": factory,
                 "stop_event": stop_event,
+                "roi_profile_path": _env_path("ZML_OCR_PROFILE_PATH"),
             },
             daemon=True,
         )
@@ -77,6 +123,7 @@ def run_stdio(*, stdin: BinaryIO | None = None, stdout: BinaryIO | None = None) 
 
             if _handle_command(command, writer=writer, factory=factory, stop_event=stop_event):
                 _join_runner(runner_thread)
+                heartbeat_thread.join(timeout=1.0)
                 writer.write(
                     factory.command_ok(
                         command_id=command.command_id,
@@ -87,6 +134,7 @@ def run_stdio(*, stdin: BinaryIO | None = None, stdout: BinaryIO | None = None) 
     finally:
         stop_event.set()
         _join_runner(runner_thread)
+        heartbeat_thread.join(timeout=1.0)
 
     return 0
 
@@ -96,12 +144,14 @@ def _run_runner(
     writer: ProtocolWriter,
     factory: AgentMessageFactory,
     stop_event: threading.Event,
+    roi_profile_path: Path | None,
 ) -> None:
     try:
         start_ocr_input(
             message_sink=writer.write,
             message_factory=factory,
             stop_event=stop_event,
+            roi_profile_path=roi_profile_path,
         )
     except Exception as exc:
         logger.exception("ocr_runner_crashed")
@@ -111,6 +161,23 @@ def _run_runner(
                 capture_available=False,
                 code="ocr_runner_crashed",
                 detail=str(exc),
+            )
+        )
+
+
+def _run_heartbeat(
+    *,
+    writer: ProtocolWriter,
+    factory: AgentMessageFactory,
+    runtime_state: AgentRuntimeState,
+    stop_event: threading.Event,
+) -> None:
+    while not stop_event.wait(_HEARTBEAT_INTERVAL_S):
+        state, capture_available = runtime_state.snapshot()
+        writer.write(
+            factory.heartbeat(
+                state=state,
+                capture_available=capture_available,
             )
         )
 
@@ -142,3 +209,10 @@ def _handle_command(
 def _join_runner(runner_thread: threading.Thread | None) -> None:
     if runner_thread is not None:
         runner_thread.join(timeout=5.0)
+
+
+def _env_path(name: str) -> Path | None:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return None
+    return Path(value)

--- a/apps/ocr-agent/tests/test_message_factory.py
+++ b/apps/ocr-agent/tests/test_message_factory.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 import pytest
-from zml_ocr_protocol import FinderSignalMessage, HelloMessage, PositionMessage, StatusMessage
+from zml_ocr_protocol import (
+    FinderSignalMessage,
+    HeartbeatMessage,
+    HelloMessage,
+    PositionMessage,
+    StatusMessage,
+)
 
 from zml_ocr_agent.message_factory import AgentMessageFactory
 from zml_ocr_agent.models import WorldPosition
@@ -9,9 +15,9 @@ from zml_ocr_agent.pipelines.mining_finder.model import MiningFinderSignal
 from zml_ocr_agent.pipelines.position.model import OcrPosition
 
 
-def test_factory_emits_ordered_hello_position_and_status_messages() -> None:
-    timestamps = iter([100, 101, 102, 103])
-    message_ids = iter(["a" * 32, "b" * 32, "c" * 32])
+def test_factory_emits_ordered_hello_position_status_and_heartbeat_messages() -> None:
+    timestamps = iter([100, 101, 102, 103, 104])
+    message_ids = iter(["a" * 32, "b" * 32, "c" * 32, "d" * 32])
     factory = AgentMessageFactory(
         clock_ms=lambda: next(timestamps),
         message_id_factory=lambda: next(message_ids),
@@ -33,11 +39,16 @@ def test_factory_emits_ordered_hello_position_and_status_messages() -> None:
         code="window_unavailable",
         detail="window missing",
     )
+    heartbeat = factory.heartbeat(
+        state="waiting_for_window",
+        capture_available=False,
+    )
 
     assert isinstance(hello, HelloMessage)
     assert hello.sequence_id == 0
     assert hello.payload.agent_version == "9.8.7"
     assert hello.payload.pid == 123
+    assert "heartbeat" in hello.payload.capabilities
     assert isinstance(position, PositionMessage)
     assert position.sequence_id == 1
     assert position.observed_ts_ms == 1_000
@@ -45,6 +56,9 @@ def test_factory_emits_ordered_hello_position_and_status_messages() -> None:
     assert isinstance(status, StatusMessage)
     assert status.sequence_id == 2
     assert status.payload.state == "waiting_for_window"
+    assert isinstance(heartbeat, HeartbeatMessage)
+    assert heartbeat.sequence_id == 3
+    assert heartbeat.payload.state == "waiting_for_window"
 
 
 @pytest.mark.parametrize(

--- a/apps/ocr-agent/tests/test_stdio.py
+++ b/apps/ocr-agent/tests/test_stdio.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from zml_ocr_protocol import HeartbeatMessage, HelloMessage, decode_agent_message
+
+from zml_ocr_agent.message_factory import AgentMessageFactory
+from zml_ocr_agent.stdio import AgentRuntimeState, ProtocolWriter
+
+
+def test_protocol_writer_assigns_wire_sequence_in_emission_order() -> None:
+    output = BytesIO()
+    runtime_state = AgentRuntimeState()
+    writer = ProtocolWriter(output, runtime_state=runtime_state)
+    factory = AgentMessageFactory(
+        clock_ms=lambda: 100,
+        message_id_factory=lambda: "a" * 32,
+    )
+    hello = factory.hello()
+    status = factory.status(
+        state="waiting_for_window",
+        capture_available=False,
+        code="window_unavailable",
+        detail="window missing",
+    )
+    heartbeat = factory.heartbeat(state="degraded", capture_available=False)
+
+    writer.write(hello)
+    writer.write(heartbeat)
+    writer.write(status)
+
+    messages = [decode_agent_message(line) for line in output.getvalue().splitlines()]
+    assert len(messages) == 3
+    assert isinstance(messages[0], HelloMessage)
+    assert isinstance(messages[1], HeartbeatMessage)
+    assert [message.sequence_id for message in messages] == [0, 1, 2]
+
+
+def test_runtime_state_tracks_latest_status_for_heartbeat() -> None:
+    runtime_state = AgentRuntimeState()
+    factory = AgentMessageFactory(
+        clock_ms=lambda: 100,
+        message_id_factory=lambda: "a" * 32,
+    )
+
+    runtime_state.observe(
+        factory.status(
+            state="waiting_for_window",
+            capture_available=False,
+            code="window_unavailable",
+            detail="window missing",
+        )
+    )
+
+    assert runtime_state.snapshot() == ("waiting_for_window", False)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,12 +66,20 @@ domain -> no app/runtime/persistence imports
 pipelines, recording/profiling tools, `tesserocr`, OpenCV, numpy, and tessdata.
 Its runner emits `zml-ocr-protocol` messages and imports no Game Bridge modules.
 
-During the migration, Game Bridge uses a path dependency on the agent and runs
-the same runner in-process through `EmbeddedOcrInputSource`. The adapter maps
-position and finder DTOs to application models and signals. The agent also has
-an independent `stdio` entrypoint that emits `hello`, accepts `shutdown`, and
-reserves stdout for NDJSON. Process supervision and transport selection are the
-next migration step.
+During the migration, Game Bridge supports two implementations of its
+`OcrInputSource` port. `EmbeddedOcrInputSource` runs the agent runner in-process
+and remains the default rollback path. `OcrAgentSupervisor` starts the agent's
+`stdio` entrypoint as a child process when `ZML_OCR_TRANSPORT=agent`, validates
+the initial `hello`, drains stdout/stderr concurrently, monitors heartbeats, and
+restarts failed processes with bounded exponential backoff. Both transports use
+one mapper for position and finder DTOs, so downstream application behavior is
+the same.
+
+The agent reports a missing game window as a recoverable capture state. Health
+diagnostics therefore distinguish `failure_kind=capture` with
+`process_state=window_unavailable` from process/protocol failures and restart
+backoff. The current settings are passed to the child as startup environment;
+revisioned `apply_config` synchronization is the next migration step.
 
 ## Signal To Event Flow
 
@@ -225,8 +233,8 @@ sequenceDiagram
   covering abrupt Electron exits without blocking Python startup.
 - `RuntimeShutdownSignal` lets WS/SSE handlers finish before Uvicorn waits for active
   connections, avoiding a circular graceful-shutdown wait.
-- The main-thread `tesserocr` preload preserves Uvicorn's `SIGINT` handler; otherwise
-  bundled `cysignals` replaces it and a single Ctrl+C ends in `KeyboardInterrupt`.
+- In embedded OCR mode, the main-thread `tesserocr` preload preserves Uvicorn's
+  `SIGINT` handler; agent mode keeps native OCR initialization in the child.
 - Absence of the Entropia window is not a process failure. OCR reports `degraded`, retries
   capture, and returns to `running` when the window becomes available.
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -60,8 +60,14 @@ Z Mining Log is now a working local mining tracker prototype:
   - profiling and finder crop recording hooks exist;
   - position outlier filtering exists;
   - missing/lost Entropia window degrades health and retries instead of crashing OCR;
-  - OCR still runs in-process by default, but the runner now emits strict
-    version 1 `packages/ocr-protocol` messages and imports no Game Bridge code;
+  - OCR still runs in-process by default, but `ZML_OCR_TRANSPORT=agent` now
+    selects a managed child process and `ZML_OCR_AGENT_PATH` can select its executable;
+  - the subprocess supervisor validates `hello`, drains both output pipes,
+    monitors heartbeats, maps observations, and restarts with bounded backoff;
+  - structured worker health distinguishes process/protocol failure and restart
+    state from an unavailable Entropia capture window;
+  - the runner emits strict version 1 `packages/ocr-protocol` messages and
+    imports no Game Bridge code;
   - `AppRuntime` owns only the `OcrInputSource` lifecycle while
     `EmbeddedOcrInputSource` maps agent messages to position snapshots, finder
     signals, preload, and worker health without changing runtime behavior;
@@ -87,7 +93,6 @@ Z Mining Log is now a working local mining tracker prototype:
 See `ROADMAP_2025-05-26.md` for the ordered roadmap. The highest-value items are:
 
 1. Managed OCR Agent migration:
-   - add the subprocess supervisor behind a rollback flag;
    - synchronize full configuration snapshots and validate real-game behavior;
    - package both executables before removing embedded OCR.
 


### PR DESCRIPTION
## What changed

- add a binary stdio transport and managed `OcrAgentSupervisor` under Game Bridge
- validate the initial protocol `hello`, required capabilities, and monotonic sequence IDs before accepting observations
- drain stdout and stderr concurrently, monitor heartbeats, and restart failed agents with bounded exponential backoff
- share one mapper between embedded and subprocess transports for position snapshots and finder application signals
- add `ZML_OCR_TRANSPORT=embedded|agent` with `embedded` still the default rollback path
- support `ZML_OCR_AGENT_PATH` for an explicit executable and pass current OCR startup settings to the child environment
- extend worker health with structured process/capture details so a missing game window is distinct from process/protocol failure
- emit heartbeat messages from the standalone agent and keep stdout sequence ordering stable across producer threads
- document the new migration state and environment switches

## Why

This implements migration-plan PR 4: Game Bridge can now own OCR Agent as a restartable child without changing the downstream position and mining paths. The embedded adapter remains available for real-game comparison and rollback until config synchronization, smoke validation, and packaging are complete.

## Impact

- default behavior remains embedded OCR
- agent mode is opt-in with `ZML_OCR_TRANSPORT=agent`
- Game Bridge stays alive while OCR Agent restarts
- unavailable Entropia window reports degraded capture health rather than triggering a restart
- position and finder observations after restart continue through the existing application services and runtime queue

## Validation

OCR Agent:
- Ruff
- Ruff format check
- Pyright: 0 errors, 0 warnings
- Pytest: 51 passed

Game Bridge:
- Ruff
- Ruff format check
- Pyright: 0 errors (36 existing Typer warnings)
- Pytest: 203 passed

The user-owned untracked `docs/ocr-agent-migration-plan.md` is intentionally excluded.