### PR TITLE
chore: prepare ZML Desktop 0.2.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zml/desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Local-first Entropia Universe mining tracker",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release 0.2.0

Bumps the ZML Desktop application version from `0.1.0` to `0.2.0` so the tagged Windows release pipeline can publish `v0.2.0`.

### Highlights since 0.1.0

- ZML Cloud claim sync with privacy-minimized mining observations
- browser-based Discord pairing for ZML Desktop
- encrypted local cloud credential storage through Electron `safeStorage`
- cloud connection restore across application restarts
- periodic batched cloud synchronization without coupling network requests to individual claims
- live/restored planet context for claims and the desktop map
- standalone managed OCR Worker process with independent packaging and restart isolation
- consolidated Backend / Desktop / OCR Worker architecture and Windows packaging pipeline

### Release flow

After this PR is merged and CI is green, create tag `v0.2.0` from `master`. `.github/workflows/package-windows.yml` validates that the tag matches `apps/desktop/package.json`, builds the Windows NSIS installer, reruns packaged process-tree verification, uploads the installer, and publishes the GitHub Release.

No Python package/protocol version is changed here; `0.2.0` is the Desktop/product release version.