### PR TITLE
feat: prototype OCR UI auto-calibration

### DIFF
--- a/apps/ocr-worker/README.md
+++ b/apps/ocr-worker/README.md
@@ -32,6 +32,7 @@ The runtime is pinned to Python 3.13 because the Windows `tesserocr` dependency 
 
 ```text
 src/zml_ocr_worker/
+  calibration/  Compass/Finder screen-region location experiments
   capture/      screen/window capture
   pipelines/    finder and position recognition pipelines
   runtime/      protocol runner, lifecycle, profiling, native runtime setup
@@ -85,6 +86,17 @@ just ocr package
 ```
 
 Useful direct CLI behavior is also exposed by `zml-ocr-worker --version`, `doctor`, and `stdio` inside the uv workspace.
+
+### UI locator POC
+
+The calibration prototype can evaluate a recorded **full Entropia client frame** without changing runtime OCR configuration:
+
+```powershell
+uv run --package zml-ocr-worker zml-ocr-worker locate-ui .\entropia.png
+uv run --package zml-ocr-worker zml-ocr-worker locate-ui .\entropia.png --annotated .\located.png
+```
+
+It prints the detected Finder/Compass rectangles, confidence, and Compass radar radius/scale. The optional annotated image is intended for tuning the locator against different resolutions, Finder positions, and Compass sizes before the calibration logic is enabled automatically in the runtime.
 
 ## Health behavior
 

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/__init__.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/__init__.py
@@ -1,0 +1,12 @@
+from zml_ocr_worker.calibration.compass import CompassLocator, CompassLocatorConfig
+from zml_ocr_worker.calibration.finder import FinderLocator, FinderLocatorConfig
+from zml_ocr_worker.calibration.model import LocatedCompass, LocatedRegion
+
+__all__ = [
+    "CompassLocator",
+    "CompassLocatorConfig",
+    "FinderLocator",
+    "FinderLocatorConfig",
+    "LocatedCompass",
+    "LocatedRegion",
+]

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/compass.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/compass.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.capture.model import RoiRect
+
+
+@dataclass(frozen=True, slots=True)
+class CompassLocatorConfig:
+    search_max_width: int = 1280
+    min_radius_fraction: float = 0.04
+    max_radius_fraction: float = 0.18
+    hough_dp: float = 1.2
+    hough_param1: float = 120.0
+    hough_param2: float = 30.0
+    min_ring_contrast: float = 0.65
+    baseline_radius: float = 142.0
+    left_radius_factor: float = 1.22
+    top_radius_factor: float = 1.49
+    width_radius_factor: float = 2.57
+    height_radius_factor: float = 2.82
+
+
+class CompassLocator:
+    """Locate the movable/resizable Compass from its concentric radar rings."""
+
+    def __init__(self, *, config: CompassLocatorConfig | None = None) -> None:
+        self._config = config or CompassLocatorConfig()
+
+    def locate(self, frame: np.ndarray) -> LocatedCompass | None:
+        if frame.size == 0 or frame.ndim != 3:
+            return None
+
+        search_frame, search_scale = self._search_frame(frame)
+        gray = cv2.cvtColor(search_frame, cv2.COLOR_BGR2GRAY)
+        blurred = cv2.GaussianBlur(gray, (5, 5), 1.2)
+        min_dimension = min(int(gray.shape[0]), int(gray.shape[1]))
+        min_radius = max(12, round(min_dimension * self._config.min_radius_fraction))
+        max_radius = max(min_radius + 1, round(min_dimension * self._config.max_radius_fraction))
+
+        circles = cv2.HoughCircles(
+            blurred,
+            cv2.HOUGH_GRADIENT,
+            dp=self._config.hough_dp,
+            minDist=max(16.0, float(min_radius) * 0.45),
+            param1=self._config.hough_param1,
+            param2=self._config.hough_param2,
+            minRadius=min_radius,
+            maxRadius=max_radius,
+        )
+        if circles is None:
+            return None
+
+        edges = cv2.Canny(gray, 50, 140) > 0
+        best_circle: tuple[float, float, float] | None = None
+        best_score = float("-inf")
+        for raw_circle in circles[0]:
+            circle = (float(raw_circle[0]), float(raw_circle[1]), float(raw_circle[2]))
+            score = _ring_contrast(edges, circle)
+            if score > best_score:
+                best_score = score
+                best_circle = circle
+
+        if best_circle is None or best_score < self._config.min_ring_contrast:
+            return None
+
+        inverse_scale = 1.0 / search_scale
+        center_x = best_circle[0] * inverse_scale
+        center_y = best_circle[1] * inverse_scale
+        radius = best_circle[2] * inverse_scale
+        rect = self._outer_rect(
+            frame_width=int(frame.shape[1]),
+            frame_height=int(frame.shape[0]),
+            center_x=center_x,
+            center_y=center_y,
+            radius=radius,
+        )
+        return LocatedCompass(
+            rect=rect,
+            confidence=min(max(best_score, 0.0), 1.0),
+            scale=radius / self._config.baseline_radius,
+            center_x=center_x,
+            center_y=center_y,
+            radius=radius,
+        )
+
+    def _search_frame(self, frame: np.ndarray) -> tuple[np.ndarray, float]:
+        frame_width = int(frame.shape[1])
+        if frame_width <= self._config.search_max_width:
+            return frame, 1.0
+        scale = self._config.search_max_width / frame_width
+        target_height = max(1, round(int(frame.shape[0]) * scale))
+        resized = cv2.resize(
+            frame,
+            (self._config.search_max_width, target_height),
+            interpolation=cv2.INTER_AREA,
+        )
+        return resized, scale
+
+    def _outer_rect(
+        self,
+        *,
+        frame_width: int,
+        frame_height: int,
+        center_x: float,
+        center_y: float,
+        radius: float,
+    ) -> RoiRect:
+        x1 = round(center_x - radius * self._config.left_radius_factor)
+        y1 = round(center_y - radius * self._config.top_radius_factor)
+        width = round(radius * self._config.width_radius_factor)
+        height = round(radius * self._config.height_radius_factor)
+        x1 = max(0, min(x1, frame_width - 1))
+        y1 = max(0, min(y1, frame_height - 1))
+        x2 = max(x1 + 1, min(frame_width, x1 + width))
+        y2 = max(y1 + 1, min(frame_height, y1 + height))
+        return RoiRect(x1=x1, x2=x2, y1=y1, y2=y2)
+
+
+def _ring_contrast(
+    edge_mask: np.ndarray,
+    circle: tuple[float, float, float],
+) -> float:
+    center_x, center_y, radius = circle
+    ring_fractions = (0.2, 0.4, 0.6, 0.8, 1.0)
+    valley_fractions = (0.1, 0.3, 0.5, 0.7, 0.9)
+    ring_support = sum(
+        _circle_edge_support(edge_mask, center_x, center_y, radius * fraction)
+        for fraction in ring_fractions
+    ) / len(ring_fractions)
+    valley_support = sum(
+        _circle_edge_support(edge_mask, center_x, center_y, radius * fraction)
+        for fraction in valley_fractions
+    ) / len(valley_fractions)
+    return float(ring_support - valley_support * 0.55)
+
+
+def _circle_edge_support(
+    edge_mask: np.ndarray,
+    center_x: float,
+    center_y: float,
+    radius: float,
+    *,
+    samples: int = 120,
+    tolerance_px: int = 1,
+) -> float:
+    height = int(edge_mask.shape[0])
+    width = int(edge_mask.shape[1])
+    hits = 0
+    considered = 0
+    for angle in np.linspace(0.0, np.pi * 2.0, samples, endpoint=False):
+        x = round(center_x + radius * np.cos(angle))
+        y = round(center_y + radius * np.sin(angle))
+        if x < 0 or x >= width or y < 0 or y >= height:
+            continue
+        considered += 1
+        x1 = max(0, x - tolerance_px)
+        x2 = min(width, x + tolerance_px + 1)
+        y1 = max(0, y - tolerance_px)
+        y2 = min(height, y + tolerance_px + 1)
+        if np.any(edge_mask[y1:y2, x1:x2]):
+            hits += 1
+    if considered == 0:
+        return 0.0
+    return hits / considered

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/coordinates.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/coordinates.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.pipelines.mining_finder.engine import FinderTextEngine
+
+_COORDINATE_VALUE_RE = re.compile(r"\b(\d{4,7}|unknown)\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class CompassCoordinateRead:
+    longitude: int | None
+    latitude: int | None
+    longitude_unknown: bool
+    latitude_unknown: bool
+    raw_text: str
+
+    @property
+    def has_position(self) -> bool:
+        return self.longitude is not None and self.latitude is not None
+
+
+class CompassCoordinateReader:
+    """Read Lon/Lat from the local text area below a located Compass radar."""
+
+    def __init__(self, *, text_engine: FinderTextEngine) -> None:
+        self._text_engine = text_engine
+
+    def read(self, frame: np.ndarray, compass: LocatedCompass) -> CompassCoordinateRead:
+        broad = _crop_coordinate_region(frame, compass)
+        broad_text = self._recognize_upscaled(broad, scale=2, psm=6)
+        longitude, longitude_unknown = _parse_labeled_value(broad_text, "lon")
+        latitude, latitude_unknown = _parse_labeled_value(broad_text, "lat")
+
+        fallback_texts: list[str] = []
+        if longitude is None and not longitude_unknown:
+            lon_line = _crop_coordinate_line(frame, compass, start_radius=0.94, end_radius=1.14)
+            lon_text = self._recognize_upscaled(lon_line, scale=3, psm=11)
+            fallback_texts.append(lon_text)
+            longitude, longitude_unknown = _parse_labeled_value(lon_text, "lon")
+
+        if latitude is None and not latitude_unknown:
+            lat_line = _crop_coordinate_line(frame, compass, start_radius=1.10, end_radius=1.34)
+            lat_text = self._recognize_upscaled(lat_line, scale=3, psm=11)
+            fallback_texts.append(lat_text)
+            latitude, latitude_unknown = _parse_labeled_value(lat_text, "lat")
+
+        raw_parts = [part.strip() for part in [broad_text, *fallback_texts] if part.strip()]
+        return CompassCoordinateRead(
+            longitude=longitude,
+            latitude=latitude,
+            longitude_unknown=longitude_unknown,
+            latitude_unknown=latitude_unknown,
+            raw_text="\n---\n".join(raw_parts),
+        )
+
+    def _recognize_upscaled(self, image: np.ndarray, *, scale: int, psm: int) -> str:
+        if image.size == 0:
+            return ""
+        if scale > 1:
+            image = cv2.resize(
+                image,
+                None,
+                fx=float(scale),
+                fy=float(scale),
+                interpolation=cv2.INTER_CUBIC,
+            )
+        return self._text_engine.recognize_text(image, psm=psm)
+
+
+def _crop_coordinate_region(frame: np.ndarray, compass: LocatedCompass) -> np.ndarray:
+    return _crop_from_radar(
+        frame,
+        compass,
+        left_radius=-1.45,
+        right_radius=0.15,
+        top_radius=0.82,
+        bottom_radius=1.52,
+    )
+
+
+def _crop_coordinate_line(
+    frame: np.ndarray,
+    compass: LocatedCompass,
+    *,
+    start_radius: float,
+    end_radius: float,
+) -> np.ndarray:
+    return _crop_from_radar(
+        frame,
+        compass,
+        left_radius=-1.50,
+        right_radius=-0.08,
+        top_radius=start_radius,
+        bottom_radius=end_radius,
+    )
+
+
+def _crop_from_radar(
+    frame: np.ndarray,
+    compass: LocatedCompass,
+    *,
+    left_radius: float,
+    right_radius: float,
+    top_radius: float,
+    bottom_radius: float,
+) -> np.ndarray:
+    height = int(frame.shape[0])
+    width = int(frame.shape[1])
+    radius = compass.radius
+    x1 = max(0, min(width, round(compass.center_x + radius * left_radius)))
+    x2 = max(0, min(width, round(compass.center_x + radius * right_radius)))
+    y1 = max(0, min(height, round(compass.center_y + radius * top_radius)))
+    y2 = max(0, min(height, round(compass.center_y + radius * bottom_radius)))
+    if x2 <= x1 or y2 <= y1:
+        return np.zeros((1, 1, 3), dtype=np.uint8)
+    return np.ascontiguousarray(frame[y1:y2, x1:x2])
+
+
+def _parse_labeled_value(text: str, label: str) -> tuple[int | None, bool]:
+    for line in text.splitlines():
+        normalized = " ".join(line.lower().replace(";", ":").split())
+        if label not in normalized:
+            continue
+        label_index = normalized.find(label)
+        match = _COORDINATE_VALUE_RE.search(normalized[label_index + len(label) :])
+        if match is None:
+            continue
+        value = match.group(1).lower()
+        if value == "unknown":
+            return None, True
+        try:
+            return int(value), False
+        except ValueError:
+            continue
+    return None, False

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/coordinates.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/coordinates.py
@@ -25,32 +25,46 @@ class CompassCoordinateRead:
         return self.longitude is not None and self.latitude is not None
 
 
-class CompassCoordinateReader:
-    """Read Lon/Lat from the local text area below a located Compass radar."""
+@dataclass(frozen=True, slots=True)
+class CompassCoordinateReaderConfig:
+    left_radius: float = -1.48
+    longitude_top_radius: float = 0.94
+    longitude_bottom_radius: float = 1.14
+    latitude_top_radius: float = 1.10
+    latitude_bottom_radius: float = 1.32
+    right_radius_candidates: tuple[float, ...] = (-0.50, -0.28, -0.04, 0.16)
+    upscale_factors: tuple[int, ...] = (3, 4)
+    page_seg_modes: tuple[int, ...] = (7, 11)
 
-    def __init__(self, *, text_engine: FinderTextEngine) -> None:
+
+class CompassCoordinateReader:
+    """Read fixed Lon/Lat lines derived from a located Compass radar."""
+
+    def __init__(
+        self,
+        *,
+        text_engine: FinderTextEngine,
+        config: CompassCoordinateReaderConfig | None = None,
+    ) -> None:
         self._text_engine = text_engine
+        self._config = config or CompassCoordinateReaderConfig()
 
     def read(self, frame: np.ndarray, compass: LocatedCompass) -> CompassCoordinateRead:
-        broad = _crop_coordinate_region(frame, compass)
-        broad_text = self._recognize_upscaled(broad, scale=2, psm=6)
-        longitude, longitude_unknown = _parse_labeled_value(broad_text, "lon")
-        latitude, latitude_unknown = _parse_labeled_value(broad_text, "lat")
-
-        fallback_texts: list[str] = []
-        if longitude is None and not longitude_unknown:
-            lon_line = _crop_coordinate_line(frame, compass, start_radius=0.94, end_radius=1.14)
-            lon_text = self._recognize_upscaled(lon_line, scale=3, psm=11)
-            fallback_texts.append(lon_text)
-            longitude, longitude_unknown = _parse_labeled_value(lon_text, "lon")
-
-        if latitude is None and not latitude_unknown:
-            lat_line = _crop_coordinate_line(frame, compass, start_radius=1.10, end_radius=1.34)
-            lat_text = self._recognize_upscaled(lat_line, scale=3, psm=11)
-            fallback_texts.append(lat_text)
-            latitude, latitude_unknown = _parse_labeled_value(lat_text, "lat")
-
-        raw_parts = [part.strip() for part in [broad_text, *fallback_texts] if part.strip()]
+        longitude, longitude_unknown, longitude_text = self._read_line(
+            frame,
+            compass,
+            label="lon",
+            top_radius=self._config.longitude_top_radius,
+            bottom_radius=self._config.longitude_bottom_radius,
+        )
+        latitude, latitude_unknown, latitude_text = self._read_line(
+            frame,
+            compass,
+            label="lat",
+            top_radius=self._config.latitude_top_radius,
+            bottom_radius=self._config.latitude_bottom_radius,
+        )
+        raw_parts = [part for part in (longitude_text, latitude_text) if part]
         return CompassCoordinateRead(
             longitude=longitude,
             latitude=latitude,
@@ -59,45 +73,54 @@ class CompassCoordinateReader:
             raw_text="\n---\n".join(raw_parts),
         )
 
-    def _recognize_upscaled(self, image: np.ndarray, *, scale: int, psm: int) -> str:
-        if image.size == 0:
-            return ""
-        if scale > 1:
-            image = cv2.resize(
-                image,
-                None,
-                fx=float(scale),
-                fy=float(scale),
-                interpolation=cv2.INTER_CUBIC,
+    def _read_line(
+        self,
+        frame: np.ndarray,
+        compass: LocatedCompass,
+        *,
+        label: str,
+        top_radius: float,
+        bottom_radius: float,
+    ) -> tuple[int | None, bool, str]:
+        attempts: list[str] = []
+        for right_radius in self._config.right_radius_candidates:
+            line = _crop_coordinate_line(
+                frame,
+                compass,
+                left_radius=self._config.left_radius,
+                right_radius=right_radius,
+                top_radius=top_radius,
+                bottom_radius=bottom_radius,
             )
-        return self._text_engine.recognize_text(image, psm=psm)
-
-
-def _crop_coordinate_region(frame: np.ndarray, compass: LocatedCompass) -> np.ndarray:
-    return _crop_from_radar(
-        frame,
-        compass,
-        left_radius=-1.45,
-        right_radius=0.15,
-        top_radius=0.82,
-        bottom_radius=1.52,
-    )
+            for scale in self._config.upscale_factors:
+                prepared = _upscale(line, scale=scale)
+                for psm in self._config.page_seg_modes:
+                    text = self._text_engine.recognize_text(prepared, psm=psm)
+                    stripped = text.strip()
+                    if stripped:
+                        attempts.append(stripped)
+                    value, unknown = _parse_labeled_value(text, label)
+                    if value is not None or unknown:
+                        return value, unknown, "\n".join(attempts)
+        return None, False, "\n".join(attempts)
 
 
 def _crop_coordinate_line(
     frame: np.ndarray,
     compass: LocatedCompass,
     *,
-    start_radius: float,
-    end_radius: float,
+    left_radius: float,
+    right_radius: float,
+    top_radius: float,
+    bottom_radius: float,
 ) -> np.ndarray:
     return _crop_from_radar(
         frame,
         compass,
-        left_radius=-1.50,
-        right_radius=-0.08,
-        top_radius=start_radius,
-        bottom_radius=end_radius,
+        left_radius=left_radius,
+        right_radius=right_radius,
+        top_radius=top_radius,
+        bottom_radius=bottom_radius,
     )
 
 
@@ -120,6 +143,18 @@ def _crop_from_radar(
     if x2 <= x1 or y2 <= y1:
         return np.zeros((1, 1, 3), dtype=np.uint8)
     return np.ascontiguousarray(frame[y1:y2, x1:x2])
+
+
+def _upscale(image: np.ndarray, *, scale: int) -> np.ndarray:
+    if image.size == 0 or scale <= 1:
+        return image
+    return cv2.resize(
+        image,
+        None,
+        fx=float(scale),
+        fy=float(scale),
+        interpolation=cv2.INTER_CUBIC,
+    )
 
 
 def _parse_labeled_value(text: str, label: str) -> tuple[int | None, bool]:

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/debug.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/debug.py
@@ -6,8 +6,10 @@ from pathlib import Path
 import cv2
 
 from zml_ocr_worker.calibration.compass import CompassLocator
+from zml_ocr_worker.calibration.coordinates import CompassCoordinateRead, CompassCoordinateReader
 from zml_ocr_worker.calibration.finder import FinderLocator
 from zml_ocr_worker.calibration.model import LocatedCompass, LocatedRegion
+from zml_ocr_worker.pipelines.mining_finder.engine import TesserocrFinderTextEngine
 
 
 def run_calibration_debug(image_path: Path, *, annotated_path: Path | None = None) -> int:
@@ -17,13 +19,21 @@ def run_calibration_debug(image_path: Path, *, annotated_path: Path | None = Non
 
     finder = FinderLocator().locate(frame)
     compass = CompassLocator().locate(frame)
+    coordinate_read: CompassCoordinateRead | None = None
+    if compass is not None:
+        text_engine = TesserocrFinderTextEngine()
+        try:
+            coordinate_read = CompassCoordinateReader(text_engine=text_engine).read(frame, compass)
+        finally:
+            text_engine.close()
+
     payload = {
         "image": {
             "width": int(frame.shape[1]),
             "height": int(frame.shape[0]),
         },
         "finder": _region_payload(finder),
-        "compass": _compass_payload(compass),
+        "compass": _compass_payload(compass, coordinates=coordinate_read),
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
 
@@ -62,7 +72,11 @@ def _region_payload(region: LocatedRegion | None) -> dict[str, object] | None:
     }
 
 
-def _compass_payload(compass: LocatedCompass | None) -> dict[str, object] | None:
+def _compass_payload(
+    compass: LocatedCompass | None,
+    *,
+    coordinates: CompassCoordinateRead | None,
+) -> dict[str, object] | None:
     payload = _region_payload(compass)
     if payload is None or compass is None:
         return None
@@ -71,7 +85,21 @@ def _compass_payload(compass: LocatedCompass | None) -> dict[str, object] | None
         "centerY": round(compass.center_y, 2),
         "radius": round(compass.radius, 2),
     }
+    payload["coordinates"] = _coordinate_payload(coordinates)
     return payload
+
+
+def _coordinate_payload(read: CompassCoordinateRead | None) -> dict[str, object] | None:
+    if read is None:
+        return None
+    return {
+        "longitude": read.longitude,
+        "latitude": read.latitude,
+        "longitudeUnknown": read.longitude_unknown,
+        "latitudeUnknown": read.latitude_unknown,
+        "hasPosition": read.has_position,
+        "rawText": read.raw_text,
+    }
 
 
 def _draw_region(frame, region: LocatedRegion, *, label: str) -> None:

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/debug.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/debug.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import cv2
+
+from zml_ocr_worker.calibration.compass import CompassLocator
+from zml_ocr_worker.calibration.finder import FinderLocator
+from zml_ocr_worker.calibration.model import LocatedCompass, LocatedRegion
+
+
+def run_calibration_debug(image_path: Path, *, annotated_path: Path | None = None) -> int:
+    frame = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
+    if frame is None:
+        raise ValueError(f"Could not read image: {image_path}")
+
+    finder = FinderLocator().locate(frame)
+    compass = CompassLocator().locate(frame)
+    payload = {
+        "image": {
+            "width": int(frame.shape[1]),
+            "height": int(frame.shape[0]),
+        },
+        "finder": _region_payload(finder),
+        "compass": _compass_payload(compass),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+    if annotated_path is not None:
+        annotated = frame.copy()
+        if finder is not None:
+            _draw_region(annotated, finder, label="Finder")
+        if compass is not None:
+            _draw_region(annotated, compass, label="Compass")
+            cv2.circle(
+                annotated,
+                (round(compass.center_x), round(compass.center_y)),
+                round(compass.radius),
+                (255, 255, 255),
+                1,
+            )
+        annotated_path.parent.mkdir(parents=True, exist_ok=True)
+        if not cv2.imwrite(str(annotated_path), annotated):
+            raise OSError(f"Could not write annotated image: {annotated_path}")
+
+    return 0 if finder is not None or compass is not None else 2
+
+
+def _region_payload(region: LocatedRegion | None) -> dict[str, object] | None:
+    if region is None:
+        return None
+    return {
+        "rect": {
+            "x": region.rect.x1,
+            "y": region.rect.y1,
+            "width": region.rect.x2 - region.rect.x1,
+            "height": region.rect.y2 - region.rect.y1,
+        },
+        "confidence": round(region.confidence, 4),
+        "scale": round(region.scale, 4),
+    }
+
+
+def _compass_payload(compass: LocatedCompass | None) -> dict[str, object] | None:
+    payload = _region_payload(compass)
+    if payload is None or compass is None:
+        return None
+    payload["radar"] = {
+        "centerX": round(compass.center_x, 2),
+        "centerY": round(compass.center_y, 2),
+        "radius": round(compass.radius, 2),
+    }
+    return payload
+
+
+def _draw_region(frame, region: LocatedRegion, *, label: str) -> None:
+    rect = region.rect
+    cv2.rectangle(frame, (rect.x1, rect.y1), (rect.x2, rect.y2), (255, 255, 255), 2)
+    cv2.putText(
+        frame,
+        f"{label} {region.confidence:.2f}",
+        (rect.x1, max(20, rect.y1 - 8)),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.6,
+        (255, 255, 255),
+        2,
+        cv2.LINE_AA,
+    )

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+
+from zml_ocr_worker.calibration.model import LocatedRegion
+from zml_ocr_worker.capture.model import RoiRect
+from zml_ocr_worker.pipelines.mining_finder.presence import FinderPresenceDetector
+
+
+@dataclass(frozen=True, slots=True)
+class FinderLocatorConfig:
+    baseline_client_width: int = 2560
+    baseline_client_height: int = 1440
+    baseline_finder_width: int = 347
+    baseline_finder_height: int = 239
+    scale_tolerance: tuple[float, ...] = (0.98, 1.0, 1.02)
+    coarse_stride_fraction: float = 0.08
+    coarse_candidate_count: int = 6
+    min_confidence: float = 0.68
+
+
+@dataclass(frozen=True, slots=True)
+class _Candidate:
+    x: int
+    y: int
+    width: int
+    height: int
+    scale: float
+    score: float
+    presence: bool
+
+
+class FinderLocator:
+    """Locate the movable Entropia finder at the size implied by client resolution."""
+
+    def __init__(
+        self,
+        *,
+        config: FinderLocatorConfig | None = None,
+        presence_detector: FinderPresenceDetector | None = None,
+    ) -> None:
+        self._config = config or FinderLocatorConfig()
+        self._presence_detector = presence_detector or FinderPresenceDetector()
+
+    def locate(self, frame: np.ndarray) -> LocatedRegion | None:
+        if frame.size == 0 or frame.ndim != 3:
+            return None
+
+        frame_height = int(frame.shape[0])
+        frame_width = int(frame.shape[1])
+        base_scale = min(
+            frame_width / self._config.baseline_client_width,
+            frame_height / self._config.baseline_client_height,
+        )
+        if base_scale <= 0:
+            return None
+
+        best: _Candidate | None = None
+        for tolerance in self._config.scale_tolerance:
+            scale = base_scale * tolerance
+            width = max(80, round(self._config.baseline_finder_width * scale))
+            height = max(50, round(self._config.baseline_finder_height * scale))
+            if width > frame_width or height > frame_height:
+                continue
+            candidate = self._locate_size(frame, width=width, height=height, scale=scale)
+            if candidate is not None and (best is None or candidate.score > best.score):
+                best = candidate
+
+        if best is None or not best.presence or best.score < self._config.min_confidence:
+            return None
+
+        return LocatedRegion(
+            rect=RoiRect(
+                x1=best.x,
+                x2=best.x + best.width,
+                y1=best.y,
+                y2=best.y + best.height,
+            ),
+            confidence=best.score,
+            scale=best.scale,
+        )
+
+    def _locate_size(
+        self,
+        frame: np.ndarray,
+        *,
+        width: int,
+        height: int,
+        scale: float,
+    ) -> _Candidate | None:
+        stride = max(8, round(min(width, height) * self._config.coarse_stride_fraction))
+        coarse: list[_Candidate] = []
+        max_y = int(frame.shape[0]) - height
+        max_x = int(frame.shape[1]) - width
+
+        for y in range(0, max_y + 1, stride):
+            for x in range(0, max_x + 1, stride):
+                candidate = self._score_candidate(
+                    frame,
+                    x=x,
+                    y=y,
+                    width=width,
+                    height=height,
+                    scale=scale,
+                )
+                coarse.append(candidate)
+
+        if not coarse:
+            return None
+        coarse.sort(key=lambda item: item.score, reverse=True)
+
+        best: _Candidate | None = None
+        refine_step = max(1, stride // 8)
+        for seed in coarse[: self._config.coarse_candidate_count]:
+            x_start = max(0, seed.x - stride)
+            x_end = min(max_x, seed.x + stride)
+            y_start = max(0, seed.y - stride)
+            y_end = min(max_y, seed.y + stride)
+            for y in range(y_start, y_end + 1, refine_step):
+                for x in range(x_start, x_end + 1, refine_step):
+                    candidate = self._score_candidate(
+                        frame,
+                        x=x,
+                        y=y,
+                        width=width,
+                        height=height,
+                        scale=scale,
+                    )
+                    if best is None or candidate.score > best.score:
+                        best = candidate
+        return best
+
+    def _score_candidate(
+        self,
+        frame: np.ndarray,
+        *,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        scale: float,
+    ) -> _Candidate:
+        crop = np.ascontiguousarray(frame[y : y + height, x : x + width])
+        presence = self._presence_detector.detect(crop)
+        line_score = _major_line_score(crop)
+        border_score = _border_score(crop)
+        score = presence.score * 0.65 + line_score * 0.25 + border_score * 0.10
+        return _Candidate(
+            x=x,
+            y=y,
+            width=width,
+            height=height,
+            scale=scale,
+            score=float(score),
+            presence=presence.present,
+        )
+
+
+def _major_line_score(crop: np.ndarray) -> float:
+    gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
+    edges = cv2.Canny(gray, 40, 120) > 0
+    specs = (
+        ((0.485, 0.02, 0.505, 0.98), (0.455, 0.02, 0.475, 0.98), (0.515, 0.02, 0.535, 0.98)),
+        ((0.50, 0.325, 0.99, 0.345), (0.50, 0.285, 0.99, 0.305), (0.50, 0.365, 0.99, 0.385)),
+        ((0.50, 0.695, 0.99, 0.715), (0.50, 0.655, 0.99, 0.675), (0.50, 0.735, 0.99, 0.755)),
+        ((0.01, 0.685, 0.49, 0.705), (0.01, 0.645, 0.49, 0.665), (0.01, 0.725, 0.49, 0.745)),
+    )
+    scores: list[float] = []
+    for line_rect, before_rect, after_rect in specs:
+        line_density = _edge_density(_crop_relative(edges, line_rect))
+        neighbor_density = (
+            _edge_density(_crop_relative(edges, before_rect))
+            + _edge_density(_crop_relative(edges, after_rect))
+        ) / 2.0
+        scores.append(min(max(line_density - neighbor_density, 0.0) / 0.10, 1.0))
+    return float(sum(scores) / len(scores))
+
+
+def _border_score(crop: np.ndarray) -> float:
+    gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
+    edges = cv2.Canny(gray, 40, 120) > 0
+    specs = (
+        ((0.00, 0.00, 1.00, 0.02), (0.00, 0.03, 1.00, 0.05)),
+        ((0.00, 0.98, 1.00, 1.00), (0.00, 0.95, 1.00, 0.97)),
+        ((0.00, 0.00, 0.02, 1.00), (0.03, 0.00, 0.05, 1.00)),
+        ((0.98, 0.00, 1.00, 1.00), (0.95, 0.00, 0.97, 1.00)),
+    )
+    scores: list[float] = []
+    for border_rect, inside_rect in specs:
+        border_density = _edge_density(_crop_relative(edges, border_rect))
+        inside_density = _edge_density(_crop_relative(edges, inside_rect))
+        scores.append(min(max(border_density - inside_density, 0.0) / 0.08, 1.0))
+    return float(sum(scores) / len(scores))
+
+
+def _crop_relative(image: np.ndarray, rect: tuple[float, float, float, float]) -> np.ndarray:
+    height = int(image.shape[0])
+    width = int(image.shape[1])
+    x1 = max(0, min(width, int(width * rect[0])))
+    y1 = max(0, min(height, int(height * rect[1])))
+    x2 = max(0, min(width, int(width * rect[2])))
+    y2 = max(0, min(height, int(height * rect[3])))
+    if x2 <= x1 or y2 <= y1:
+        return np.zeros((1, 1), dtype=image.dtype)
+    return np.ascontiguousarray(image[y1:y2, x1:x2])
+
+
+def _edge_density(edge_mask: np.ndarray) -> float:
+    if edge_mask.size == 0:
+        return 0.0
+    return float(np.count_nonzero(edge_mask)) / float(edge_mask.size)

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
@@ -289,12 +289,7 @@ def _rect_ratio(
     y2 = y + int(height * rect[3])
     if x2 <= x1 or y2 <= y1:
         return 0.0
-    total = (
-        integral[y2, x2]
-        - integral[y1, x2]
-        - integral[y2, x1]
-        + integral[y1, x1]
-    )
+    total = integral[y2, x2] - integral[y1, x2] - integral[y2, x1] + integral[y1, x1]
     return float(total) / float((x2 - x1) * (y2 - y1))
 
 

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
@@ -9,6 +9,8 @@ from zml_ocr_worker.calibration.model import LocatedRegion
 from zml_ocr_worker.capture.model import RoiRect
 from zml_ocr_worker.pipelines.mining_finder.presence import FinderPresenceDetector
 
+RelativeRect = tuple[float, float, float, float]
+
 
 @dataclass(frozen=True, slots=True)
 class FinderLocatorConfig:
@@ -17,9 +19,9 @@ class FinderLocatorConfig:
     baseline_finder_width: int = 347
     baseline_finder_height: int = 239
     scale_tolerance: tuple[float, ...] = (0.98, 1.0, 1.02)
-    coarse_stride_fraction: float = 0.08
-    coarse_candidate_count: int = 6
-    min_confidence: float = 0.68
+    coarse_stride_fraction: float = 0.035
+    coarse_candidate_count: int = 12
+    min_confidence: float = 0.72
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,8 +31,15 @@ class _Candidate:
     width: int
     height: int
     scale: float
-    score: float
-    presence: bool
+    fast_score: float
+
+
+@dataclass(frozen=True, slots=True)
+class _FrameFeatures:
+    dark: np.ndarray
+    edges: np.ndarray
+    blue: np.ndarray
+    green: np.ndarray
 
 
 class FinderLocator:
@@ -58,157 +67,239 @@ class FinderLocator:
         if base_scale <= 0:
             return None
 
-        best: _Candidate | None = None
+        features = _frame_features(frame)
+        candidates: list[_Candidate] = []
         for tolerance in self._config.scale_tolerance:
             scale = base_scale * tolerance
             width = max(80, round(self._config.baseline_finder_width * scale))
             height = max(50, round(self._config.baseline_finder_height * scale))
             if width > frame_width or height > frame_height:
                 continue
-            candidate = self._locate_size(frame, width=width, height=height, scale=scale)
-            if candidate is not None and (best is None or candidate.score > best.score):
-                best = candidate
-
-        if best is None or not best.presence or best.score < self._config.min_confidence:
-            return None
-
-        return LocatedRegion(
-            rect=RoiRect(
-                x1=best.x,
-                x2=best.x + best.width,
-                y1=best.y,
-                y2=best.y + best.height,
-            ),
-            confidence=best.score,
-            scale=best.scale,
-        )
-
-    def _locate_size(
-        self,
-        frame: np.ndarray,
-        *,
-        width: int,
-        height: int,
-        scale: float,
-    ) -> _Candidate | None:
-        stride = max(8, round(min(width, height) * self._config.coarse_stride_fraction))
-        coarse: list[_Candidate] = []
-        max_y = int(frame.shape[0]) - height
-        max_x = int(frame.shape[1]) - width
-
-        for y in range(0, max_y + 1, stride):
-            for x in range(0, max_x + 1, stride):
-                candidate = self._score_candidate(
-                    frame,
-                    x=x,
-                    y=y,
+            candidates.extend(
+                self._locate_size(
+                    features,
+                    frame_width=frame_width,
+                    frame_height=frame_height,
                     width=width,
                     height=height,
                     scale=scale,
                 )
-                coarse.append(candidate)
+            )
 
-        if not coarse:
+        candidates.sort(key=lambda item: item.fast_score, reverse=True)
+        best: tuple[float, _Candidate] | None = None
+        for candidate in candidates[: self._config.coarse_candidate_count * 2]:
+            crop = np.ascontiguousarray(
+                frame[
+                    candidate.y : candidate.y + candidate.height,
+                    candidate.x : candidate.x + candidate.width,
+                ]
+            )
+            presence = self._presence_detector.detect(crop)
+            if not presence.present:
+                continue
+            confidence = presence.score * 0.65 + candidate.fast_score * 0.35
+            if best is None or confidence > best[0]:
+                best = (float(confidence), candidate)
+
+        if best is None or best[0] < self._config.min_confidence:
             return None
-        coarse.sort(key=lambda item: item.score, reverse=True)
 
-        best: _Candidate | None = None
-        refine_step = max(1, stride // 8)
-        for seed in coarse[: self._config.coarse_candidate_count]:
-            x_start = max(0, seed.x - stride)
-            x_end = min(max_x, seed.x + stride)
-            y_start = max(0, seed.y - stride)
-            y_end = min(max_y, seed.y + stride)
-            for y in range(y_start, y_end + 1, refine_step):
-                for x in range(x_start, x_end + 1, refine_step):
-                    candidate = self._score_candidate(
-                        frame,
+        confidence, candidate = best
+        return LocatedRegion(
+            rect=RoiRect(
+                x1=candidate.x,
+                x2=candidate.x + candidate.width,
+                y1=candidate.y,
+                y2=candidate.y + candidate.height,
+            ),
+            confidence=confidence,
+            scale=candidate.scale,
+        )
+
+    def _locate_size(
+        self,
+        features: _FrameFeatures,
+        *,
+        frame_width: int,
+        frame_height: int,
+        width: int,
+        height: int,
+        scale: float,
+    ) -> list[_Candidate]:
+        stride = max(5, round(min(width, height) * self._config.coarse_stride_fraction))
+        max_y = frame_height - height
+        max_x = frame_width - width
+        coarse: list[_Candidate] = []
+
+        for y in _scan_positions(max_y, stride):
+            for x in _scan_positions(max_x, stride):
+                coarse.append(
+                    _Candidate(
                         x=x,
                         y=y,
                         width=width,
                         height=height,
                         scale=scale,
+                        fast_score=_fast_score(features, x=x, y=y, width=width, height=height),
                     )
-                    if best is None or candidate.score > best.score:
-                        best = candidate
-        return best
+                )
 
-    def _score_candidate(
-        self,
-        frame: np.ndarray,
-        *,
-        x: int,
-        y: int,
-        width: int,
-        height: int,
-        scale: float,
-    ) -> _Candidate:
-        crop = np.ascontiguousarray(frame[y : y + height, x : x + width])
-        presence = self._presence_detector.detect(crop)
-        line_score = _major_line_score(crop)
-        border_score = _border_score(crop)
-        score = presence.score * 0.65 + line_score * 0.25 + border_score * 0.10
-        return _Candidate(
+        coarse.sort(key=lambda item: item.fast_score, reverse=True)
+        refined: dict[tuple[int, int], _Candidate] = {}
+        for seed in coarse[: self._config.coarse_candidate_count]:
+            x_start = max(0, seed.x - stride)
+            x_end = min(max_x, seed.x + stride)
+            y_start = max(0, seed.y - stride)
+            y_end = min(max_y, seed.y + stride)
+            for y in range(y_start, y_end + 1):
+                for x in range(x_start, x_end + 1):
+                    candidate = _Candidate(
+                        x=x,
+                        y=y,
+                        width=width,
+                        height=height,
+                        scale=scale,
+                        fast_score=_fast_score(features, x=x, y=y, width=width, height=height),
+                    )
+                    key = (x, y)
+                    previous = refined.get(key)
+                    if previous is None or candidate.fast_score > previous.fast_score:
+                        refined[key] = candidate
+
+        result = sorted(refined.values(), key=lambda item: item.fast_score, reverse=True)
+        return result[: self._config.coarse_candidate_count]
+
+
+def _frame_features(frame: np.ndarray) -> _FrameFeatures:
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    edges = cv2.Canny(gray, 40, 120) > 0
+    hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+    hue = hsv[:, :, 0]
+    saturation = hsv[:, :, 1]
+    value = hsv[:, :, 2]
+    blue = (hue >= 85) & (hue <= 130) & (saturation >= 60) & (value >= 50)
+    green = (hue >= 45) & (hue <= 80) & (saturation >= 70) & (value >= 70)
+    return _FrameFeatures(
+        dark=cv2.integral((gray <= 70).astype(np.uint8), sdepth=cv2.CV_64F),
+        edges=cv2.integral(edges.astype(np.uint8), sdepth=cv2.CV_64F),
+        blue=cv2.integral(blue.astype(np.uint8), sdepth=cv2.CV_64F),
+        green=cv2.integral(green.astype(np.uint8), sdepth=cv2.CV_64F),
+    )
+
+
+def _fast_score(
+    features: _FrameFeatures,
+    *,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+) -> float:
+    panel_rects: tuple[RelativeRect, ...] = (
+        (0.05, 0.05, 0.45, 0.68),
+        (0.52, 0.05, 0.96, 0.32),
+        (0.52, 0.39, 0.96, 0.68),
+        (0.52, 0.74, 0.96, 0.96),
+    )
+    panel_dark_score = sum(
+        _rect_ratio(features.dark, x=x, y=y, width=width, height=height, rect=rect)
+        for rect in panel_rects
+    ) / len(panel_rects)
+
+    line_specs: tuple[tuple[RelativeRect, RelativeRect, RelativeRect], ...] = (
+        (
+            (0.485, 0.02, 0.505, 0.98),
+            (0.455, 0.02, 0.475, 0.98),
+            (0.515, 0.02, 0.535, 0.98),
+        ),
+        (
+            (0.01, 0.685, 0.49, 0.705),
+            (0.01, 0.645, 0.49, 0.665),
+            (0.01, 0.725, 0.49, 0.745),
+        ),
+        (
+            (0.50, 0.325, 0.99, 0.345),
+            (0.50, 0.285, 0.99, 0.305),
+            (0.50, 0.365, 0.99, 0.385),
+        ),
+        (
+            (0.50, 0.695, 0.99, 0.715),
+            (0.50, 0.655, 0.99, 0.675),
+            (0.50, 0.735, 0.99, 0.755),
+        ),
+    )
+    grid_scores: list[float] = []
+    for line_rect, before_rect, after_rect in line_specs:
+        line_density = _rect_ratio(
+            features.edges,
             x=x,
             y=y,
             width=width,
             height=height,
-            scale=scale,
-            score=float(score),
-            presence=presence.present,
+            rect=line_rect,
         )
-
-
-def _major_line_score(crop: np.ndarray) -> float:
-    gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
-    edges = cv2.Canny(gray, 40, 120) > 0
-    specs = (
-        ((0.485, 0.02, 0.505, 0.98), (0.455, 0.02, 0.475, 0.98), (0.515, 0.02, 0.535, 0.98)),
-        ((0.50, 0.325, 0.99, 0.345), (0.50, 0.285, 0.99, 0.305), (0.50, 0.365, 0.99, 0.385)),
-        ((0.50, 0.695, 0.99, 0.715), (0.50, 0.655, 0.99, 0.675), (0.50, 0.735, 0.99, 0.755)),
-        ((0.01, 0.685, 0.49, 0.705), (0.01, 0.645, 0.49, 0.665), (0.01, 0.725, 0.49, 0.745)),
-    )
-    scores: list[float] = []
-    for line_rect, before_rect, after_rect in specs:
-        line_density = _edge_density(_crop_relative(edges, line_rect))
         neighbor_density = (
-            _edge_density(_crop_relative(edges, before_rect))
-            + _edge_density(_crop_relative(edges, after_rect))
+            _rect_ratio(
+                features.edges,
+                x=x,
+                y=y,
+                width=width,
+                height=height,
+                rect=before_rect,
+            )
+            + _rect_ratio(
+                features.edges,
+                x=x,
+                y=y,
+                width=width,
+                height=height,
+                rect=after_rect,
+            )
         ) / 2.0
-        scores.append(min(max(line_density - neighbor_density, 0.0) / 0.10, 1.0))
-    return float(sum(scores) / len(scores))
+        grid_scores.append(min(max(line_density - neighbor_density, 0.0) / 0.08, 1.0))
+    grid_score = sum(grid_scores) / len(grid_scores)
 
-
-def _border_score(crop: np.ndarray) -> float:
-    gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
-    edges = cv2.Canny(gray, 40, 120) > 0
-    specs = (
-        ((0.00, 0.00, 1.00, 0.02), (0.00, 0.03, 1.00, 0.05)),
-        ((0.00, 0.98, 1.00, 1.00), (0.00, 0.95, 1.00, 0.97)),
-        ((0.00, 0.00, 0.02, 1.00), (0.03, 0.00, 0.05, 1.00)),
-        ((0.98, 0.00, 1.00, 1.00), (0.95, 0.00, 0.97, 1.00)),
+    whole = (0.0, 0.0, 1.0, 1.0)
+    blue_score = min(
+        _rect_ratio(features.blue, x=x, y=y, width=width, height=height, rect=whole) / 0.025,
+        1.0,
     )
-    scores: list[float] = []
-    for border_rect, inside_rect in specs:
-        border_density = _edge_density(_crop_relative(edges, border_rect))
-        inside_density = _edge_density(_crop_relative(edges, inside_rect))
-        scores.append(min(max(border_density - inside_density, 0.0) / 0.08, 1.0))
-    return float(sum(scores) / len(scores))
+    green_score = min(
+        _rect_ratio(features.green, x=x, y=y, width=width, height=height, rect=whole) / 0.035,
+        1.0,
+    )
+    return float(
+        panel_dark_score * 0.45 + grid_score * 0.35 + blue_score * 0.15 + green_score * 0.05
+    )
 
 
-def _crop_relative(image: np.ndarray, rect: tuple[float, float, float, float]) -> np.ndarray:
-    height = int(image.shape[0])
-    width = int(image.shape[1])
-    x1 = max(0, min(width, int(width * rect[0])))
-    y1 = max(0, min(height, int(height * rect[1])))
-    x2 = max(0, min(width, int(width * rect[2])))
-    y2 = max(0, min(height, int(height * rect[3])))
+def _rect_ratio(
+    integral: np.ndarray,
+    *,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    rect: RelativeRect,
+) -> float:
+    x1 = x + int(width * rect[0])
+    y1 = y + int(height * rect[1])
+    x2 = x + int(width * rect[2])
+    y2 = y + int(height * rect[3])
     if x2 <= x1 or y2 <= y1:
-        return np.zeros((1, 1), dtype=image.dtype)
-    return np.ascontiguousarray(image[y1:y2, x1:x2])
-
-
-def _edge_density(edge_mask: np.ndarray) -> float:
-    if edge_mask.size == 0:
         return 0.0
-    return float(np.count_nonzero(edge_mask)) / float(edge_mask.size)
+    total = (
+        integral[y2, x2]
+        - integral[y1, x2]
+        - integral[y2, x1]
+        + integral[y1, x1]
+    )
+    return float(total) / float((x2 - x1) * (y2 - y1))
+
+
+def _scan_positions(limit: int, stride: int) -> list[int]:
+    positions = list(range(0, limit + 1, stride))
+    if not positions or positions[-1] != limit:
+        positions.append(limit)
+    return positions

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/model.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/model.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from zml_ocr_worker.capture.model import RoiRect
+
+
+@dataclass(frozen=True, slots=True)
+class LocatedRegion:
+    rect: RoiRect
+    confidence: float
+    scale: float
+
+
+@dataclass(frozen=True, slots=True)
+class LocatedCompass(LocatedRegion):
+    center_x: float
+    center_y: float
+    radius: float

--- a/apps/ocr-worker/src/zml_ocr_worker/cli.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 
 from zml_ocr_worker import __version__
 
@@ -12,6 +13,18 @@ def build_parser() -> argparse.ArgumentParser:
     subcommands = parser.add_subparsers(dest="command", required=True)
     subcommands.add_parser("doctor", help="Validate the native OCR runtime and tessdata")
     subcommands.add_parser("stdio", help="Run the NDJSON process protocol on stdin/stdout")
+
+    locate_ui = subcommands.add_parser(
+        "locate-ui",
+        help="Locate Compass and Finder regions in a captured Entropia client frame",
+    )
+    locate_ui.add_argument("image", type=Path, help="Full Entropia client screenshot")
+    locate_ui.add_argument(
+        "--annotated",
+        type=Path,
+        default=None,
+        help="Optional output path for an annotated preview image",
+    )
     return parser
 
 
@@ -30,4 +43,8 @@ def main(argv: list[str] | None = None) -> int:
             from zml_ocr_worker.runtime.stdio import run_stdio
 
             return run_stdio()
+        case "locate-ui":
+            from zml_ocr_worker.calibration.debug import run_calibration_debug
+
+            return run_calibration_debug(args.image, annotated_path=args.annotated)
     raise RuntimeError(f"Unsupported command: {args.command}")

--- a/apps/ocr-worker/tests/test_calibration_compass.py
+++ b/apps/ocr-worker/tests/test_calibration_compass.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from zml_ocr_worker.calibration.compass import CompassLocator, CompassLocatorConfig
+
+
+def test_compass_locator_finds_concentric_radar_and_scale() -> None:
+    frame = np.full((720, 1280, 3), 80, dtype=np.uint8)
+    center = (900, 480)
+    radius = 90
+    for fraction in (0.2, 0.4, 0.6, 0.8, 1.0):
+        cv2.circle(
+            frame,
+            center,
+            round(radius * fraction),
+            (220, 220, 220),
+            2,
+            cv2.LINE_AA,
+        )
+
+    locator = CompassLocator(
+        config=CompassLocatorConfig(
+            hough_param2=20.0,
+            min_ring_contrast=0.55,
+        )
+    )
+    located = locator.locate(frame)
+
+    assert located is not None
+    assert abs(located.center_x - center[0]) <= 4
+    assert abs(located.center_y - center[1]) <= 4
+    assert abs(located.radius - radius) <= 5
+    assert located.confidence >= 0.55
+
+
+def test_compass_locator_returns_none_without_concentric_rings() -> None:
+    frame = np.full((720, 1280, 3), 80, dtype=np.uint8)
+
+    assert CompassLocator().locate(frame) is None

--- a/apps/ocr-worker/tests/test_calibration_coordinates.py
+++ b/apps/ocr-worker/tests/test_calibration_coordinates.py
@@ -13,10 +13,14 @@ class _FakeTextEngine:
     def __init__(self, *responses: str) -> None:
         self._responses = deque(responses)
         self.psm_calls: list[int] = []
+        self.image_shapes: list[tuple[int, ...]] = []
 
     def recognize_text(self, img: np.ndarray, *, psm: int = 6) -> str:
         assert img.size > 0
         self.psm_calls.append(psm)
+        self.image_shapes.append(tuple(int(value) for value in img.shape))
+        if not self._responses:
+            return ""
         return self._responses.popleft()
 
     def close(self) -> None:
@@ -34,8 +38,8 @@ def _compass() -> LocatedCompass:
     )
 
 
-def test_coordinate_reader_reads_both_values_from_broad_region() -> None:
-    engine = _FakeTextEngine("Lon: 61460\nLat: 75048")
+def test_coordinate_reader_reads_fixed_lon_and_lat_lines() -> None:
+    engine = _FakeTextEngine("Lon: 61460", "Lat: 75048")
     reader = CompassCoordinateReader(text_engine=engine)
 
     result = reader.read(np.zeros((720, 1280, 3), dtype=np.uint8), _compass())
@@ -43,11 +47,11 @@ def test_coordinate_reader_reads_both_values_from_broad_region() -> None:
     assert result.longitude == 61460
     assert result.latitude == 75048
     assert result.has_position
-    assert engine.psm_calls == [6]
+    assert engine.psm_calls == [7, 7]
 
 
-def test_coordinate_reader_falls_back_only_for_missing_line() -> None:
-    engine = _FakeTextEngine("Lon; 135708", "Lat: 83952")
+def test_coordinate_reader_expands_line_width_when_short_crop_is_not_enough() -> None:
+    engine = _FakeTextEngine("", "", "", "", "Lon; 135708", "Lat: 83952")
     reader = CompassCoordinateReader(text_engine=engine)
 
     result = reader.read(np.zeros((720, 1280, 3), dtype=np.uint8), _compass())
@@ -55,11 +59,13 @@ def test_coordinate_reader_falls_back_only_for_missing_line() -> None:
     assert result.longitude == 135708
     assert result.latitude == 83952
     assert result.has_position
-    assert engine.psm_calls == [6, 11]
+    first_width = engine.image_shapes[0][1]
+    expanded_width = engine.image_shapes[4][1]
+    assert expanded_width > first_width
 
 
 def test_coordinate_reader_preserves_unknown_position_state() -> None:
-    engine = _FakeTextEngine("Lon: Unknown N\nLat: Unknown")
+    engine = _FakeTextEngine("Lon: Unknown N", "Lat: Unknown")
     reader = CompassCoordinateReader(text_engine=engine)
 
     result = reader.read(np.zeros((720, 1280, 3), dtype=np.uint8), _compass())
@@ -69,11 +75,11 @@ def test_coordinate_reader_preserves_unknown_position_state() -> None:
     assert result.longitude_unknown
     assert result.latitude_unknown
     assert not result.has_position
-    assert engine.psm_calls == [6]
+    assert engine.psm_calls == [7, 7]
 
 
 def test_coordinate_reader_does_not_accept_unlabeled_numbers() -> None:
-    engine = _FakeTextEngine("12345 67890", "99999", "88888")
+    engine = _FakeTextEngine("12345", "67890")
     reader = CompassCoordinateReader(text_engine=engine)
 
     result = reader.read(np.zeros((720, 1280, 3), dtype=np.uint8), _compass())
@@ -83,4 +89,4 @@ def test_coordinate_reader_does_not_accept_unlabeled_numbers() -> None:
     assert not result.longitude_unknown
     assert not result.latitude_unknown
     assert not result.has_position
-    assert engine.psm_calls == [6, 11, 11]
+    assert len(engine.psm_calls) == 32

--- a/apps/ocr-worker/tests/test_calibration_coordinates.py
+++ b/apps/ocr-worker/tests/test_calibration_coordinates.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+
+from zml_ocr_worker.calibration.coordinates import CompassCoordinateReader
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.capture.model import RoiRect
+
+
+class _FakeTextEngine:
+    def __init__(self, *responses: str) -> None:
+        self._responses = deque(responses)
+        self.psm_calls: list[int] = []
+
+    def recognize_text(self, img: np.ndarray, *, psm: int = 6) -> str:
+        assert img.size > 0
+        self.psm_calls.append(psm)
+        return self._responses.popleft()
+
+    def close(self) -> None:
+        return None
+
+
+def _compass() -> LocatedCompass:
+    return LocatedCompass(
+        rect=RoiRect(x1=300, x2=600, y1=100, y2=430),
+        confidence=0.9,
+        scale=1.0,
+        center_x=450.0,
+        center_y=250.0,
+        radius=100.0,
+    )
+
+
+def test_coordinate_reader_reads_both_values_from_broad_region() -> None:
+    engine = _FakeTextEngine("Lon: 61460\nLat: 75048")
+    reader = CompassCoordinateReader(text_engine=engine)
+
+    result = reader.read(np.zeros((720, 1280, 3), dtype=np.uint8), _compass())
+
+    assert result.longitude == 61460
+    assert result.latitude == 75048
+    assert result.has_position
+    assert engine.psm_calls == [6]
+
+
+def test_coordinate_reader_falls_back_only_for_missing_line() -> None:
+    engine = _FakeTextEngine("Lon; 135708", "Lat: 83952")
+    reader = CompassCoordinateReader(text_engine=engine)
+
+    result = reader.read(np.zeros((720, 1280, 3), dtype=np.uint8), _compass())
+
+    assert result.longitude == 135708
+    assert result.latitude == 83952
+    assert result.has_position
+    assert engine.psm_calls == [6, 11]
+
+
+def test_coordinate_reader_preserves_unknown_position_state() -> None:
+    engine = _FakeTextEngine("Lon: Unknown N\nLat: Unknown")
+    reader = CompassCoordinateReader(text_engine=engine)
+
+    result = reader.read(np.zeros((720, 1280, 3), dtype=np.uint8), _compass())
+
+    assert result.longitude is None
+    assert result.latitude is None
+    assert result.longitude_unknown
+    assert result.latitude_unknown
+    assert not result.has_position
+    assert engine.psm_calls == [6]
+
+
+def test_coordinate_reader_does_not_accept_unlabeled_numbers() -> None:
+    engine = _FakeTextEngine("12345 67890", "99999", "88888")
+    reader = CompassCoordinateReader(text_engine=engine)
+
+    result = reader.read(np.zeros((720, 1280, 3), dtype=np.uint8), _compass())
+
+    assert result.longitude is None
+    assert result.latitude is None
+    assert not result.longitude_unknown
+    assert not result.latitude_unknown
+    assert not result.has_position
+    assert engine.psm_calls == [6, 11, 11]

--- a/apps/ocr-worker/tests/test_calibration_finder.py
+++ b/apps/ocr-worker/tests/test_calibration_finder.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from zml_ocr_worker.calibration.finder import FinderLocator
+
+
+def test_finder_locator_finds_movable_panel_at_resolution_derived_size() -> None:
+    frame = np.full((720, 1280, 3), (110, 120, 100), dtype=np.uint8)
+    panel = _finder_panel(width=174, height=120)
+    x = 500
+    y = 400
+    frame[y : y + panel.shape[0], x : x + panel.shape[1]] = panel
+
+    located = FinderLocator().locate(frame)
+
+    assert located is not None
+    assert abs(located.rect.x1 - x) <= 4
+    assert abs(located.rect.y1 - y) <= 4
+    assert abs((located.rect.x2 - located.rect.x1) - panel.shape[1]) <= 4
+    assert abs((located.rect.y2 - located.rect.y1) - panel.shape[0]) <= 4
+    assert located.confidence >= 0.68
+
+
+def test_finder_locator_returns_none_when_panel_is_absent() -> None:
+    frame = np.full((720, 1280, 3), (110, 120, 100), dtype=np.uint8)
+
+    assert FinderLocator().locate(frame) is None
+
+
+def _finder_panel(*, width: int, height: int) -> np.ndarray:
+    panel = np.full((height, width, 3), (25, 30, 38), dtype=np.uint8)
+    line_color = (90, 100, 110)
+    cv2.line(
+        panel,
+        (round(width * 0.49), 0),
+        (round(width * 0.49), height - 1),
+        line_color,
+        1,
+    )
+    for fraction in (0.34, 0.71):
+        row = round(height * fraction)
+        cv2.line(panel, (round(width * 0.50), row), (width - 1, row), line_color, 1)
+    row = round(height * 0.70)
+    cv2.line(panel, (0, row), (round(width * 0.49), row), line_color, 1)
+
+    center = (round(width * 0.24), round(height * 0.34))
+    for radius in (10, 20, 30):
+        cv2.circle(panel, center, radius, (220, 110, 20), 2, cv2.LINE_AA)
+    cv2.circle(
+        panel,
+        (round(width * 0.20), round(height * 0.85)),
+        10,
+        (30, 220, 30),
+        -1,
+    )
+    cv2.rectangle(panel, (0, 0), (width - 1, height - 1), line_color, 1)
+    return panel


### PR DESCRIPTION
## Scope

Prototype automatic screen-region location inside the standalone OCR Worker for issue #66.

- add `FinderLocator` for a movable Finder whose size is derived from current client resolution
- reuse the existing `FinderPresenceDetector` and add major-line/border alignment scoring
- add `CompassLocator` using concentric radar-ring detection so Compass position and player-selected scale can both be recovered
- add `CompassCoordinateReader` that derives two fixed Lon/Lat scan lines from the located radar geometry instead of scanning a broad arbitrary text block
- keep line position/height scale-aware relative to radar center/radius, while trying progressively wider horizontal crops to cover 4–6+ digit coordinate formats
- run stronger OCR only on those two small line crops (multiple upscale/PSM attempts) and require the `Lon` / `Lat` labels before accepting numeric values
- add `zml-ocr-worker locate-ui <full-client-image> [--annotated ...]` for evaluating the locators and coordinate read against screenshots
- add synthetic/unit regression tests only; real Steam/community screenshots are intentionally not committed as fixtures in this POC

## Current stage

This PR is intentionally a POC/debug slice first. It does **not** yet replace the runtime's configured ROIs or persist calibration. The next step after live validation is to add the calibration coordinator/cache/status flow described in #66.

## Manual validation so far

Against the supplied set of nine community screenshots:
- 8 screenshots actually contain a Compass; the current concentric-ring locator detects 7/8
- the Finder-only screenshot is correctly rejected as having no Compass
- the detected Compass screenshots established that the Lon/Lat lines stay in a stable geometric position relative to the radar, while line width varies with coordinate digit count
- the coordinate reader therefore now uses fixed scale-aware line geometry plus progressive width candidates instead of a broad local OCR block
- screenshots where `Lon` / `Lat` are not rendered should not produce a false position because labeled values are required
- the remaining Compass miss is a very bright / washed-out Calypso case where concentric-ring contrast is too low; this needs a low-contrast fallback before runtime rollout

Draft only; do not merge until live in-game validation and the low-contrast Compass fallback are addressed.