### PR TITLE
fix(ocr): stabilize Finder hit reads and restore hit captures

### DIFF
--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
@@ -18,6 +18,7 @@ class FinderLocatorConfig:
     baseline_client_height: int = 1440
     baseline_finder_width: int = 354
     baseline_finder_height: int = 239
+    baseline_finder_x_offset: int = 7
     scale_tolerance: tuple[float, ...] = (0.98, 1.0, 1.02)
     coarse_stride_fraction: float = 0.09
     coarse_candidate_count: int = 8
@@ -106,10 +107,12 @@ class FinderLocator:
             return None
 
         confidence, candidate = best
+        x_offset = round(self._config.baseline_finder_x_offset * candidate.scale)
+        x1 = min(max(0, candidate.x + x_offset), frame_width - candidate.width)
         return LocatedRegion(
             rect=RoiRect(
-                x1=candidate.x,
-                x2=candidate.x + candidate.width,
+                x1=x1,
+                x2=x1 + candidate.width,
                 y1=candidate.y,
                 y2=candidate.y + candidate.height,
             ),

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/finder.py
@@ -16,7 +16,7 @@ RelativeRect = tuple[float, float, float, float]
 class FinderLocatorConfig:
     baseline_client_width: int = 2560
     baseline_client_height: int = 1440
-    baseline_finder_width: int = 347
+    baseline_finder_width: int = 354
     baseline_finder_height: int = 239
     scale_tolerance: tuple[float, ...] = (0.98, 1.0, 1.02)
     coarse_stride_fraction: float = 0.09

--- a/apps/ocr-worker/src/zml_ocr_worker/pipelines/mining_finder/recording.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/pipelines/mining_finder/recording.py
@@ -11,10 +11,12 @@ from typing import Literal
 import cv2
 import numpy as np
 
+from zml_ocr_worker.pipelines.image import to_bgr_u8
 from zml_ocr_worker.pipelines.mining_finder.model import (
     FinderFeatures,
     MiningFinderSignal,
 )
+from zml_ocr_worker.pipelines.mining_finder.vision import FinderPanelLayout
 from zml_ocr_worker.runtime.paths import get_app_data_dir
 
 logger = logging.getLogger(__name__)
@@ -46,11 +48,14 @@ class FinderCropRecorder:
         *,
         config: FinderRecordingConfig,
         roi_name: str,
+        layout: FinderPanelLayout | None = None,
     ) -> None:
         self._config = config
         self._roi_name = roi_name
+        self._layout = layout or FinderPanelLayout()
         self._last_interval_ts_ms: int | None = None
         self._sequence = 0
+        self._annotated_hit_sequence = 0
         if config.enabled:
             config.root_dir.mkdir(parents=True, exist_ok=True)
 
@@ -93,14 +98,28 @@ class FinderCropRecorder:
         features: FinderFeatures,
         signals: list[MiningFinderSignal],
     ) -> None:
-        """Record interval/manual Finder diagnostics after feature OCR."""
+        """Record post-OCR Finder diagnostics and annotated emitted hits."""
 
         if not self._config.enabled:
             return
-        if self._sequence >= self._config.max_samples:
-            return
 
         try:
+            if "accepted" in self._config.modes:
+                hit_signal = next(
+                    (signal for signal in signals if signal.kind == "finder_hit_hint"),
+                    None,
+                )
+                if hit_signal is not None:
+                    self._write_annotated_hit(
+                        finder_roi,
+                        ts_ms=ts_ms,
+                        features=features,
+                        signal=hit_signal,
+                    )
+
+            if self._sequence >= self._config.max_samples:
+                return
+
             reasons = self._post_ocr_recording_reasons(ts_ms=ts_ms)
             if not reasons:
                 return
@@ -196,6 +215,60 @@ class FinderCropRecorder:
             phase,
         )
 
