### PR TITLE
feat: connect ZML Desktop to ZML Cloud

### DIFF
--- a/apps/backend/src/zml_backend/api/routes/__init__.py
+++ b/apps/backend/src/zml_backend/api/routes/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 
+from .cloud_sync import router as cloud_sync_router
 from .events import router as events_router
 from .health import router as health_router
 from .mining import router as mining_router
@@ -15,4 +16,5 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(runs_router)
     app.include_router(mining_router)
     app.include_router(mining_tools_router)
+    app.include_router(cloud_sync_router)
     app.include_router(position_router)

--- a/apps/backend/src/zml_backend/api/routes/cloud_sync.py
+++ b/apps/backend/src/zml_backend/api/routes/cloud_sync.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+
+from zml_backend.api.dependencies import RuntimeDep
+
+router = APIRouter(prefix="/api/v1/runtime/cloud-sync", tags=["runtime"])
+
+
+class CloudSyncConfigRequest(BaseModel):
+    base_url: str | None = None
+    token: str | None = None
+
+
+@router.put("", status_code=status.HTTP_204_NO_CONTENT)
+def configure_cloud_sync(request: CloudSyncConfigRequest, runtime: RuntimeDep) -> None:
+    base_url = _normalize_optional(request.base_url)
+    token = _normalize_optional(request.token)
+    if (base_url is None) != (token is None):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Cloud sync base URL and token must be configured together",
+        )
+    if base_url is not None and not base_url.startswith(("http://", "https://")):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Cloud sync base URL must use HTTP or HTTPS",
+        )
+
+    runtime.configure_cloud_sync(base_url=base_url, token=token)
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None

--- a/apps/backend/src/zml_backend/runtime/bootstrap.py
+++ b/apps/backend/src/zml_backend/runtime/bootstrap.py
@@ -52,7 +52,7 @@ class RuntimeComponents:
     persisted_events: InMemoryPersistedEventBus
     position_service: PositionTrackingService
     ocr_input_source: OcrInputSource
-    cloud_sync_worker: CloudSyncWorker | None
+    cloud_sync_worker: CloudSyncWorker
     mining_equipment_service: MiningEquipmentService
     run_session_service: RunSessionService
     mining_coordinator: MiningCoordinator
@@ -204,16 +204,19 @@ def build_cloud_sync_worker(
     settings: Settings,
     *,
     pending_db_commands: DbCommandChannel,
-) -> CloudSyncWorker | None:
+) -> CloudSyncWorker:
     base_url = settings.cloud_sync_base_url
     token = settings.cloud_sync_token
-    if base_url is None or token is None:
-        return None
+    client = (
+        CloudSyncClient(base_url=base_url, token=token)
+        if base_url is not None and token is not None
+        else None
+    )
 
     return CloudSyncWorker(
         db_path=settings.db_path,
         pending_db_commands=pending_db_commands,
-        client=CloudSyncClient(base_url=base_url, token=token),
+        client=client,
         interval_s=settings.cloud_sync_interval_s,
         batch_size=settings.cloud_sync_batch_size,
     )
@@ -227,7 +230,7 @@ def build_worker_supervisor(settings: Settings) -> WorkerSupervisor:
         "claim_expiration_maintenance",
         enabled=settings.claim_expiration_maintenance_enabled,
     )
-    supervisor.register("cloud_sync", enabled=settings.cloud_sync_enabled)
+    supervisor.register("cloud_sync", enabled=True)
     supervisor.register("chat_tail", enabled=True)
     supervisor.register("ocr_worker", enabled=settings.ocr_enabled)
     supervisor.register("mock_mining_input", enabled=settings.mock_inputs_enabled)

--- a/apps/backend/src/zml_backend/runtime/cloud_sync.py
+++ b/apps/backend/src/zml_backend/runtime/cloud_sync.py
@@ -144,6 +144,7 @@ class CloudSyncWorker:
             self._batch_size,
         )
         while not stop_event.is_set():
+            self._wake_event.clear()
             try:
                 synced_count = self.sync_once()
             except ChannelClosedError:
@@ -162,7 +163,9 @@ class CloudSyncWorker:
                 if synced_count:
                     logger.info("cloud_sync_completed claims=%s", synced_count)
 
-            self._wait_until_next_sync(stop_event)
+            if stop_event.is_set():
+                break
+            self._wake_event.wait(self._interval_s)
         logger.info("cloud_sync_stopped")
 
     def sync_once(self) -> int:
@@ -182,12 +185,6 @@ class CloudSyncWorker:
         )
         self._pending_db_commands.execute(command, timeout_s=10.0)
         return len(outcomes)
-
-    def _wait_until_next_sync(self, stop_event: threading.Event) -> None:
-        self._wake_event.clear()
-        if stop_event.is_set():
-            return
-        self._wake_event.wait(self._interval_s)
 
     def _read_pending_claims(self) -> list[PendingCloudClaim]:
         conn = open_read_connection(self._db_path)

--- a/apps/backend/src/zml_backend/runtime/cloud_sync.py
+++ b/apps/backend/src/zml_backend/runtime/cloud_sync.py
@@ -108,15 +108,34 @@ class CloudSyncWorker:
         *,
         db_path: Path,
         pending_db_commands: DbCommandChannel,
-        client: CloudSyncClient,
+        client: CloudSyncClient | None,
         interval_s: float,
         batch_size: int,
     ) -> None:
         self._db_path = db_path
         self._pending_db_commands = pending_db_commands
         self._client = client
+        self._client_lock = threading.Lock()
+        self._wake_event = threading.Event()
         self._interval_s = max(5.0, interval_s)
         self._batch_size = max(1, min(250, batch_size))
