### PR TITLE
feat: include claim depth in cloud sync

### DIFF
--- a/apps/backend/src/zml_backend/persistence/cloud_sync.py
+++ b/apps/backend/src/zml_backend/persistence/cloud_sync.py
@@ -16,6 +16,7 @@ class PendingCloudClaim:
     y: int
     resource_name: str
     size_index: int
+    depth_m: float
     observed_ts_ms: int
 
 
@@ -40,6 +41,7 @@ class CloudClaimSyncStore:
                 c.y,
                 c.resource_name,
                 c.size_index,
+                c.depth_m,
                 c.observed_ts_ms
             FROM mining_claims AS c
             LEFT JOIN cloud_claim_sync AS s ON s.claim_id = c.claim_id
@@ -51,6 +53,7 @@ class CloudClaimSyncStore:
               AND c.resource_name IS NOT NULL
               AND TRIM(c.resource_name) <> ''
               AND c.size_index IS NOT NULL
+              AND c.depth_m IS NOT NULL
             ORDER BY c.observed_ts_ms ASC, c.created_event_id ASC
             LIMIT ?
             """,
@@ -64,6 +67,7 @@ class CloudClaimSyncStore:
                 y=int(row["y"]),
                 resource_name=str(row["resource_name"]),
                 size_index=int(row["size_index"]),
+                depth_m=float(row["depth_m"]),
                 observed_ts_ms=int(row["observed_ts_ms"]),
             )
             for row in cur.fetchall()

--- a/apps/backend/src/zml_backend/runtime/cloud_sync.py
+++ b/apps/backend/src/zml_backend/runtime/cloud_sync.py
@@ -64,6 +64,7 @@ class CloudSyncClient:
                     "y": claim.y,
                     "resourceName": claim.resource_name,
                     "sizeIndex": claim.size_index,
+                    "depthM": claim.depth_m,
                     "observedTsMs": claim.observed_ts_ms,
                 }
                 for claim in claims

--- a/apps/backend/tests/persistence/test_cloud_sync.py
+++ b/apps/backend/tests/persistence/test_cloud_sync.py
@@ -18,7 +18,7 @@ def test_cloud_sync_store_lists_complete_unsynced_claims_and_records_outcomes(tm
             INSERT INTO events (event_id, created_ts_ms, event_type, payload_json)
             VALUES (?, ?, 'MiningClaimCreatedEvent', '{}')
             """,
-            [(1, 1_000), (2, 2_000), (3, 3_000)],
+            [(1, 1_000), (2, 2_000), (3, 3_000), (4, 4_000)],
         )
         conn.executemany(
             """
@@ -30,14 +30,16 @@ def test_cloud_sync_store_lists_complete_unsynced_claims_and_records_outcomes(tm
                 x,
                 y,
                 resource_name,
-                size_index
+                size_index,
+                depth_m
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
-                ("claim-accepted", 1, 1_000, "Calypso", 65_000, 80_000, "Belkar Stone", 12),
-                ("claim-rejected", 2, 2_000, "Calypso", 65_100, 80_100, "Belkar Stone", 13),
-                ("claim-incomplete", 3, 3_000, "Calypso", 65_200, 80_200, None, 14),
+                ("claim-accepted", 1, 1_000, "Calypso", 65_000, 80_000, "Belkar Stone", 12, 812.5),
+                ("claim-rejected", 2, 2_000, "Calypso", 65_100, 80_100, "Belkar Stone", 13, 740.0),
+                ("claim-incomplete", 3, 3_000, "Calypso", 65_200, 80_200, None, 14, 690.0),
+                ("claim-no-depth", 4, 4_000, "Calypso", 65_300, 80_300, "Belkar Stone", 15, None),
             ],
         )
         conn.commit()
@@ -45,13 +47,14 @@ def test_cloud_sync_store_lists_complete_unsynced_claims_and_records_outcomes(tm
         store = CloudClaimSyncStore(conn)
         pending = store.list_pending(limit=250)
         assert [claim.claim_id for claim in pending] == ["claim-accepted", "claim-rejected"]
+        assert [claim.depth_m for claim in pending] == [812.5, 740.0]
 
         store.record_outcomes(
             (
                 CloudSyncOutcome("claim-accepted", "accepted"),
                 CloudSyncOutcome("claim-rejected", "rejected", "unknown_resource"),
             ),
-            updated_ts_ms=4_000,
+            updated_ts_ms=5_000,
         )
         conn.commit()
 
@@ -64,8 +67,8 @@ def test_cloud_sync_store_lists_complete_unsynced_claims_and_records_outcomes(tm
             """
         ).fetchall()
         assert [tuple(row) for row in rows] == [
-            ("claim-accepted", "synced", "accepted", None, 4_000),
-            ("claim-rejected", "rejected", "rejected", "unknown_resource", 4_000),
+            ("claim-accepted", "synced", "accepted", None, 5_000),
+            ("claim-rejected", "rejected", "rejected", "unknown_resource", 5_000),
         ]
     finally:
         conn.close()

--- a/apps/backend/tests/runtime/test_cloud_sync_client.py
+++ b/apps/backend/tests/runtime/test_cloud_sync_client.py
@@ -32,6 +32,7 @@ def _claim(claim_id: str) -> PendingCloudClaim:
         y=80_000,
         resource_name="Belkar Stone",
         size_index=12,
+        depth_m=812.5,
         observed_ts_ms=1_700_000_000_000,
     )
 
@@ -75,6 +76,7 @@ def test_cloud_sync_client_posts_existing_zml_claim_shape(monkeypatch) -> None:
                     "y": 80_000,
                     "resourceName": "Belkar Stone",
                     "sizeIndex": 12,
+                    "depthM": 812.5,
                     "observedTsMs": 1_700_000_000_000,
                 }
             ]


### PR DESCRIPTION
Adds depth to the Desktop-to-Cloud claim payload and waits until local depth is known before enqueueing a claim. Includes persistence and client tests. Depends on zml-cloud PR #14. Closes #62.