### PR TITLE
Centralize repository task orchestration with just

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up just
+        uses: extractions/setup-just@v4
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
 
@@ -130,5 +133,8 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Verify frontend
-        run: pnpm frontend:verify
+      - name: Verify shared package
+        run: just shared verify
+
+      - name: Verify desktop
+        run: just desktop verify

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -79,10 +79,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Stage Python components in Electron resources
-        run: pnpm python:stage
+        run: just stage-python
 
       - name: Package Electron application
-        run: pnpm frontend:package
+        run: just desktop package
 
       - name: Verify bundled Python process tree
         shell: pwsh

--- a/apps/electron-ui/justfile
+++ b/apps/electron-ui/justfile
@@ -1,0 +1,25 @@
+default:
+    just --list
+
+dev:
+    pnpm dev
+
+dev-mocks:
+    pnpm dev:mocks
+
+typecheck:
+    pnpm typecheck
+
+lint:
+    pnpm lint
+
+test:
+    pnpm test
+
+build:
+    pnpm build
+
+package:
+    pnpm package
+
+verify: typecheck lint test build

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
-set default-list := true
+default:
+    just --list
 
 # Component task modules. Each module runs from its own project directory.
 mod backend 'apps/game-bridge'

--- a/justfile
+++ b/justfile
@@ -31,5 +31,6 @@ stage-python:
     node scripts/stage-python-components.mjs
 
 # Package both Python processes, stage them, then build the desktop installer.
-package: ocr::package backend::package shared::build && desktop::package
+package: ocr::package backend::package shared::build
     node scripts/stage-python-components.mjs
+    just desktop package

--- a/justfile
+++ b/justfile
@@ -1,0 +1,35 @@
+set default-list := true
+
+# Component task modules. Each module runs from its own project directory.
+mod backend 'apps/game-bridge'
+mod desktop 'apps/electron-ui'
+mod ocr 'apps/ocr-agent'
+mod protocol 'packages/ocr-protocol'
+mod shared 'packages/shared'
+
+# Start the desktop development process. Electron owns the local backend lifecycle.
+dev: shared::build
+    pnpm --filter @zml/electron-ui dev
+
+# Run the complete repository quality gate.
+verify: protocol::verify ocr::verify backend::verify shared::verify desktop::verify
+
+# Run all test suites that exist today.
+test: protocol::test ocr::test backend::test desktop::test
+
+# Run all configured linters.
+lint: protocol::lint ocr::lint backend::lint desktop::lint
+
+# Format Python components. TypeScript formatting is not enforced repository-wide yet.
+format-python: protocol::format ocr::format backend::format
+
+# Build TypeScript workspace artifacts.
+build: shared::build desktop::build
+
+# Stage already-packaged Python components into Electron resources.
+stage-python:
+    node scripts/stage-python-components.mjs
+
+# Package both Python processes, stage them, then build the desktop installer.
+package: ocr::package backend::package shared::build && desktop::package
+    node scripts/stage-python-components.mjs

--- a/package.json
+++ b/package.json
@@ -6,27 +6,6 @@
     "apps/*",
     "packages/*"
   ],
-  "scripts": {
-    "dev": "pnpm --filter @zml/electron-ui dev",
-    "ocr-protocol:format": "cd packages/ocr-protocol && just format",
-    "ocr-protocol:verify": "cd packages/ocr-protocol && just verify",
-    "bridge:format": "cd apps/game-bridge && just format",
-    "bridge:package": "cd apps/game-bridge && just package",
-    "bridge:verify": "cd apps/game-bridge && just verify",
-    "ocr-agent:format": "cd apps/ocr-agent && just format",
-    "ocr-agent:package": "cd apps/ocr-agent && just package",
-    "ocr-agent:verify": "cd apps/ocr-agent && just verify",
-    "python:stage": "node scripts/stage-python-components.mjs",
-    "backend:stage": "pnpm python:stage",
-    "shared:verify": "pnpm --filter @zml/shared typecheck && pnpm --filter @zml/shared build",
-    "frontend:verify": "pnpm shared:verify && pnpm --filter @zml/electron-ui typecheck && pnpm --filter @zml/electron-ui lint && pnpm --filter @zml/electron-ui test && pnpm --filter @zml/electron-ui build",
-    "frontend:build": "pnpm --filter @zml/shared build && pnpm --filter @zml/electron-ui build",
-    "frontend:package": "pnpm --filter @zml/shared build && pnpm --filter @zml/electron-ui package",
-    "verify": "pnpm ocr-protocol:verify && pnpm ocr-agent:verify && pnpm bridge:verify && pnpm frontend:verify",
-    "build": "pnpm frontend:build",
-    "package": "pnpm ocr-agent:package && pnpm bridge:package && pnpm python:stage && pnpm frontend:package",
-    "lint": "cd packages/ocr-protocol && just lint && cd ../../apps/ocr-agent && just lint && cd ../game-bridge && just lint && cd ../.. && pnpm --filter @zml/electron-ui lint"
-  },
   "devDependencies": {
     "concurrently": "^9.2.1",
     "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,27 @@
     "apps/*",
     "packages/*"
   ],
+  "scripts": {
+    "dev": "just dev",
+    "ocr-protocol:format": "just protocol format",
+    "ocr-protocol:verify": "just protocol verify",
+    "bridge:format": "just backend format",
+    "bridge:package": "just backend package",
+    "bridge:verify": "just backend verify",
+    "ocr-agent:format": "just ocr format",
+    "ocr-agent:package": "just ocr package",
+    "ocr-agent:verify": "just ocr verify",
+    "python:stage": "just stage-python",
+    "backend:stage": "just stage-python",
+    "shared:verify": "just shared verify",
+    "frontend:verify": "just shared verify && just desktop verify",
+    "frontend:build": "just build",
+    "frontend:package": "just shared build && just desktop package",
+    "verify": "just verify",
+    "build": "just build",
+    "package": "just package",
+    "lint": "just lint"
+  },
   "devDependencies": {
     "concurrently": "^9.2.1",
     "eslint-config-prettier": "^10.1.8",

--- a/packages/shared/justfile
+++ b/packages/shared/justfile
@@ -1,0 +1,13 @@
+default:
+    just --list
+
+dev:
+    pnpm dev
+
+typecheck:
+    pnpm typecheck
+
+build:
+    pnpm build
+
+verify: typecheck build


### PR DESCRIPTION
## What changed

- added a root `justfile` as the repository-level task interface
- exposed backend, OCR Agent, OCR protocol, Electron UI, and shared TS package as `just` modules
- added local `justfile`s for Electron UI and the shared TS package
- changed root `package.json` scripts into thin compatibility aliases that delegate to `just`
- updated frontend CI and Windows desktop packaging to use the root task interface directly

## Why

The repository currently has three overlapping orchestration layers: pnpm scripts, component-level justfiles, and uv commands. This change makes responsibilities explicit:

- `just` orchestrates repository tasks
- `pnpm` owns JavaScript/TypeScript dependencies and component scripts
- `uv` owns Python environments and dependencies

Existing `pnpm dev`, `pnpm verify`, and component aliases remain available during the transition, but the orchestration logic now lives in one place.

## Scope

This intentionally does **not** introduce a root uv workspace or a shared Python lockfile yet. Existing component `uv.lock` files remain unchanged so this PR can validate the task boundary independently before dependency resolution is reorganized.

## Validation

CI should validate the module paths and frontend recipes. Python component recipes themselves are unchanged from the parent OCR refactor branch.