+    def _write_annotated_hit(
+        self,
+        finder_roi: np.ndarray,
+        *,
+        ts_ms: int,
+        features: FinderFeatures,
+        signal: MiningFinderSignal,
+    ) -> None:
+        if self._annotated_hit_sequence >= self._config.max_samples:
+            return
+        self._annotated_hit_sequence += 1
+
+        timestamp = datetime.fromtimestamp(ts_ms / 1000, tz=UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        stem = f"{timestamp}_hit_{self._annotated_hit_sequence:06d}_annotated"
+        png_path = self._config.root_dir / f"{stem}.png"
+        json_path = self._config.root_dir / f"{stem}.json"
+        annotated = _annotate_hit(
+            finder_roi,
+            layout=self._layout,
+            resource_name=features.resource_name,
+            size_label=features.hit_size_label,
+            size_index=features.hit_size_index,
+        )
+
+        if not cv2.imwrite(str(png_path), annotated):
+            raise RuntimeError(f"Failed to write annotated finder hit: {png_path}")
+
+        json_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "created_at": datetime.now(tz=UTC).isoformat(),
+                    "ts_ms": ts_ms,
+                    "roi_name": self._roi_name,
+                    "image_file": png_path.name,
+                    "image_shape": list(annotated.shape),
+                    "reasons": ["finder_hit_hint"],
+                    "phase": "hit_annotated",
+                    "features": _features_to_json(features),
+                    "signals": [_signal_to_json(signal)],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        logger.info(
+            "finder_hit_capture_recorded path=%s resource=%r size=%r",
+            png_path,
+            features.resource_name,
+            _size_text(features.hit_size_label, features.hit_size_index),
+        )
+
 
 def finder_recording_config_from_env(
     *,
@@ -261,6 +334,123 @@ def _parse_modes(raw: str | None) -> frozenset[FinderRecordingMode]:
             logger.warning("finder_recording_mode_ignored mode=%r", item)
 
     return frozenset(modes)
+
+
+def _annotate_hit(
+    finder_roi: np.ndarray,
+    *,
+    layout: FinderPanelLayout,
+    resource_name: str | None,
+    size_label: str | None,
+    size_index: int | None,
+) -> np.ndarray:
+    image = to_bgr_u8(finder_roi).copy()
+    height, width = image.shape[:2]
+    header_height = max(52, round(height * 0.22))
+    canvas = np.full((height + header_height, width, 3), 20, dtype=np.uint8)
+    canvas[header_height:, :] = image
+
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    font_scale = max(0.34, min(0.55, width / 720.0))
+    thickness = 1
+    resource_text = _fit_label(f"RESOURCE: {resource_name or '?'}", width, font, font_scale)
+    size_text = _fit_label(
+        f"SIZE: {_size_text(size_label, size_index)}",
+        width,
+        font,
+        font_scale,
+    )
+    cv2.putText(
+        canvas,
+        resource_text,
+        (6, max(17, round(header_height * 0.38))),
+        font,
+        font_scale,
+        (235, 235, 235),
+        thickness,
+        cv2.LINE_AA,
+    )
+    cv2.putText(
+        canvas,
+        size_text,
+        (6, max(35, round(header_height * 0.78))),
+        font,
+        font_scale,
+        (235, 235, 235),
+        thickness,
+        cv2.LINE_AA,
+    )
+
+    _draw_relative_box(
+        canvas,
+        layout.details,
+        image_width=width,
+        image_height=height,
+        y_offset=header_height,
+        label="RESOURCE / DETAILS",
+        color=(80, 210, 255),
+    )
+    _draw_relative_box(
+        canvas,
+        layout.status,
+        image_width=width,
+        image_height=height,
+        y_offset=header_height,
+        label="SIZE / STATUS",
+        color=(120, 255, 120),
+    )
+    return canvas
+
+
+def _draw_relative_box(
+    image: np.ndarray,
+    rect: tuple[float, float, float, float],
+    *,
+    image_width: int,
+    image_height: int,
+    y_offset: int,
+    label: str,
+    color: tuple[int, int, int],
+) -> None:
+    x1 = max(0, min(image_width - 1, round(rect[0] * image_width)))
+    y1 = max(0, min(image_height - 1, round(rect[1] * image_height))) + y_offset
+    x2 = max(x1 + 1, min(image_width - 1, round(rect[2] * image_width)))
+    y2 = max(y1 + 1, min(image_height - 1, round(rect[3] * image_height) + y_offset))
+    cv2.rectangle(image, (x1, y1), (x2, y2), color, 1, cv2.LINE_AA)
+    cv2.putText(
+        image,
+        label,
+        (min(image_width - 1, x1 + 3), min(image.shape[0] - 4, y1 + 13)),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.32,
+        color,
+        1,
+        cv2.LINE_AA,
+    )
+
+
+def _fit_label(text: str, width: int, font: int, font_scale: float) -> str:
+    if width <= 0:
+        return ""
+    result = text
+    while result:
+        (text_width, _), _ = cv2.getTextSize(result, font, font_scale, 1)
+        if text_width <= max(1, width - 12):
+            return result
+        if len(result) <= 4:
+            break
+        result = result[:-4].rstrip() + "..."
+    return result
+
+
+def _size_text(label: str | None, index: int | None) -> str:
+    if label is None and index is None:
+        return "?"
+    if index is None:
+        return label or "?"
+    if label is None:
+        return f"? ({index})"
+    return f"{label} ({index})"
 
 
 def _features_to_json(features: FinderFeatures) -> dict[str, object]:

--- a/apps/ocr-worker/src/zml_ocr_worker/pipelines/position/engine.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/pipelines/position/engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 from zml_ocr_worker.runtime.paths import get_tessdata_dir
@@ -7,8 +9,13 @@ from zml_ocr_worker.runtime.tesserocr import preload_tesserocr
 
 
 class TesserDigitsEngine:
-    def __init__(self, *, tessdata_dir: str | None = None) -> None:
-        tesserocr = preload_tesserocr()
+    def __init__(
+        self,
+        *,
+        tessdata_dir: str | None = None,
+        tesserocr_module: Any | None = None,
+    ) -> None:
+        tesserocr = tesserocr_module or preload_tesserocr()
 
         resolved_tessdata_dir = get_tessdata_dir(tessdata_dir)
 
@@ -16,12 +23,13 @@ class TesserDigitsEngine:
         self._api = tesserocr.PyTessBaseAPI(
             path=str(resolved_tessdata_dir),
             lang="eng",
-            psm=tesserocr.PSM.SINGLE_LINE,
+            psm=tesserocr.PSM.SINGLE_WORD,
             oem=tesserocr.OEM.LSTM_ONLY,
         )
         self._last_confidence: float | None = None
 
-        # Digits-only configuration.
+        # Coordinate ROIs contain exactly one numeric token. SINGLE_WORD prevents
+        # Tesseract from over-segmenting a connected glyph into multiple digits.
         self._api.SetVariable("tessedit_char_whitelist", "0123456789")
         self._api.SetVariable("classify_bln_numeric_mode", "1")
         self._api.SetVariable("user_defined_dpi", "300")

--- a/apps/ocr-worker/tests/test_calibration_finder.py
+++ b/apps/ocr-worker/tests/test_calibration_finder.py
@@ -8,7 +8,7 @@ from zml_ocr_worker.calibration.finder import FinderLocator
 
 def test_finder_locator_finds_movable_panel_at_resolution_derived_size() -> None:
     frame = np.full((720, 1280, 3), (110, 120, 100), dtype=np.uint8)
-    panel = _finder_panel(width=174, height=120)
+    panel = _finder_panel(width=177, height=120)
     x = 500
     y = 400
     frame[y : y + panel.shape[0], x : x + panel.shape[1]] = panel

--- a/apps/ocr-worker/tests/test_finder_hit_recording.py
+++ b/apps/ocr-worker/tests/test_finder_hit_recording.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from zml_ocr_worker.pipelines.mining_finder.model import FinderFeatures, MiningFinderSignal
+from zml_ocr_worker.pipelines.mining_finder.recording import (
+    FinderCropRecorder,
+    FinderRecordingConfig,
+)
+
+
+def test_accepted_recording_writes_annotated_hit_with_resource_and_size(tmp_path: Path) -> None:
+    recorder = FinderCropRecorder(
+        config=FinderRecordingConfig(
+            modes=frozenset({"accepted"}),
+            root_dir=tmp_path,
+            max_samples=10,
+        ),
+        roi_name="finder_auto",
+    )
+    crop = np.zeros((239, 347, 4), dtype=np.uint8)
+    features = FinderFeatures(
+        status_kind="found",
+        hit_size_label="Considerable",
+        hit_size_index=5,
+        resource_name="Garcen Grease",
+        raw_status_text="Estimated size: Considerable (5)",
+        raw_details_text="RANGE 8.8m\nDEPTH 125m\nTYPE Garcen Grease",
+    )
+    signal = MiningFinderSignal(
+        ts_ms=1_000,
+        kind="finder_hit_hint",
+        hit_size_label="Considerable",
+        hit_size_index=5,
+        resource_name="Garcen Grease",
+    )
+
+    recorder.record_accepted_frame(crop, ts_ms=1_000)
+    recorder.record_frame(
+        crop,
+        ts_ms=1_000,
+        features=features,
+        signals=[signal],
+    )
+
+    annotated_files = list(tmp_path.glob("*_hit_*_annotated.png"))
+    assert len(annotated_files) == 1
+    annotated = cv2.imread(str(annotated_files[0]), cv2.IMREAD_COLOR)
+    assert annotated is not None
+    assert annotated.shape[0] > crop.shape[0]
+    assert annotated.shape[1] == crop.shape[1]
+    assert np.count_nonzero(annotated) > 0
+
+    metadata_path = annotated_files[0].with_suffix(".json")
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["phase"] == "hit_annotated"
+    assert metadata["features"]["resource_name"] == "Garcen Grease"
+    assert metadata["features"]["hit_size_label"] == "Considerable"
+    assert metadata["features"]["hit_size_index"] == 5
+    assert metadata["signals"][0]["kind"] == "finder_hit_hint"
+
+
+def test_accepted_recording_does_not_annotate_non_hit_frames(tmp_path: Path) -> None:
+    recorder = FinderCropRecorder(
+        config=FinderRecordingConfig(
+            modes=frozenset({"accepted"}),
+            root_dir=tmp_path,
+            max_samples=10,
+        ),
+        roi_name="finder_auto",
+    )
+    crop = np.zeros((239, 347, 4), dtype=np.uint8)
+
+    recorder.record_accepted_frame(crop, ts_ms=1_000)
+    recorder.record_frame(
+        crop,
+        ts_ms=1_000,
+        features=FinderFeatures(status_kind="no_resources"),
+        signals=[MiningFinderSignal(ts_ms=1_000, kind="finder_no_resources")],
+    )
+
+    assert list(tmp_path.glob("*_hit_*_annotated.png")) == []

--- a/apps/ocr-worker/tests/test_position_engine.py
+++ b/apps/ocr-worker/tests/test_position_engine.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from zml_ocr_worker.pipelines.position.engine import TesserDigitsEngine
+
+
+class _FakeApi:
+    def __init__(self) -> None:
+        self.variables: dict[str, str] = {}
+        self.closed = False
+
+    def SetVariable(self, name: str, value: str) -> None:
+        self.variables[name] = value
+
+    def End(self) -> None:
+        self.closed = True
+
+
+class _FakeTesserocr:
+    class PSM:
+        SINGLE_WORD = 8
+
+    class OEM:
+        LSTM_ONLY = 1
+
+    def __init__(self) -> None:
+        self.api = _FakeApi()
+        self.created_psm: int | None = None
+
+    def PyTessBaseAPI(
+        self,
+        *,
+        path: str,
+        lang: str,
+        psm: int,
+        oem: int,
+    ) -> _FakeApi:
+        assert Path(path).exists()
+        assert lang == "eng"
+        assert oem == self.OEM.LSTM_ONLY
+        self.created_psm = psm
+        return self.api
+
+
+def test_digits_engine_uses_single_word_page_segmentation(tmp_path: Path) -> None:
+    (tmp_path / "eng.traineddata").touch()
+    tesserocr = _FakeTesserocr()
+
+    engine = TesserDigitsEngine(
+        tessdata_dir=str(tmp_path),
+        tesserocr_module=tesserocr,
+    )
+    try:
+        assert tesserocr.created_psm == tesserocr.PSM.SINGLE_WORD
+        assert tesserocr.api.variables["tessedit_char_whitelist"] == "0123456789"
+        assert tesserocr.api.variables["classify_bln_numeric_mode"] == "1"
+    finally:
+        engine.close()
+
+    assert tesserocr.api.closed


### PR DESCRIPTION
## Current scope

- restores Finder debug evidence for emitted hit hints under the existing `accepted` recording mode
- keeps the raw accepted Finder crop before OCR
- adds an annotated hit PNG only when a `finder_hit_hint` is actually emitted
- overlays `RESOURCE / DETAILS` and `SIZE / STATUS` boxes plus the parsed resource/size text
- stores matching JSON with raw OCR text/features/signals
- never records the full game frame

## Why

Live 0.3.1 testing showed worse Finder resource/size reads after switching fully to auto-location. These captures make each emitted claim decision inspectable without reverting to full-screen screenshots.

More Finder hit-stability work may follow on this branch after live evidence confirms whether the problem is OCR/crop quality or first-frame instability.