+
+    def configure(self, *, base_url: str | None, token: str | None) -> None:
+        if (base_url is None) != (token is None):
+            raise ValueError("Cloud sync base URL and token must be configured together")
+
+        client = None
+        if base_url is not None and token is not None:
+            client = CloudSyncClient(base_url=base_url, token=token)
+
+        with self._client_lock:
+            self._client = client
+
+        logger.info("cloud_sync_configuration_changed enabled=%s", client is not None)
+        self.request_sync()
+
+    def request_sync(self) -> None:
+        self._wake_event.set()
 
     def run(self, *, stop_event: threading.Event) -> None:
         logger.info(
@@ -143,21 +162,32 @@ class CloudSyncWorker:
                 if synced_count:
                     logger.info("cloud_sync_completed claims=%s", synced_count)
 
-            stop_event.wait(self._interval_s)
+            self._wait_until_next_sync(stop_event)
         logger.info("cloud_sync_stopped")
 
     def sync_once(self) -> int:
+        with self._client_lock:
+            client = self._client
+        if client is None:
+            return 0
+
         claims = self._read_pending_claims()
         if not claims:
             return 0
 
-        outcomes = self._client.upload_claims(claims)
+        outcomes = client.upload_claims(claims)
         command = RecordCloudSyncOutcomesCommand(
             outcomes=tuple(outcomes),
             updated_ts_ms=_now_ms(),
         )
         self._pending_db_commands.execute(command, timeout_s=10.0)
         return len(outcomes)
+
+    def _wait_until_next_sync(self, stop_event: threading.Event) -> None:
+        self._wake_event.clear()
+        if stop_event.is_set():
+            return
+        self._wake_event.wait(self._interval_s)
 
     def _read_pending_claims(self) -> list[PendingCloudClaim]:
         conn = open_read_connection(self._db_path)

--- a/apps/backend/src/zml_backend/runtime/runtime.py
+++ b/apps/backend/src/zml_backend/runtime/runtime.py
@@ -14,6 +14,7 @@ from zml_backend.application.mining.claims.commands import (
 from zml_backend.application.mining.equipment.service import MiningEquipmentService
 from zml_backend.application.mining.segments.session import RunSessionService
 from zml_backend.application.position.tracking import PositionTrackingService
+from zml_backend.events.envelope import EventEnvelope
 from zml_backend.inputs.chat.runner import start_chat_input
 from zml_backend.inputs.mock.mining import start_mock_mining_input
 from zml_backend.runtime.bootstrap import RuntimeComponents
@@ -28,6 +29,11 @@ from zml_backend.runtime.supervisor import WorkerSupervisor
 from zml_backend.settings import Settings
 
 logger = logging.getLogger(__name__)
+
+_CLOUD_SYNC_WAKE_EVENT_TYPES = {
+    "MiningClaimCreatedEvent",
+    "MiningClaimUpdatedEvent",
+}
 
 
 class AppRuntime:
@@ -46,6 +52,7 @@ class AppRuntime:
         self._supervisor = supervisor
         self._stop_event = threading.Event()
         self._sub_sse = None
+        self._sub_cloud_sync = None
         self._sse_hub = sse_hub
         self._position_hub = position_hub
         self._shutdown_signal = shutdown_signal
@@ -86,6 +93,9 @@ class AppRuntime:
 
     def execute_db_command[T](self, command: DbCommand[T], *, timeout_s: float = 5.0) -> T:
         return self._components.pending_db_commands.execute(command, timeout_s=timeout_s)
+
+    def configure_cloud_sync(self, *, base_url: str | None, token: str | None) -> None:
+        self._components.cloud_sync_worker.configure(base_url=base_url, token=token)
 
     def health(self) -> dict[str, object]:
         return self._supervisor.health()
@@ -140,18 +150,21 @@ class AppRuntime:
             self._settings.ocr_profiling_enabled,
         )
 
+        self._sub_cloud_sync = self._components.persisted_events.subscribe(
+            self._on_persisted_event_for_cloud_sync
+        )
+
         self._supervisor.start_thread(
             name="db_writer",
             target=self._components.db_writer_worker.run,
             worker_kwargs={"stop_event": self._stop_event},
         )
 
-        if self._components.cloud_sync_worker is not None:
-            self._supervisor.start_thread(
-                name="cloud_sync",
-                target=self._components.cloud_sync_worker.run,
-                worker_kwargs={"stop_event": self._stop_event},
-            )
+        self._supervisor.start_thread(
+            name="cloud_sync",
+            target=self._components.cloud_sync_worker.run,
+            worker_kwargs={"stop_event": self._stop_event},
+        )
 
         self._supervisor.start_thread(
             name="input_coordinator",
@@ -192,6 +205,10 @@ class AppRuntime:
 
         if self._sse_hub is not None:
             self._sub_sse = self._components.persisted_events.subscribe(self._sse_hub.on_envelope)
+
+    def _on_persisted_event_for_cloud_sync(self, envelope: EventEnvelope) -> None:
+        if envelope.event_type in _CLOUD_SYNC_WAKE_EVENT_TYPES:
+            self._components.cloud_sync_worker.request_sync()
 
     def _run_claim_expiration_maintenance(self, *, stop_event: threading.Event) -> None:
         interval_s = max(1.0, self._settings.claim_expiration_maintenance_interval_s)
@@ -236,17 +253,20 @@ class AppRuntime:
             return
         logger.info("app_stopping")
         self._stop_event.set()
+        self._components.cloud_sync_worker.request_sync()
 
         if self._sub_sse is not None:
             self._sub_sse.close()
             self._sub_sse = None
+        if self._sub_cloud_sync is not None:
+            self._sub_cloud_sync.close()
+            self._sub_cloud_sync = None
 
         self._supervisor.join_thread("chat_tail")
         self._components.ocr_input_source.stop()
         self._supervisor.join_thread("mock_mining_input")
         self._supervisor.join_thread("claim_expiration_maintenance")
-        if self._components.cloud_sync_worker is not None:
-            self._supervisor.join_thread("cloud_sync")
+        self._supervisor.join_thread("cloud_sync")
 
         self._components.pending_inputs.close()
         self._supervisor.join_thread("input_coordinator")

--- a/apps/backend/src/zml_backend/runtime/runtime.py
+++ b/apps/backend/src/zml_backend/runtime/runtime.py
@@ -14,7 +14,6 @@ from zml_backend.application.mining.claims.commands import (
 from zml_backend.application.mining.equipment.service import MiningEquipmentService
 from zml_backend.application.mining.segments.session import RunSessionService
 from zml_backend.application.position.tracking import PositionTrackingService
-from zml_backend.events.envelope import EventEnvelope
 from zml_backend.inputs.chat.runner import start_chat_input
 from zml_backend.inputs.mock.mining import start_mock_mining_input
 from zml_backend.runtime.bootstrap import RuntimeComponents
@@ -29,11 +28,6 @@ from zml_backend.runtime.supervisor import WorkerSupervisor
 from zml_backend.settings import Settings
 
 logger = logging.getLogger(__name__)
-
-_CLOUD_SYNC_WAKE_EVENT_TYPES = {
-    "MiningClaimCreatedEvent",
-    "MiningClaimUpdatedEvent",
-}
 
 
 class AppRuntime:
@@ -52,7 +46,6 @@ class AppRuntime:
         self._supervisor = supervisor
         self._stop_event = threading.Event()
         self._sub_sse = None
-        self._sub_cloud_sync = None
         self._sse_hub = sse_hub
         self._position_hub = position_hub
         self._shutdown_signal = shutdown_signal
@@ -150,10 +143,6 @@ class AppRuntime:
             self._settings.ocr_profiling_enabled,
         )
 
-        self._sub_cloud_sync = self._components.persisted_events.subscribe(
-            self._on_persisted_event_for_cloud_sync
-        )
-
         self._supervisor.start_thread(
             name="db_writer",
             target=self._components.db_writer_worker.run,
@@ -206,10 +195,6 @@ class AppRuntime:
         if self._sse_hub is not None:
             self._sub_sse = self._components.persisted_events.subscribe(self._sse_hub.on_envelope)
 
-    def _on_persisted_event_for_cloud_sync(self, envelope: EventEnvelope) -> None:
-        if envelope.event_type in _CLOUD_SYNC_WAKE_EVENT_TYPES:
-            self._components.cloud_sync_worker.request_sync()
-
     def _run_claim_expiration_maintenance(self, *, stop_event: threading.Event) -> None:
         interval_s = max(1.0, self._settings.claim_expiration_maintenance_interval_s)
         logger.info("claim_expiration_maintenance_started interval_s=%s", interval_s)
@@ -258,9 +243,6 @@ class AppRuntime:
         if self._sub_sse is not None:
             self._sub_sse.close()
             self._sub_sse = None
-        if self._sub_cloud_sync is not None:
-            self._sub_cloud_sync.close()
-            self._sub_cloud_sync = None
 
         self._supervisor.join_thread("chat_tail")
         self._components.ocr_input_source.stop()

--- a/apps/backend/tests/runtime/test_runtime_ocr_input.py
+++ b/apps/backend/tests/runtime/test_runtime_ocr_input.py
@@ -49,21 +49,11 @@ class _Worker:
 
 
 class _CloudSyncWorker(_Worker):
-    def __init__(self) -> None:
-        self.wake_calls = 0
+    def configure(self, *, base_url: str | None, token: str | None) -> None:
+        del base_url, token
 
     def request_sync(self) -> None:
-        self.wake_calls += 1
-
-
-class _Subscription:
-    def close(self) -> None:
         pass
-
-
-class _PersistedEvents:
-    def subscribe(self, _handler: object) -> _Subscription:
-        return _Subscription()
 
 
 class _Restorer:
@@ -106,7 +96,6 @@ def test_app_runtime_delegates_ocr_lifecycle_to_input_source() -> None:
     pending_events = _Channel()
     pending_db_commands = _Channel()
     restorer = _Restorer()
-    cloud_sync_worker = _CloudSyncWorker()
     components = cast(
         RuntimeComponents,
         _Components(
@@ -115,7 +104,6 @@ def test_app_runtime_delegates_ocr_lifecycle_to_input_source() -> None:
             pending_events=pending_events,
             pending_db_commands=pending_db_commands,
             restorer=restorer,
-            cloud_sync_worker=cloud_sync_worker,
         ),
     )
     supervisor = _Supervisor()
@@ -145,9 +133,8 @@ def test_app_runtime_delegates_ocr_lifecycle_to_input_source() -> None:
 
     assert ocr_source.stop_event.is_set()
     assert ocr_source.stop_calls == 1
-    assert cloud_sync_worker.wake_calls == 1
-    assert "cloud_sync" in supervisor.joined
     assert "ocr_worker" not in supervisor.joined
+    assert "cloud_sync" in supervisor.joined
     assert pending_inputs.closed
     assert pending_events.closed
     assert pending_db_commands.closed
@@ -162,15 +149,14 @@ class _Components:
         pending_events: _Channel,
         pending_db_commands: _Channel,
         restorer: _Restorer,
-        cloud_sync_worker: _CloudSyncWorker,
     ) -> None:
         self.pending_inputs = pending_inputs
         self.pending_events = pending_events
         self.pending_db_commands = pending_db_commands
-        self.persisted_events = _PersistedEvents()
+        self.persisted_events = object()
         self.position_service = _PositionService()
         self.ocr_input_source = ocr_source
-        self.cloud_sync_worker = cloud_sync_worker
+        self.cloud_sync_worker = _CloudSyncWorker()
         self.mining_equipment_service = object()
         self.run_session_service = object()
         self.mining_coordinator = object()

--- a/apps/backend/tests/runtime/test_runtime_ocr_input.py
+++ b/apps/backend/tests/runtime/test_runtime_ocr_input.py
@@ -48,6 +48,24 @@ class _Worker:
         del stop_event
 
 
+class _CloudSyncWorker(_Worker):
+    def __init__(self) -> None:
+        self.wake_calls = 0
+
+    def request_sync(self) -> None:
+        self.wake_calls += 1
+
+
+class _Subscription:
+    def close(self) -> None:
+        pass
+
+
+class _PersistedEvents:
+    def subscribe(self, _handler: object) -> _Subscription:
+        return _Subscription()
+
+
 class _Restorer:
     def __init__(self) -> None:
         self.restore_calls = 0
@@ -88,6 +106,7 @@ def test_app_runtime_delegates_ocr_lifecycle_to_input_source() -> None:
     pending_events = _Channel()
     pending_db_commands = _Channel()
     restorer = _Restorer()
+    cloud_sync_worker = _CloudSyncWorker()
     components = cast(
         RuntimeComponents,
         _Components(
@@ -96,6 +115,7 @@ def test_app_runtime_delegates_ocr_lifecycle_to_input_source() -> None:
             pending_events=pending_events,
             pending_db_commands=pending_db_commands,
             restorer=restorer,
+            cloud_sync_worker=cloud_sync_worker,
         ),
     )
     supervisor = _Supervisor()
@@ -117,6 +137,7 @@ def test_app_runtime_delegates_ocr_lifecycle_to_input_source() -> None:
     assert ocr_source.stop_event is not None
     assert not ocr_source.stop_event.is_set()
     assert "ocr_worker" not in supervisor.started
+    assert "cloud_sync" in supervisor.started
     assert restorer.restore_calls == 1
     assert shutdown_signal.install_calls == 1
 
@@ -124,6 +145,8 @@ def test_app_runtime_delegates_ocr_lifecycle_to_input_source() -> None:
 
     assert ocr_source.stop_event.is_set()
     assert ocr_source.stop_calls == 1
+    assert cloud_sync_worker.wake_calls == 1
+    assert "cloud_sync" in supervisor.joined
     assert "ocr_worker" not in supervisor.joined
     assert pending_inputs.closed
     assert pending_events.closed
@@ -139,14 +162,15 @@ class _Components:
         pending_events: _Channel,
         pending_db_commands: _Channel,
         restorer: _Restorer,
+        cloud_sync_worker: _CloudSyncWorker,
     ) -> None:
         self.pending_inputs = pending_inputs
         self.pending_events = pending_events
         self.pending_db_commands = pending_db_commands
-        self.persisted_events = object()
+        self.persisted_events = _PersistedEvents()
         self.position_service = _PositionService()
         self.ocr_input_source = ocr_source
-        self.cloud_sync_worker = None
+        self.cloud_sync_worker = cloud_sync_worker
         self.mining_equipment_service = object()
         self.run_session_service = object()
         self.mining_coordinator = object()

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,6 +1,6 @@
 # Z Mining Log Desktop
 
-The Desktop is the Electron + React application. It owns user-facing windows, the renderer security boundary, local Backend process ownership, Backend clients, and distribution of live state to renderer windows.
+The Desktop is the Electron + React application. It owns user-facing windows, the renderer security boundary, local Backend process ownership, Backend clients, ZML Cloud account pairing, and distribution of live state to renderer windows.
 
 ## Runtime boundary
 
@@ -12,15 +12,17 @@ flowchart TB
     Backend -->|SSE events| Main
     Backend -->|WebSocket position| Main
     Main -->|state patches| Renderer
+    Main -->|device-style pairing| Atlas[ZML Atlas / Cloud gateway]
 ```
 
-Renderer windows do not talk directly to Python and do not receive Node integration.
+Renderer windows do not talk directly to Python or ZML Cloud and do not receive Node integration.
 
 ## Source layout
 
 ```text
 electron/
   backend/      REST/SSE/WS clients and Backend process manager
+  cloud/        browser pairing, secure credential storage, connection orchestration
   ipc/          IPC handlers and state pushes
   mining/       Electron-side mining state application
   runs/         Electron-side run state application
@@ -47,6 +49,14 @@ nodeIntegration = false
 
 The preload exposes a narrow `window.zml` API backed by known IPC commands. Prefer adding a specific command over exposing generic filesystem/process access to renderer code.
 
+The ZML Cloud browser-pairing flow also stays behind Electron main:
+
+- Discord OAuth happens only in the system browser through ZML Atlas/ZML Cloud;
+- the renderer receives connection state, never the final `zml_...` credential;
+- the one-time sync credential is encrypted with Electron `safeStorage` before it is persisted;
+- the encrypted credential is restored for the current operating-system user on application restart;
+- the Desktop-managed Backend receives the credential only through its process environment.
+
 ## Backend lifecycle
 
 In the default local development and packaged paths, Electron owns Backend lifecycle.
@@ -58,11 +68,11 @@ sequenceDiagram
     participant W as OCR Worker
 
     D->>B: spawn
-    B->>W: spawn
+    B->>W: spawn OCR Worker
     D->>B: poll /health
     B-->>D: ready/degraded
     Note over D,W: application runs
-    D->>B: shutdown over parent stdin
+    D->>B: shutdown via parent stdin
     B->>W: protocol shutdown
     W-->>B: exit
     B-->>D: exit
@@ -76,6 +86,46 @@ Environment overrides:
 ZML_BACKEND_URL
 ZML_MANAGE_BACKEND
 ```
+
+## ZML Cloud connection
+
+The Setup view can connect the Desktop to ZML Cloud without asking the user to copy a sync token manually.
+
+```mermaid
+sequenceDiagram
+    participant D as Desktop
+    participant A as ZML Atlas
+    participant C as ZML Cloud
+    participant B as Browser
+
+    D->>A: POST /api/v1/pairing
+    A-->>D: pairing id + device secret + browser code
+    D->>B: open /pair?id=...&code=...
+    B->>C: Discord login + approve
+    loop until approved
+        D->>A: poll with device secret
+    end
+    D->>A: one-time exchange
+    A-->>D: zml_... credential
+    D->>D: encrypt with safeStorage
+    D->>D: restart managed Backend with credential
+```
+
+The production pairing gateway defaults to:
+
+```text
+https://zml-atlas.zabulog.workers.dev
+```
+
+Development/operator overrides:
+
+```text
+ZML_CLOUD_GATEWAY_URL   # pairing/browser gateway
+ZML_CLOUD_BASE_URL      # Backend claim-sync endpoint override
+ZML_CLOUD_SYNC_TOKEN    # manual token override; takes precedence over secure storage
+```
+
+The environment-token path remains useful for development and debugging. Normal users should use browser pairing. An explicitly external Backend cannot be reconfigured by the Desktop pairing UI and should continue to receive cloud configuration through its own environment.
 
 ## REST contract
 
@@ -129,9 +179,9 @@ The mock Desktop path exercises renderer/Electron behavior without creating the 
 
 ## Desktop state
 
-Electron main keeps an in-memory runtime snapshot containing run/mining/tool/stream state. It pushes bootstrap state and incremental patches through IPC to all renderer windows.
+Electron main keeps an in-memory runtime snapshot containing run/mining/tool/stream/cloud state. It pushes bootstrap state and incremental patches through IPC to all renderer windows.
 
-The renderer should treat Electron main as the Desktop-side source for live state rather than opening independent REST/SSE/WS connections from every window.
+The renderer should treat Electron main as the Desktop-side source for live state rather than opening independent REST/SSE/WS/cloud connections from every window.
 
 ## Windows
 

--- a/apps/desktop/electron/backend/backendProcessManager.ts
+++ b/apps/desktop/electron/backend/backendProcessManager.ts
@@ -27,6 +27,7 @@ export class BackendProcessManager {
   private readonly startupTimeoutMs: number;
   private readonly shutdownTimeoutMs: number;
   private readonly maxRestartsPerMinute: number;
+  private readonly environmentOverrides: Record<string, string> = {};
 
   private child: ChildProcessWithoutNullStreams | null = null;
   private restartTimer: NodeJS.Timeout | null = null;
@@ -46,6 +47,18 @@ export class BackendProcessManager {
     this.startupTimeoutMs = startupTimeoutMs;
     this.shutdownTimeoutMs = shutdownTimeoutMs;
     this.maxRestartsPerMinute = maxRestartsPerMinute;
+  }
+
+  isExternalBackend(): boolean {
+    return this.usingExternalBackend;
+  }
+
+  setEnvironmentOverride(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete this.environmentOverrides[name];
+      return;
+    }
+    this.environmentOverrides[name] = value;
   }
 
   async start(): Promise<boolean> {
@@ -121,6 +134,7 @@ export class BackendProcessManager {
         PYTHONUNBUFFERED: "1",
         ZML_PARENT_MANAGED: "1",
         ...this.launch.environment,
+        ...this.environmentOverrides,
       },
       shell: false,
       stdio: ["pipe", "pipe", "pipe"],

--- a/apps/desktop/electron/cloud/cloudConnectionService.test.ts
+++ b/apps/desktop/electron/cloud/cloudConnectionService.test.ts
@@ -58,8 +58,11 @@ function createService({
   pairingClient?: FakePairingClient;
   credentialStore?: FakeCredentialStore;
 } = {}) {
-  const openExternal = vi.fn(async () => undefined);
-  const applyCredential = vi.fn(async () => undefined);
+  let openedUrl: string | null = null;
+  const openExternal = vi.fn(async (url: string) => {
+    openedUrl = url;
+  });
+  const applyCredential = vi.fn(async (_token: string | null, _restartBackend: boolean) => undefined);
   const onState = vi.fn();
   const service = new CloudConnectionService({
     pairingClient,
@@ -75,6 +78,7 @@ function createService({
     pairingClient,
     credentialStore,
     openExternal,
+    getOpenedUrl: () => openedUrl,
     applyCredential,
     onState,
   };
@@ -99,7 +103,14 @@ describe("CloudConnectionService", () => {
   });
 
   it("pairs through the browser and activates the issued credential", async () => {
-    const { service, pairingClient, credentialStore, openExternal, applyCredential } = createService();
+    const {
+      service,
+      pairingClient,
+      credentialStore,
+      openExternal,
+      getOpenedUrl,
+      applyCredential,
+    } = createService();
 
     const state = await service.connect();
 
@@ -107,7 +118,9 @@ describe("CloudConnectionService", () => {
     expect(state.credentialSource).toBe("secure_store");
     expect(pairingClient.createPairing).toHaveBeenCalledWith("ZML Desktop");
     expect(openExternal).toHaveBeenCalledTimes(1);
-    const approvalUrl = new URL(openExternal.mock.calls[0][0]);
+    const openedUrl = getOpenedUrl();
+    expect(openedUrl).not.toBeNull();
+    const approvalUrl = new URL(openedUrl ?? "https://invalid.example");
     expect(approvalUrl.origin).toBe("https://zml-atlas.example");
     expect(approvalUrl.pathname).toBe("/pair");
     expect(approvalUrl.searchParams.get("id")).toBe("pairing-id");

--- a/apps/desktop/electron/cloud/cloudConnectionService.test.ts
+++ b/apps/desktop/electron/cloud/cloudConnectionService.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CloudConnectionService } from "./cloudConnectionService";
+import type {
+  CloudPairingClientLike,
+  CloudPairingStatus,
+  CreatedCloudPairing,
+  ExchangedCloudCredential,
+} from "./cloudPairingClient";
+import type {
+  CloudCredentialStoreLike,
+  StoredCloudCredential,
+} from "./cloudCredentialStore";
+
+class FakePairingClient implements CloudPairingClientLike {
+  readonly created: CreatedCloudPairing = {
+    id: "pairing-id",
+    deviceSecret: "device-secret",
+    browserCode: "browser-code",
+    label: "ZML Desktop",
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    pollAfterSeconds: 2,
+  };
+  readonly status: CloudPairingStatus = {
+    id: this.created.id,
+    label: this.created.label,
+    status: "approved",
+    expiresAt: this.created.expiresAt,
+  };
+  readonly issued: ExchangedCloudCredential = {
+    id: "token-id",
+    token: "zml_test_token",
+    label: "ZML Desktop",
+    createdAt: "2026-08-10T17:00:00.000Z",
+  };
+
+  createPairing = vi.fn(async () => this.created);
+  pollPairing = vi.fn(async () => this.status);
+  exchangePairing = vi.fn(async () => this.issued);
+}
+
+class FakeCredentialStore implements CloudCredentialStoreLike {
+  credential: StoredCloudCredential | null = null;
+
+  load = vi.fn(async () => this.credential);
+  save = vi.fn(async (credential: StoredCloudCredential) => {
+    this.credential = credential;
+  });
+  delete = vi.fn(async () => {
+    this.credential = null;
+  });
+}
+
+function createService({
+  pairingClient = new FakePairingClient(),
+  credentialStore = new FakeCredentialStore(),
+}: {
+  pairingClient?: FakePairingClient;
+  credentialStore?: FakeCredentialStore;
+} = {}) {
+  const openExternal = vi.fn(async () => undefined);
+  const applyCredential = vi.fn(async () => undefined);
+  const onState = vi.fn();
+  const service = new CloudConnectionService({
+    pairingClient,
+    credentialStore,
+    approvalBaseUrl: "https://zml-atlas.example",
+    openExternal,
+    applyCredential,
+    canApplyCredential: () => true,
+    onState,
+  });
+  return {
+    service,
+    pairingClient,
+    credentialStore,
+    openExternal,
+    applyCredential,
+    onState,
+  };
+}
+
+describe("CloudConnectionService", () => {
+  it("restores a securely stored credential before backend startup", async () => {
+    const credentialStore = new FakeCredentialStore();
+    credentialStore.credential = {
+      tokenId: "stored-id",
+      token: "zml_stored_token",
+      label: "ZML Desktop",
+      createdAt: "2026-08-10T17:00:00.000Z",
+    };
+    const { service, applyCredential } = createService({ credentialStore });
+
+    const state = await service.restore();
+
+    expect(state.status).toBe("connected");
+    expect(state.credentialSource).toBe("secure_store");
+    expect(applyCredential).toHaveBeenCalledWith("zml_stored_token", false);
+  });
+
+  it("pairs through the browser and activates the issued credential", async () => {
+    const { service, pairingClient, credentialStore, openExternal, applyCredential } = createService();
+
+    const state = await service.connect();
+
+    expect(state.status).toBe("connected");
+    expect(state.credentialSource).toBe("secure_store");
+    expect(pairingClient.createPairing).toHaveBeenCalledWith("ZML Desktop");
+    expect(openExternal).toHaveBeenCalledTimes(1);
+    const approvalUrl = new URL(openExternal.mock.calls[0][0]);
+    expect(approvalUrl.origin).toBe("https://zml-atlas.example");
+    expect(approvalUrl.pathname).toBe("/pair");
+    expect(approvalUrl.searchParams.get("id")).toBe("pairing-id");
+    expect(approvalUrl.searchParams.get("code")).toBe("browser-code");
+    expect(pairingClient.pollPairing).toHaveBeenCalledWith("pairing-id", "device-secret");
+    expect(pairingClient.exchangePairing).toHaveBeenCalledWith("pairing-id", "device-secret");
+    expect(credentialStore.save).toHaveBeenCalledWith({
+      tokenId: "token-id",
+      token: "zml_test_token",
+      label: "ZML Desktop",
+      createdAt: "2026-08-10T17:00:00.000Z",
+    });
+    expect(applyCredential).toHaveBeenCalledWith("zml_test_token", true);
+  });
+
+  it("removes the local credential and restarts without cloud sync on disconnect", async () => {
+    const credentialStore = new FakeCredentialStore();
+    credentialStore.credential = {
+      tokenId: "stored-id",
+      token: "zml_stored_token",
+      label: "ZML Desktop",
+      createdAt: "2026-08-10T17:00:00.000Z",
+    };
+    const { service, applyCredential } = createService({ credentialStore });
+    await service.restore();
+    applyCredential.mockClear();
+
+    const state = await service.disconnect();
+
+    expect(state.status).toBe("disconnected");
+    expect(credentialStore.delete).toHaveBeenCalledTimes(1);
+    expect(applyCredential).toHaveBeenCalledWith(null, true);
+  });
+});

--- a/apps/desktop/electron/cloud/cloudConnectionService.test.ts
+++ b/apps/desktop/electron/cloud/cloudConnectionService.test.ts
@@ -62,7 +62,10 @@ function createService({
   const openExternal = vi.fn(async (url: string) => {
     openedUrl = url;
   });
-  const applyCredential = vi.fn(async (_token: string | null, _restartBackend: boolean) => undefined);
+  const applyCredential = vi.fn(async (token: string | null, restartBackend: boolean) => {
+    void token;
+    void restartBackend;
+  });
   const onState = vi.fn();
   const service = new CloudConnectionService({
     pairingClient,

--- a/apps/desktop/electron/cloud/cloudConnectionService.ts
+++ b/apps/desktop/electron/cloud/cloudConnectionService.ts
@@ -1,0 +1,224 @@
+import type { CloudConnectionState } from "@desktop/shared";
+import type {
+  CloudPairingClientLike,
+  ExchangedCloudCredential,
+} from "./cloudPairingClient.ts";
+import type {
+  CloudCredentialStoreLike,
+  StoredCloudCredential,
+} from "./cloudCredentialStore.ts";
+
+export type ApplyCloudCredential = (
+  token: string | null,
+  restartBackend: boolean,
+) => Promise<void>;
+
+type CloudConnectionServiceOptions = {
+  pairingClient: CloudPairingClientLike;
+  credentialStore: CloudCredentialStoreLike;
+  approvalBaseUrl: string;
+  openExternal: (url: string) => Promise<void>;
+  applyCredential: ApplyCloudCredential;
+  canApplyCredential: () => boolean;
+  onState: (state: CloudConnectionState) => void;
+  environmentToken?: string;
+};
+
+export class CloudConnectionService {
+  private readonly pairingClient: CloudPairingClientLike;
+  private readonly credentialStore: CloudCredentialStoreLike;
+  private readonly approvalBaseUrl: string;
+  private readonly openExternal: (url: string) => Promise<void>;
+  private readonly applyCredential: ApplyCloudCredential;
+  private readonly canApplyCredential: () => boolean;
+  private readonly onState: (state: CloudConnectionState) => void;
+  private readonly environmentToken?: string;
+
+  private state: CloudConnectionState = { status: "disconnected" };
+  private attempt = 0;
+
+  constructor(options: CloudConnectionServiceOptions) {
+    this.pairingClient = options.pairingClient;
+    this.credentialStore = options.credentialStore;
+    this.approvalBaseUrl = options.approvalBaseUrl.replace(/\/+$/, "");
+    this.openExternal = options.openExternal;
+    this.applyCredential = options.applyCredential;
+    this.canApplyCredential = options.canApplyCredential;
+    this.onState = options.onState;
+    this.environmentToken = normalizeToken(options.environmentToken);
+  }
+
+  getState(): CloudConnectionState {
+    return { ...this.state };
+  }
+
+  async restore(): Promise<CloudConnectionState> {
+    try {
+      if (this.environmentToken !== undefined) {
+        await this.applyCredential(this.environmentToken, false);
+        return this.setState({
+          status: "connected",
+          credentialSource: "environment",
+          connectedAtTsMs: Date.now(),
+        });
+      }
+
+      const credential = await this.credentialStore.load();
+      if (credential === null) {
+        return this.setState({ status: "disconnected" });
+      }
+
+      await this.applyCredential(credential.token, false);
+      return this.setState({
+        status: "connected",
+        credentialSource: "secure_store",
+        connectedAtTsMs: parseTimestamp(credential.createdAt),
+      });
+    } catch (error) {
+      return this.setState({
+        status: "error",
+        lastError: errorToMessage(error),
+      });
+    }
+  }
+
+  async connect(): Promise<CloudConnectionState> {
+    if (this.environmentToken !== undefined) return this.getState();
+    if (this.state.status === "connected") return this.getState();
+    if (!this.canApplyCredential()) {
+      return this.setState({
+        status: "error",
+        lastError: "ZML Cloud connection requires the Desktop-managed local Backend",
+      });
+    }
+
+    const attempt = ++this.attempt;
+    this.setState({ status: "connecting" });
+
+    try {
+      const pairing = await this.pairingClient.createPairing("ZML Desktop");
+      if (!this.isCurrentAttempt(attempt)) return this.getState();
+
+      const expiresAtTsMs = parseTimestamp(pairing.expiresAt);
+      this.setState({
+        status: "waiting_for_approval",
+        pairingExpiresAtTsMs: expiresAtTsMs,
+      });
+
+      const approvalUrl = new URL("/pair", `${this.approvalBaseUrl}/`);
+      approvalUrl.searchParams.set("id", pairing.id);
+      approvalUrl.searchParams.set("code", pairing.browserCode);
+      await this.openExternal(approvalUrl.toString());
+
+      while (this.isCurrentAttempt(attempt) && Date.now() < expiresAtTsMs) {
+        const status = await this.pairingClient.pollPairing(pairing.id, pairing.deviceSecret);
+        if (!this.isCurrentAttempt(attempt)) return this.getState();
+
+        if (status.status === "approved") {
+          const issued = await this.pairingClient.exchangePairing(pairing.id, pairing.deviceSecret);
+          if (!this.isCurrentAttempt(attempt)) return this.getState();
+          await this.finishConnection(issued);
+          return this.getState();
+        }
+        if (status.status === "expired") {
+          throw new Error("ZML Cloud connection request expired");
+        }
+        if (status.status === "consumed") {
+          throw new Error("ZML Cloud connection request was already used");
+        }
+
+        await delay(pairing.pollAfterSeconds * 1_000);
+      }
+
+      if (this.isCurrentAttempt(attempt)) {
+        throw new Error("ZML Cloud connection request expired");
+      }
+      return this.getState();
+    } catch (error) {
+      if (!this.isCurrentAttempt(attempt)) return this.getState();
+      return this.setState({
+        status: "error",
+        lastError: errorToMessage(error),
+      });
+    }
+  }
+
+  async disconnect(): Promise<CloudConnectionState> {
+    ++this.attempt;
+
+    if (this.environmentToken !== undefined) {
+      return this.setState({
+        status: "error",
+        credentialSource: "environment",
+        connectedAtTsMs: this.state.connectedAtTsMs,
+        lastError: "ZML Cloud is configured by environment variables and cannot be disconnected here",
+      });
+    }
+
+    if (this.state.status === "connecting" || this.state.status === "waiting_for_approval") {
+      return this.setState({ status: "disconnected" });
+    }
+
+    try {
+      await this.credentialStore.delete();
+      if (this.canApplyCredential()) {
+        await this.applyCredential(null, true);
+      }
+      return this.setState({ status: "disconnected" });
+    } catch (error) {
+      return this.setState({
+        status: "error",
+        lastError: errorToMessage(error),
+      });
+    }
+  }
+
+  private async finishConnection(issued: ExchangedCloudCredential): Promise<void> {
+    const credential: StoredCloudCredential = {
+      tokenId: issued.id,
+      token: issued.token,
+      label: issued.label,
+      createdAt: issued.createdAt,
+    };
+    await this.credentialStore.save(credential);
+    await this.applyCredential(credential.token, true);
+    this.setState({
+      status: "connected",
+      credentialSource: "secure_store",
+      connectedAtTsMs: parseTimestamp(credential.createdAt),
+    });
+  }
+
+  private isCurrentAttempt(attempt: number): boolean {
+    return this.attempt === attempt;
+  }
+
+  private setState(next: CloudConnectionState): CloudConnectionState {
+    this.state = {
+      ...next,
+      lastError: next.lastError ?? null,
+    };
+    const snapshot = this.getState();
+    this.onState(snapshot);
+    return snapshot;
+  }
+}
+
+function normalizeToken(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function parseTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) throw new Error("ZML Cloud returned an invalid timestamp");
+  return timestamp;
+}
+
+function errorToMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/desktop/electron/cloud/cloudCredentialStore.ts
+++ b/apps/desktop/electron/cloud/cloudCredentialStore.ts
@@ -47,15 +47,15 @@ export class CloudCredentialStore implements CloudCredentialStoreLike {
         throw new Error("Invalid credential envelope");
       }
       envelope = { version: 1, encrypted: parsed.encrypted };
-    } catch (error) {
-      throw new Error("Stored ZML Cloud credential is invalid", { cause: error });
+    } catch {
+      throw new Error("Stored ZML Cloud credential is invalid");
     }
 
     try {
       const plaintext = safeStorage.decryptString(Buffer.from(envelope.encrypted, "base64"));
       return parseCredential(JSON.parse(plaintext) as unknown);
-    } catch (error) {
-      throw new Error("Stored ZML Cloud credential could not be decrypted", { cause: error });
+    } catch {
+      throw new Error("Stored ZML Cloud credential could not be decrypted");
     }
   }
 

--- a/apps/desktop/electron/cloud/cloudCredentialStore.ts
+++ b/apps/desktop/electron/cloud/cloudCredentialStore.ts
@@ -1,0 +1,109 @@
+import { safeStorage } from "electron";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type StoredCloudCredential = {
+  tokenId: string;
+  token: string;
+  label: string | null;
+  createdAt: string;
+};
+
+type CredentialEnvelope = {
+  version: 1;
+  encrypted: string;
+};
+
+export interface CloudCredentialStoreLike {
+  load(): Promise<StoredCloudCredential | null>;
+  save(credential: StoredCloudCredential): Promise<void>;
+  delete(): Promise<void>;
+}
+
+export class CloudCredentialStore implements CloudCredentialStoreLike {
+  private readonly filePath: string;
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  async load(): Promise<StoredCloudCredential | null> {
+    let raw: string;
+    try {
+      raw = await readFile(this.filePath, "utf8");
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") return null;
+      throw error;
+    }
+
+    if (!safeStorage.isEncryptionAvailable()) {
+      throw new Error("Secure credential storage is unavailable on this system");
+    }
+
+    let envelope: CredentialEnvelope;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (!isRecord(parsed) || parsed.version !== 1 || typeof parsed.encrypted !== "string") {
+        throw new Error("Invalid credential envelope");
+      }
+      envelope = { version: 1, encrypted: parsed.encrypted };
+    } catch (error) {
+      throw new Error("Stored ZML Cloud credential is invalid", { cause: error });
+    }
+
+    try {
+      const plaintext = safeStorage.decryptString(Buffer.from(envelope.encrypted, "base64"));
+      return parseCredential(JSON.parse(plaintext) as unknown);
+    } catch (error) {
+      throw new Error("Stored ZML Cloud credential could not be decrypted", { cause: error });
+    }
+  }
+
+  async save(credential: StoredCloudCredential): Promise<void> {
+    if (!safeStorage.isEncryptionAvailable()) {
+      throw new Error("Secure credential storage is unavailable on this system");
+    }
+
+    const plaintext = JSON.stringify(credential);
+    const encrypted = safeStorage.encryptString(plaintext).toString("base64");
+    const envelope: CredentialEnvelope = { version: 1, encrypted };
+    await mkdir(path.dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, `${JSON.stringify(envelope)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+  }
+
+  async delete(): Promise<void> {
+    await rm(this.filePath, { force: true });
+  }
+}
+
+function parseCredential(value: unknown): StoredCloudCredential {
+  if (!isRecord(value)) throw new Error("Invalid credential payload");
+  const tokenId = requiredString(value.tokenId, "token id");
+  const token = requiredString(value.token, "sync token");
+  const createdAt = requiredString(value.createdAt, "creation time");
+  if (!token.startsWith("zml_")) throw new Error("Invalid sync token format");
+  return {
+    tokenId,
+    token,
+    label: typeof value.label === "string" ? value.label : null,
+    createdAt,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid ${field}`);
+  }
+  return value;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/apps/desktop/electron/cloud/cloudPairingClient.ts
+++ b/apps/desktop/electron/cloud/cloudPairingClient.ts
@@ -1,0 +1,153 @@
+export type CreatedCloudPairing = {
+  id: string;
+  deviceSecret: string;
+  browserCode: string;
+  label: string | null;
+  expiresAt: string;
+  pollAfterSeconds: number;
+};
+
+export type CloudPairingStatus = {
+  id: string;
+  label: string | null;
+  status: "pending" | "approved" | "expired" | "consumed";
+  expiresAt: string;
+};
+
+export type ExchangedCloudCredential = {
+  id: string;
+  token: string;
+  label: string | null;
+  createdAt: string;
+};
+
+export interface CloudPairingClientLike {
+  createPairing(label?: string): Promise<CreatedCloudPairing>;
+  pollPairing(pairingId: string, deviceSecret: string): Promise<CloudPairingStatus>;
+  exchangePairing(pairingId: string, deviceSecret: string): Promise<ExchangedCloudCredential>;
+}
+
+export class CloudPairingClient implements CloudPairingClientLike {
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+
+  constructor({ baseUrl, timeoutMs = 10_000 }: { baseUrl: string; timeoutMs?: number }) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.timeoutMs = timeoutMs;
+  }
+
+  async createPairing(label?: string): Promise<CreatedCloudPairing> {
+    const payload = await this.requestJson("/api/v1/pairing", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(label ? { label } : {}),
+    });
+    return parseCreatedPairing(payload);
+  }
+
+  async pollPairing(pairingId: string, deviceSecret: string): Promise<CloudPairingStatus> {
+    const payload = await this.requestJson(`/api/v1/pairing/${encodeURIComponent(pairingId)}`, {
+      headers: { "X-ZML-Pairing-Secret": deviceSecret },
+    });
+    return parsePairingStatus(payload);
+  }
+
+  async exchangePairing(pairingId: string, deviceSecret: string): Promise<ExchangedCloudCredential> {
+    const payload = await this.requestJson(
+      `/api/v1/pairing/${encodeURIComponent(pairingId)}/exchange`,
+      {
+        method: "POST",
+        headers: { "X-ZML-Pairing-Secret": deviceSecret },
+      },
+    );
+    return parseExchangedCredential(payload);
+  }
+
+  private async requestJson(pathname: string, init: RequestInit): Promise<unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(new URL(pathname, `${this.baseUrl}/`), {
+        ...init,
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "ZML-Desktop/1.2",
+          ...init.headers,
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`ZML Cloud request failed (${response.status})`);
+      }
+      return await response.json();
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new Error("ZML Cloud request timed out", { cause: error });
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function parseCreatedPairing(value: unknown): CreatedCloudPairing {
+  if (!isRecord(value)) throw new Error("Invalid pairing response");
+  const id = requiredString(value.id, "pairing id");
+  const deviceSecret = requiredString(value.deviceSecret, "device secret");
+  const browserCode = requiredString(value.browserCode, "browser code");
+  const expiresAt = requiredString(value.expiresAt, "expiry");
+  const pollAfterSeconds = value.pollAfterSeconds;
+  if (typeof pollAfterSeconds !== "number" || !Number.isFinite(pollAfterSeconds)) {
+    throw new Error("Invalid pairing poll interval");
+  }
+  return {
+    id,
+    deviceSecret,
+    browserCode,
+    label: nullableString(value.label),
+    expiresAt,
+    pollAfterSeconds: Math.min(10, Math.max(1, pollAfterSeconds)),
+  };
+}
+
+function parsePairingStatus(value: unknown): CloudPairingStatus {
+  if (!isRecord(value)) throw new Error("Invalid pairing status response");
+  const rawStatus = requiredString(value.status, "pairing status");
+  if (!["pending", "approved", "expired", "consumed"].includes(rawStatus)) {
+    throw new Error("Invalid pairing status");
+  }
+  return {
+    id: requiredString(value.id, "pairing id"),
+    label: nullableString(value.label),
+    status: rawStatus as CloudPairingStatus["status"],
+    expiresAt: requiredString(value.expiresAt, "expiry"),
+  };
+}
+
+function parseExchangedCredential(value: unknown): ExchangedCloudCredential {
+  if (!isRecord(value)) throw new Error("Invalid pairing exchange response");
+  const token = requiredString(value.token, "sync token");
+  if (!token.startsWith("zml_")) throw new Error("Invalid sync token format");
+  return {
+    id: requiredString(value.id, "token id"),
+    token,
+    label: nullableString(value.label),
+    createdAt: requiredString(value.createdAt, "creation time"),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid ${field}`);
+  }
+  return value;
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}

--- a/apps/desktop/electron/cloud/cloudPairingClient.ts
+++ b/apps/desktop/electron/cloud/cloudPairingClient.ts
@@ -27,6 +27,10 @@ export interface CloudPairingClientLike {
   exchangePairing(pairingId: string, deviceSecret: string): Promise<ExchangedCloudCredential>;
 }
 
+type CloudRequestInit = Omit<RequestInit, "headers"> & {
+  headers?: Record<string, string>;
+};
+
 export class CloudPairingClient implements CloudPairingClientLike {
   private readonly baseUrl: string;
   private readonly timeoutMs: number;
@@ -63,7 +67,7 @@ export class CloudPairingClient implements CloudPairingClientLike {
     return parseExchangedCredential(payload);
   }
 
-  private async requestJson(pathname: string, init: RequestInit): Promise<unknown> {
+  private async requestJson(pathname: string, init: CloudRequestInit): Promise<unknown> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -82,7 +86,7 @@ export class CloudPairingClient implements CloudPairingClientLike {
       return await response.json();
     } catch (error) {
       if (controller.signal.aborted) {
-        throw new Error("ZML Cloud request timed out", { cause: error });
+        throw new Error("ZML Cloud request timed out");
       }
       throw error;
     } finally {

--- a/apps/desktop/electron/ipc/registerIpc.ts
+++ b/apps/desktop/electron/ipc/registerIpc.ts
@@ -13,6 +13,7 @@ import {
 } from "@desktop/shared";
 import { runtime } from "../runtime";
 import type { BackendClient } from "../backend/restClient.ts";
+import type { CloudConnectionService } from "../cloud/cloudConnectionService.ts";
 import { pushStatePatch } from "./pushStatePatch.ts";
 import { replaceMiningClaims, replaceMiningDrops } from "../mining/miningDropsState.ts";
 import { replaceMiningLoot, replaceMiningLootTotals } from "../mining/miningLootState.ts";
@@ -22,11 +23,17 @@ type RegisterIpcDeps = {
     backendRestClient: BackendClient;
     toggleMapWindow: () => Promise<boolean>;
     toggleOverlayWindow: () => Promise<boolean>;
+    cloudConnectionService: CloudConnectionService;
 };
 
 let registered = false;
 
-export function registerIpc({ backendRestClient, toggleMapWindow, toggleOverlayWindow }: RegisterIpcDeps): void {
+export function registerIpc({
+    backendRestClient,
+    toggleMapWindow,
+    toggleOverlayWindow,
+    cloudConnectionService,
+}: RegisterIpcDeps): void {
     if (registered) return;
     registered = true;
 
@@ -39,6 +46,7 @@ export function registerIpc({ backendRestClient, toggleMapWindow, toggleOverlayW
             nowTsMs: Date.now(),
             agent: runtime.agent,
             streams: runtime.streams,
+            cloud: runtime.cloud,
             position: runtime.lastPosition,
             mapWindowVisible: runtime.mapWindowVisible,
             overlayWindowVisible: runtime.overlayWindowVisible,
@@ -309,4 +317,7 @@ export function registerIpc({ backendRestClient, toggleMapWindow, toggleOverlayW
         pushStatePatch({ activeMiningTools });
         return activeMiningTools;
     });
+
+    ipcMain.handle(IPC_CMD.CONNECT_CLOUD, async () => cloudConnectionService.connect());
+    ipcMain.handle(IPC_CMD.DISCONNECT_CLOUD, async () => cloudConnectionService.disconnect());
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -216,7 +216,10 @@ function stopPositionStreamIfRunning() {
   stopEventStream = null;
 }
 
-async function applyCloudCredential(token: string | null, restartBackend: boolean): Promise<void> {
+async function applyCloudCredential(
+  token: string | null,
+  applyToRunningBackend: boolean,
+): Promise<void> {
   backendProcessManager.setEnvironmentOverride(
     "ZML_CLOUD_BASE_URL",
     token === null ? undefined : CLOUD_SYNC_BASE_URL,
@@ -226,22 +229,41 @@ async function applyCloudCredential(token: string | null, restartBackend: boolea
     token === null ? undefined : token,
   );
 
-  if (!restartBackend) return;
+  if (!applyToRunningBackend) return;
   if (!MANAGE_BACKEND || backendProcessManager.isExternalBackend()) {
     throw new Error("Cannot update cloud credentials for an external Backend");
   }
 
-  stopPositionStreamIfRunning();
-  await backendProcessManager.stop();
-  const ready = await backendProcessManager.start();
-  if (!ready) {
-    throw new Error("Backend did not become ready after updating ZML Cloud credentials");
-  }
+  await configureRunningBackendCloudSync(token);
+}
 
-  startPositionStream();
-  startEventStream();
-  void refreshRunSnapshot();
-  void refreshMiningToolSnapshot();
+async function configureRunningBackendCloudSync(token: string | null): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const response = await fetch(new URL("/api/v1/runtime/cloud-sync", BACKEND_URL), {
+      method: "PUT",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        base_url: token === null ? null : CLOUD_SYNC_BASE_URL,
+        token,
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Backend cloud sync configuration failed (${response.status})`);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Backend cloud sync configuration timed out");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function updateCloudState(state: ReturnType<CloudConnectionService["getState"]>): void {
@@ -267,7 +289,7 @@ function createCloudConnectionService(): CloudConnectionService {
 }
 
 function updateWindowVisibilityState(): void {
-  runtime.mapWindowVisible = Boolean(mapWin && !mapWin.isDestroyed() && mapWin.isVisible());
+  runtime.mapWindowVisible = Boolean(mainWin && !mainWin.isDestroyed() && mainWin.isVisible());
   runtime.overlayWindowVisible = Boolean(overlayWin && !overlayWin.isDestroyed() && overlayWin.isVisible());
   pushStatePatch({
     mapWindowVisible: runtime.mapWindowVisible,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -289,7 +289,7 @@ function createCloudConnectionService(): CloudConnectionService {
 }
 
 function updateWindowVisibilityState(): void {
-  runtime.mapWindowVisible = Boolean(mainWin && !mainWin.isDestroyed() && mainWin.isVisible());
+  runtime.mapWindowVisible = Boolean(mapWin && !mapWin.isDestroyed() && mapWin.isVisible());
   runtime.overlayWindowVisible = Boolean(overlayWin && !overlayWin.isDestroyed() && overlayWin.isVisible());
   pushStatePatch({
     mapWindowVisible: runtime.mapWindowVisible,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,6 +1,6 @@
-import { app, BrowserWindow } from 'electron'
-import { fileURLToPath } from 'node:url'
-import path from 'node:path'
+import { app, BrowserWindow, shell } from "electron";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 import { resolveDevelopmentAppDataPaths } from "./appDataPaths.ts";
 import { registerIpc } from "./ipc/registerIpc";
@@ -10,13 +10,13 @@ import { createOverlayWindow } from "./windows/createOverlayWindow";
 import { loadRenderer } from "./windows/loadRenderer";
 import { registerWindow } from "./windows/registry";
 
-import {runtime} from "./runtime.ts";
+import { runtime } from "./runtime.ts";
 import {
   startAgentEventStream,
   type AgentEventStreamStatus,
   type StopAgentEventStream,
 } from "./backend/eventStreamClient.ts";
-import {startPositionWsClient} from "./backend/positionWsClient.ts";
+import { startPositionWsClient } from "./backend/positionWsClient.ts";
 import { BackendRestClient } from "./backend/restClient.ts";
 import { isUiMockMode } from "./mocks/mockConfig.ts";
 import { MockBackendRestClient } from "./mocks/mockBackendRestClient.ts";
@@ -36,10 +36,13 @@ import {
 } from "./mining/miningLootState.ts";
 import { applyRunEvent, replaceActiveRun, replaceRunSegments } from "./runs/runSegmentsState.ts";
 import type { PositionSourceOptions, PositionSourceStatus, StopPositionSource } from "./backend/positionSource.ts";
+import { CloudPairingClient } from "./cloud/cloudPairingClient.ts";
+import { CloudCredentialStore } from "./cloud/cloudCredentialStore.ts";
+import { CloudConnectionService } from "./cloud/cloudConnectionService.ts";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-process.env.APP_ROOT = path.join(__dirname, '..')
+process.env.APP_ROOT = path.join(__dirname, "..");
 
 if (!app.isPackaged) {
   const devAppData = resolveDevelopmentAppDataPaths(process.env.APP_ROOT);
@@ -47,13 +50,17 @@ if (!app.isPackaged) {
   process.env.ZML_APP_DATA_DIR ??= devAppData.backend;
 }
 
-export const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL']
-export const MAIN_DIST = path.join(process.env.APP_ROOT, 'dist-electron')
-export const RENDERER_DIST = path.join(process.env.APP_ROOT, 'dist')
-export const preloadPath = path.join(MAIN_DIST, 'preload.mjs')
-process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL ? path.join(process.env.APP_ROOT, 'public') : RENDERER_DIST
+export const VITE_DEV_SERVER_URL = process.env["VITE_DEV_SERVER_URL"];
+export const MAIN_DIST = path.join(process.env.APP_ROOT, "dist-electron");
+export const RENDERER_DIST = path.join(process.env.APP_ROOT, "dist");
+export const preloadPath = path.join(MAIN_DIST, "preload.mjs");
+process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL ? path.join(process.env.APP_ROOT, "public") : RENDERER_DIST;
 
 const BACKEND_URL = process.env.ZML_BACKEND_URL ?? "http://127.0.0.1:17171";
+const CLOUD_GATEWAY_URL = normalizeCloudUrl(
+  process.env.ZML_CLOUD_GATEWAY_URL ?? "https://zml-atlas.zabulog.workers.dev",
+);
+const CLOUD_SYNC_BASE_URL = normalizeCloudUrl(process.env.ZML_CLOUD_BASE_URL ?? CLOUD_GATEWAY_URL);
 const UI_MOCKS_ENABLED = isUiMockMode();
 const MANAGE_BACKEND = shouldManageBackend({
   mocksEnabled: UI_MOCKS_ENABLED,
@@ -77,6 +84,7 @@ let mapWin: BrowserWindow | null = null;
 let overlayWin: BrowserWindow | null = null;
 let stopPositionStream: StopPositionSource | null = null;
 let stopEventStream: StopAgentEventStream | null = null;
+let cloudConnectionService: CloudConnectionService | null = null;
 let appIsQuitting = false;
 let backendShutdownComplete = false;
 let backendShutdownPromise: Promise<void> | null = null;
@@ -99,10 +107,9 @@ function startPositionStream() {
     onEvent: pushPosition,
   };
 
-  stopPositionStream =
-    UI_MOCKS_ENABLED
-      ? startMockPositionSource(options)
-      : startPositionWsClient({
+  stopPositionStream = UI_MOCKS_ENABLED
+    ? startMockPositionSource(options)
+    : startPositionWsClient({
         ...options,
         baseUrl: BACKEND_URL,
       });
@@ -209,6 +216,56 @@ function stopPositionStreamIfRunning() {
   stopEventStream = null;
 }
 
+async function applyCloudCredential(token: string | null, restartBackend: boolean): Promise<void> {
+  backendProcessManager.setEnvironmentOverride(
+    "ZML_CLOUD_BASE_URL",
+    token === null ? undefined : CLOUD_SYNC_BASE_URL,
+  );
+  backendProcessManager.setEnvironmentOverride(
+    "ZML_CLOUD_SYNC_TOKEN",
+    token === null ? undefined : token,
+  );
+
+  if (!restartBackend) return;
+  if (!MANAGE_BACKEND || backendProcessManager.isExternalBackend()) {
+    throw new Error("Cannot update cloud credentials for an external Backend");
+  }
+
+  stopPositionStreamIfRunning();
+  await backendProcessManager.stop();
+  const ready = await backendProcessManager.start();
+  if (!ready) {
+    throw new Error("Backend did not become ready after updating ZML Cloud credentials");
+  }
+
+  startPositionStream();
+  startEventStream();
+  void refreshRunSnapshot();
+  void refreshMiningToolSnapshot();
+}
+
+function updateCloudState(state: ReturnType<CloudConnectionService["getState"]>): void {
+  runtime.cloud = state;
+  pushStatePatch({ cloud: state });
+}
+
+function createCloudConnectionService(): CloudConnectionService {
+  return new CloudConnectionService({
+    pairingClient: new CloudPairingClient({ baseUrl: CLOUD_GATEWAY_URL }),
+    credentialStore: new CloudCredentialStore(
+      path.join(app.getPath("userData"), "cloud-credential.json"),
+    ),
+    approvalBaseUrl: CLOUD_GATEWAY_URL,
+    openExternal: async (url) => {
+      await shell.openExternal(url);
+    },
+    applyCredential: applyCloudCredential,
+    canApplyCredential: () => MANAGE_BACKEND && !backendProcessManager.isExternalBackend(),
+    onState: updateCloudState,
+    environmentToken: process.env.ZML_CLOUD_SYNC_TOKEN,
+  });
+}
+
 function updateWindowVisibilityState(): void {
   runtime.mapWindowVisible = Boolean(mapWin && !mapWin.isDestroyed() && mapWin.isVisible());
   runtime.overlayWindowVisible = Boolean(overlayWin && !overlayWin.isDestroyed() && overlayWin.isVisible());
@@ -275,9 +332,16 @@ function wireHideOnClose(win: BrowserWindow): void {
 }
 
 async function createWindows() {
-  registerIpc({ backendRestClient, toggleMapWindow, toggleOverlayWindow });
+  if (cloudConnectionService === null) {
+    throw new Error("Cloud connection service is not initialized");
+  }
+  registerIpc({
+    backendRestClient,
+    toggleMapWindow,
+    toggleOverlayWindow,
+    cloudConnectionService,
+  });
 
-  // Windows
   mainWin = createMainWindow(preloadPath);
   registerWindow("main", mainWin);
   mainWin.on("closed", () => {
@@ -290,8 +354,6 @@ async function createWindows() {
   await ensureMapWindow();
   await ensureOverlayWindow();
 
-
-  // backend connector (single source of truth)
   startPositionStream();
   startEventStream();
   void refreshRunSnapshot();
@@ -299,6 +361,9 @@ async function createWindows() {
 }
 
 async function startApplication(): Promise<void> {
+  cloudConnectionService = createCloudConnectionService();
+  await cloudConnectionService.restore();
+
   const backendStartup = MANAGE_BACKEND
     ? backendProcessManager.start().catch((error: unknown) => {
         console.error("[backend] failed to start managed backend", error);
@@ -327,27 +392,26 @@ app.on("before-quit", (event) => {
   });
 });
 
-// Quit when all windows are closed, except on macOS. There, it's common
-// for applications and their menu bar to stay active until the user quits
-// explicitly with Cmd + Q.
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit()
-    mainWin = null
-    mapWin = null
-    overlayWin = null
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
+    app.quit();
+    mainWin = null;
+    mapWin = null;
+    overlayWin = null;
   }
-})
+});
 
-app.on('activate', () => {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
+app.on("activate", () => {
   if (BrowserWindow.getAllWindows().length === 0) {
-    createWindows()
+    void createWindows();
   }
-})
+});
 
 void app.whenReady().then(startApplication).catch((error: unknown) => {
   console.error("Application startup failed", error);
   app.quit();
-})
+});
+
+function normalizeCloudUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -3,6 +3,7 @@ import type {
   BackendHealthDto,
   ActiveMiningToolsDto,
   BootstrapState,
+  CloudConnectionState,
   CreateMiningToolProfileRequest,
   GetBootstrapStateReq,
   MiningClaimDto,
@@ -45,6 +46,8 @@ type ZmlApi = {
   deleteMiningTool: (toolId: string) => Promise<void>;
   getActiveMiningTools: () => Promise<ActiveMiningToolsDto>;
   setActiveMiningTools: (request: SetActiveMiningToolsRequest) => Promise<ActiveMiningToolsDto>;
+  connectCloud: () => Promise<CloudConnectionState>;
+  disconnectCloud: () => Promise<CloudConnectionState>;
   onPosition: (cb: (event: OcrPositionEvent) => void) => Unsubscribe;
   onStatePatch: (cb: (patch: RuntimeStatePatch) => void) => Unsubscribe;
 };
@@ -133,6 +136,14 @@ const api: ZmlApi = {
 
   async setActiveMiningTools(request) {
     return ipcRenderer.invoke(IPC_CMD.SET_ACTIVE_MINING_TOOLS, request) as Promise<ActiveMiningToolsDto>;
+  },
+
+  async connectCloud() {
+    return ipcRenderer.invoke(IPC_CMD.CONNECT_CLOUD) as Promise<CloudConnectionState>;
+  },
+
+  async disconnectCloud() {
+    return ipcRenderer.invoke(IPC_CMD.DISCONNECT_CLOUD) as Promise<CloudConnectionState>;
   },
 
   onPosition(cb) {

--- a/apps/desktop/electron/runtime.ts
+++ b/apps/desktop/electron/runtime.ts
@@ -2,6 +2,7 @@ import type {
     BootstrapAgentState,
     BootstrapStreamsState,
     ActiveMiningToolsDto,
+    CloudConnectionState,
     MiningClaimDto,
     MiningDropDto,
     MiningLootItemDto,
@@ -16,6 +17,7 @@ export type RuntimeState = {
     seq: number;
     agent: BootstrapAgentState;
     streams: BootstrapStreamsState;
+    cloud: CloudConnectionState;
     lastError?: string | null;
     lastPosition?: OcrPositionDTO;
     mapWindowVisible: boolean;
@@ -35,6 +37,7 @@ export const runtime: RuntimeState = {
     seq: 0,
     agent: { status: "connecting" },
     streams: { ws: false, sse: false },
+    cloud: { status: "disconnected" },
     lastPosition: undefined,
     mapWindowVisible: false,
     overlayWindowVisible: false,

--- a/apps/desktop/shared/cloud/cloudConnection.ts
+++ b/apps/desktop/shared/cloud/cloudConnection.ts
@@ -1,0 +1,16 @@
+export type CloudConnectionStatus =
+  | "disconnected"
+  | "connecting"
+  | "waiting_for_approval"
+  | "connected"
+  | "error";
+
+export type CloudCredentialSource = "environment" | "secure_store";
+
+export type CloudConnectionState = {
+  status: CloudConnectionStatus;
+  credentialSource?: CloudCredentialSource;
+  connectedAtTsMs?: number;
+  pairingExpiresAtTsMs?: number;
+  lastError?: string | null;
+};

--- a/apps/desktop/shared/index.ts
+++ b/apps/desktop/shared/index.ts
@@ -3,6 +3,8 @@ export * from "./ipc/bootstrap.js";
 export * from "./ipc/push.js";
 export * from "./ipc/channels.js";
 
+export * from "./cloud/cloudConnection.js";
+
 export * from "./dto/worldPos.js";
 export * from "./dto/ocrPosition.js";
 export * from "./dto/miningClaims.js";

--- a/apps/desktop/shared/ipc/bootstrap.ts
+++ b/apps/desktop/shared/ipc/bootstrap.ts
@@ -5,6 +5,7 @@ import type { MiningDropDto } from "../dto/miningDrops";
 import type { MiningLootItemDto, MiningLootTotalDto } from "../dto/miningLoot";
 import type { ActiveMiningToolsDto, MiningToolProfileDto } from "../dto/miningTools";
 import type { RunDto, RunSegmentDto } from "../backend/runs";
+import type { CloudConnectionState } from "../cloud/cloudConnection";
 
 export const IPC_VERSION = 1 as const;
 export type IpcVersion = typeof IPC_VERSION;
@@ -33,6 +34,7 @@ export type BootstrapState = {
 
     agent: BootstrapAgentState;
     streams: BootstrapStreamsState;
+    cloud: CloudConnectionState;
 
     // Last known position (if any)
     position?: OcrPositionDTO;

--- a/apps/desktop/shared/ipc/channels.ts
+++ b/apps/desktop/shared/ipc/channels.ts
@@ -22,6 +22,8 @@ export const IPC_CMD = {
     DELETE_MINING_TOOL: `${IPC_NAMESPACE}:cmd:delete_mining_tool`,
     GET_ACTIVE_MINING_TOOLS: `${IPC_NAMESPACE}:cmd:get_active_mining_tools`,
     SET_ACTIVE_MINING_TOOLS: `${IPC_NAMESPACE}:cmd:set_active_mining_tools`,
+    CONNECT_CLOUD: `${IPC_NAMESPACE}:cmd:connect_cloud`,
+    DISCONNECT_CLOUD: `${IPC_NAMESPACE}:cmd:disconnect_cloud`,
 } as const;
 
 export const IPC_PUSH = {

--- a/apps/desktop/shared/ipc/push.ts
+++ b/apps/desktop/shared/ipc/push.ts
@@ -5,6 +5,7 @@ import type { MiningDropDto } from "../dto/miningDrops";
 import type { MiningLootItemDto, MiningLootTotalDto } from "../dto/miningLoot";
 import type { ActiveMiningToolsDto, MiningToolProfileDto } from "../dto/miningTools";
 import type { RunDto, RunSegmentDto } from "../backend/runs";
+import type { CloudConnectionState } from "../cloud/cloudConnection";
 import type { BootstrapAgentState, BootstrapStreamsState } from "./bootstrap";
 
 // Main -> Renderer (map/hud) push payload
@@ -15,6 +16,7 @@ export type PushPosition = {
 export type RuntimeStatePatch = {
     agent?: BootstrapAgentState;
     streams?: BootstrapStreamsState;
+    cloud?: CloudConnectionState;
     position?: OcrPositionDTO;
     mapWindowVisible?: boolean;
     overlayWindowVisible?: boolean;

--- a/apps/desktop/src/state/zmlRendererStore.ts
+++ b/apps/desktop/src/state/zmlRendererStore.ts
@@ -5,6 +5,7 @@ import type {
   BootstrapAgentState,
   BootstrapState,
   BootstrapStreamsState,
+  CloudConnectionState,
   CreateMiningToolProfileRequest,
   MiningClaimDto,
   MiningDropDto,
@@ -26,6 +27,7 @@ export type ZmlRendererState = {
   bootstrapping: boolean;
   agent: BootstrapAgentState;
   streams: BootstrapStreamsState;
+  cloud: CloudConnectionState;
   position?: OcrPositionDTO;
   positionEvent?: OcrPositionEvent;
   mapWindowVisible: boolean;
@@ -55,6 +57,7 @@ const initialState: ZmlRendererState = {
   bootstrapping: false,
   agent: { status: "connecting" },
   streams: { ws: false, sse: false },
+  cloud: { status: "disconnected" },
   mapWindowVisible: false,
   overlayWindowVisible: false,
   activeRun: null,
@@ -105,6 +108,7 @@ function applyBootstrap(bootstrap: BootstrapState): void {
     bootstrapping: false,
     agent: bootstrap.agent,
     streams: bootstrap.streams,
+    cloud: bootstrap.cloud,
     position: bootstrap.position ?? state.position,
     mapWindowVisible: bootstrap.mapWindowVisible ?? state.mapWindowVisible,
     overlayWindowVisible: bootstrap.overlayWindowVisible ?? state.overlayWindowVisible,
@@ -702,6 +706,42 @@ export async function setActiveMiningTools(request: SetActiveMiningToolsRequest)
       toolCommandPending: false,
       lastCommandError: errorToMessage(error),
     });
+  }
+}
+
+export async function connectCloud(): Promise<void> {
+  let api;
+  try {
+    api = getZml();
+  } catch (error) {
+    setState({ lastCommandError: errorToMessage(error) });
+    return;
+  }
+
+  setState({ lastCommandError: null });
+  try {
+    const cloud = await api.connectCloud();
+    setState({ cloud, lastCommandError: cloud.lastError ?? null });
+  } catch (error) {
+    setState({ lastCommandError: errorToMessage(error) });
+  }
+}
+
+export async function disconnectCloud(): Promise<void> {
+  let api;
+  try {
+    api = getZml();
+  } catch (error) {
+    setState({ lastCommandError: errorToMessage(error) });
+    return;
+  }
+
+  setState({ lastCommandError: null });
+  try {
+    const cloud = await api.disconnectCloud();
+    setState({ cloud, lastCommandError: cloud.lastError ?? null });
+  } catch (error) {
+    setState({ lastCommandError: errorToMessage(error) });
   }
 }
 

--- a/apps/desktop/src/types/zml.d.ts
+++ b/apps/desktop/src/types/zml.d.ts
@@ -2,6 +2,7 @@ import type {
   BackendHealthDto,
   ActiveMiningToolsDto,
   BootstrapState,
+  CloudConnectionState,
   CreateMiningToolProfileRequest,
   MiningClaimDto,
   MiningToolProfileDto,
@@ -40,6 +41,8 @@ declare global {
       deleteMiningTool: (toolId: string) => Promise<void>;
       getActiveMiningTools: () => Promise<ActiveMiningToolsDto>;
       setActiveMiningTools: (request: SetActiveMiningToolsRequest) => Promise<ActiveMiningToolsDto>;
+      connectCloud: () => Promise<CloudConnectionState>;
+      disconnectCloud: () => Promise<CloudConnectionState>;
       onPosition: (cb: (event: OcrPositionEvent) => void) => () => void;
       onStatePatch: (cb: (patch: RuntimeStatePatch) => void) => () => void;
     };

--- a/apps/desktop/src/windows/miningToolsPanel.tsx
+++ b/apps/desktop/src/windows/miningToolsPanel.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import type {
   ActiveMiningToolsDto,
+  CloudConnectionState,
   MiningToolKind,
   MiningToolProfileDto,
 } from "@desktop/shared";
 import {
+  connectCloud,
   createMiningTool,
   deleteMiningTool,
+  disconnectCloud,
   refreshMiningTools,
   setActiveMiningTools,
+  useZmlRendererStore,
 } from "../state/zmlRendererStore";
 
 type MiningToolsPanelProps = {
@@ -39,6 +43,7 @@ export function MiningToolsPanel({
   loading,
   pending,
 }: MiningToolsPanelProps) {
+  const cloud = useZmlRendererStore("main").cloud;
   const [kind, setKind] = useState<MiningToolKind>("finder");
   const [name, setName] = useState("");
   const [decayMpec, setDecayMpec] = useState("0");
@@ -106,6 +111,8 @@ export function MiningToolsPanel({
 
   return (
     <section style={panelStyle}>
+      <CloudConnectionSection cloud={cloud} />
+
       <div style={panelHeaderStyle}>
         <h3 style={{ margin: 0 }}>Mining Tools</h3>
         <button
@@ -345,6 +352,76 @@ export function MiningToolsPanel({
   );
 }
 
+function CloudConnectionSection({ cloud }: { cloud: CloudConnectionState }) {
+  const pending = cloud.status === "connecting" || cloud.status === "waiting_for_approval";
+  const environmentManaged = cloud.credentialSource === "environment";
+  const statusLabel = cloudStatusLabel(cloud);
+
+  return (
+    <div style={cloudSectionStyle}>
+      <div style={cloudCopyStyle}>
+        <div style={cloudTitleRowStyle}>
+          <h3 style={{ margin: 0 }}>ZML Cloud</h3>
+          <span style={cloudStatusStyle(cloud.status === "connected")}>{statusLabel}</span>
+        </div>
+        <div style={mutedStyle}>
+          Sync complete mining claim observations through your ZML account. Discord authorization opens in your browser; Desktop stores only a revocable ZML credential.
+        </div>
+        {cloud.status === "waiting_for_approval" && cloud.pairingExpiresAtTsMs !== undefined && (
+          <div style={cloudHintStyle}>
+            Waiting for browser approval. Request expires at {new Date(cloud.pairingExpiresAtTsMs).toLocaleTimeString()}.
+          </div>
+        )}
+        {cloud.status === "connected" && (
+          <div style={cloudHintStyle}>
+            {environmentManaged
+              ? "Connected using the ZML_CLOUD_SYNC_TOKEN development override."
+              : "Connected. The credential is encrypted for this operating-system user and restored on restart."}
+          </div>
+        )}
+        {cloud.lastError && <div style={errorStyle}>{cloud.lastError}</div>}
+      </div>
+
+      <div style={cloudActionsStyle}>
+        {(cloud.status === "disconnected" || cloud.status === "error") && (
+          <button type="button" onClick={() => void connectCloud()} disabled={environmentManaged}>
+            Connect ZML Cloud
+          </button>
+        )}
+        {pending && (
+          <button type="button" onClick={() => void disconnectCloud()}>
+            Cancel
+          </button>
+        )}
+        {cloud.status === "connected" && (
+          <button
+            type="button"
+            onClick={() => void disconnectCloud()}
+            disabled={environmentManaged}
+          >
+            {environmentManaged ? "Managed by environment" : "Disconnect"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function cloudStatusLabel(cloud: CloudConnectionState): string {
+  switch (cloud.status) {
+    case "disconnected":
+      return "Not connected";
+    case "connecting":
+      return "Connecting...";
+    case "waiting_for_approval":
+      return "Waiting for approval";
+    case "connected":
+      return "Connected";
+    case "error":
+      return "Connection error";
+  }
+}
+
 function parseToolForm({
   kind,
   name,
@@ -427,6 +504,52 @@ const panelHeaderStyle = {
   gap: 12,
   alignItems: "center",
 } satisfies CSSProperties;
+
+const cloudSectionStyle = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: 16,
+  marginBottom: 16,
+  padding: 12,
+  border: "1px solid #2c3f52",
+  borderRadius: 8,
+  background: "#101923",
+} satisfies CSSProperties;
+
+const cloudCopyStyle = {
+  display: "grid",
+  gap: 6,
+  minWidth: 0,
+} satisfies CSSProperties;
+
+const cloudTitleRowStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: 10,
+} satisfies CSSProperties;
+
+const cloudActionsStyle = {
+  display: "flex",
+  alignItems: "center",
+  flexShrink: 0,
+} satisfies CSSProperties;
+
+const cloudHintStyle = {
+  color: "#a7d7ff",
+  fontSize: 12,
+} satisfies CSSProperties;
+
+function cloudStatusStyle(connected: boolean): CSSProperties {
+  return {
+    padding: "3px 7px",
+    border: `1px solid ${connected ? "#316b4a" : "#4b5666"}`,
+    borderRadius: 99,
+    color: connected ? "#8ee3af" : "#a9b6c8",
+    fontSize: 11,
+    fontWeight: 700,
+  };
+}
 
 const splitGridStyle = {
   display: "grid",

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -23,6 +23,7 @@ Current capabilities include:
 - drop, claim, and loot views;
 - dashboard, map, overlay, health, and debugging UI;
 - opt-in background upload of complete claim observations to ZML Cloud;
+- browser-based ZML Cloud device pairing through Atlas, with an encrypted Desktop credential;
 - mock input paths for development;
 - Windows installer packaging with both Python processes bundled.
 
@@ -41,14 +42,17 @@ The large OCR/repository refactor is complete:
 - application names are now consistently `desktop`, `backend`, and `ocr-worker`.
 - Windows CI verifies both raw and Electron-bundled Backend/OCR process trees.
 
-The first ZML Cloud write boundary is also intentionally narrow:
+The ZML Cloud write boundary is intentionally narrow:
 
 - local SQLite remains the source of truth for the user's mining history;
 - a cloud outage never blocks OCR, claim persistence, or local UI updates;
 - only complete claim map observations are uploaded;
 - no ammo, cost, finder, amplifier, bankroll, or run-return data is sent;
 - per-claim cloud outcomes are written back through `DbWriterWorker`, not an ad-hoc SQLite writer;
-- manual `zml_...` token configuration is temporary until browser-based device pairing exists.
+- normal Desktop connection uses short-lived browser/device pairing through ZML Atlas;
+- Discord credentials never enter Electron and the final `zml_...` credential never enters the renderer;
+- the Desktop credential is encrypted with Electron `safeStorage` and restored before the managed Backend starts;
+- manual `ZML_CLOUD_SYNC_TOKEN` configuration remains only as a development/operator override.
 
 ## Stable design rules
 
@@ -62,31 +66,38 @@ Do not rebuild these casually:
 - OCR observations are rejected until the full desired config revision is acknowledged.
 - Desktop renderer remains behind the preload/IPC boundary.
 - Cloud synchronization stays asynchronous and local-first.
+- Desktop pairing credentials stay in Electron main / Backend process boundaries, never renderer state.
 
 ## Highest-value next work
 
-1. **Operational gameplay validation**
+1. **Cloud connection production smoke**
+   - run the packaged Desktop through Connect -> Discord -> approve -> automatic exchange;
+   - verify the managed Backend restarts with the encrypted credential and pending complete claims upload;
+   - restart Desktop and verify the connection restores without a second Discord login;
+   - verify Disconnect removes the local credential and restarts without cloud sync.
+
+2. **Operational gameplay validation**
    - longer packaged gameplay smoke/soak sessions;
    - observe worker restart/health behavior under real game conditions;
    - tune OCR based on captured evidence rather than architecture churn.
 
-2. **Cloud connection UX**
-   - replace manual sync-token configuration with browser-based device pairing;
-   - expose connection/sync status without leaking credentials;
-   - validate periodic uploads on real mining sessions before expanding the payload.
+3. **Public Atlas read path**
+   - expose purpose-built anonymous claim reads from ZML Cloud;
+   - query by planet and visible viewport rather than downloading the whole dataset;
+   - replace Atlas sample points with real observations before adding clustering/heatmaps.
 
-3. **Runtime configuration UX**
+4. **Runtime configuration UX**
    - expose safe OCR/runtime settings beyond environment-only configuration;
    - define which changes apply live and which require worker restart.
 
-4. **ROI calibration**
+5. **ROI calibration**
    - finish finder calibration UX;
    - add compass/lon/lat calibration and reusable presets.
 
-5. **Debug/operator UX**
+6. **Debug/operator UX**
    - replace JSON-heavy diagnostics with concise worker/OCR/run/event/warning panels.
 
-6. **Persistence/domain cleanup as features demand it**
+7. **Persistence/domain cleanup as features demand it**
    - keep the event journal focused on durable reconstruction facts;
    - revisit unused fields only when product behavior makes the decision clear.
 
@@ -94,6 +105,7 @@ Do not rebuild these casually:
 
 These are useful but do not justify another large refactor by themselves:
 
+- server-side revocation/account management for paired Desktop credentials beyond local Disconnect;
 - move the `openapi-typescript` generator into the pnpm lock instead of invoking it through `pnpm dlx`;
 - consider a stronger typed contract for SSE event payloads if manual runtime validators become costly;
 - clean remaining non-protocol `Agent` naming where it still means Backend rather than OCR protocol vocabulary;
@@ -119,6 +131,8 @@ Desktop:
 ```text
 apps/desktop/electron/main.ts
 apps/desktop/electron/backend/backendProcessManager.ts
+apps/desktop/electron/cloud/cloudConnectionService.ts
+apps/desktop/electron/cloud/cloudCredentialStore.ts
 apps/desktop/electron/ipc/registerIpc.ts
 apps/desktop/electron/preload.ts
 apps/desktop/src/state/zmlRendererStore.ts


### PR DESCRIPTION
## Summary

- add browser-based ZML Cloud pairing to Electron main through the production Atlas gateway
- keep the final `zml_...` credential out of the renderer and encrypt it at rest with Electron `safeStorage`
- restore the stored credential on application startup
- reconfigure the already-running local Backend cloud-sync worker through a localhost-only runtime endpoint instead of restarting the mining/OCR runtime
- keep cloud sync batched on the existing periodic interval (10 minutes by default); connect/restore may trigger an immediate backlog attempt, but individual claims do not trigger network requests
- retain `ZML_CLOUD_SYNC_TOKEN` / `ZML_CLOUD_BASE_URL` as development overrides
- expose cloud connection state through the existing typed preload/IPC/runtime-state boundary
- add Connect / Cancel / Disconnect controls in the Setup view
- add focused tests for restore, pairing/exchange, disconnect orchestration and runtime lifecycle

## Production flow

```text
ZML Desktop
  -> POST Atlas /api/v1/pairing
  -> open Atlas /pair in system browser
  -> Discord approval
  -> poll approved
  -> one-time exchange for zml_...
  -> Electron safeStorage
  -> configure the already-running local CloudSyncWorker
  -> periodic batched upload of pending complete claims
```

Connect/disconnect no longer restarts the Backend, OCR worker, chat tail, or mining lifecycle. The renderer never receives the sync token or Discord credentials.

## Configuration

- pairing/browser gateway defaults to `https://zml-atlas.zabulog.workers.dev`
- `ZML_CLOUD_GATEWAY_URL` may override the pairing gateway for development
- `ZML_CLOUD_BASE_URL` remains an optional sync endpoint override
- `ZML_CLOUD_SYNC_TOKEN` remains a manual development override and takes precedence over the encrypted store
- `ZML_CLOUD_SYNC_INTERVAL_S` remains 600 seconds by default

## Verification

- production Connect -> Discord -> approve -> automatic exchange -> Connected: passed
- application restart -> secure credential restore -> Connected: passed
- latest CI #143: green

The remaining manual confidence check is that the next periodic sync after restore uploads pending claims without requiring a reconnect.