### PR TITLE
fix(ocr): stop coordinate digit over-segmentation

### DIFF
--- a/apps/ocr-worker/src/zml_ocr_worker/pipelines/position/engine.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/pipelines/position/engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 from zml_ocr_worker.runtime.paths import get_tessdata_dir
@@ -7,8 +9,13 @@ from zml_ocr_worker.runtime.tesserocr import preload_tesserocr
 
 
 class TesserDigitsEngine:
-    def __init__(self, *, tessdata_dir: str | None = None) -> None:
-        tesserocr = preload_tesserocr()
+    def __init__(
+        self,
+        *,
+        tessdata_dir: str | None = None,
+        tesserocr_module: Any | None = None,
+    ) -> None:
+        tesserocr = tesserocr_module or preload_tesserocr()
 
         resolved_tessdata_dir = get_tessdata_dir(tessdata_dir)
 
@@ -16,12 +23,13 @@ class TesserDigitsEngine:
         self._api = tesserocr.PyTessBaseAPI(
             path=str(resolved_tessdata_dir),
             lang="eng",
-            psm=tesserocr.PSM.SINGLE_LINE,
+            psm=tesserocr.PSM.SINGLE_WORD,
             oem=tesserocr.OEM.LSTM_ONLY,
         )
         self._last_confidence: float | None = None
 
-        # Digits-only configuration.
+        # Coordinate ROIs contain exactly one numeric token. SINGLE_WORD prevents
+        # Tesseract from over-segmenting a connected glyph into multiple digits.
         self._api.SetVariable("tessedit_char_whitelist", "0123456789")
         self._api.SetVariable("classify_bln_numeric_mode", "1")
         self._api.SetVariable("user_defined_dpi", "300")

--- a/apps/ocr-worker/tests/test_position_engine.py
+++ b/apps/ocr-worker/tests/test_position_engine.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from zml_ocr_worker.pipelines.position.engine import TesserDigitsEngine
+
+
+class _FakeApi:
+    def __init__(self) -> None:
+        self.variables: dict[str, str] = {}
+        self.closed = False
+
+    def SetVariable(self, name: str, value: str) -> None:
+        self.variables[name] = value
+
+    def End(self) -> None:
+        self.closed = True
+
+
+class _FakeTesserocr:
+    class PSM:
+        SINGLE_WORD = 8
+
+    class OEM:
+        LSTM_ONLY = 1
+
+    def __init__(self) -> None:
+        self.api = _FakeApi()
+        self.created_psm: int | None = None
+
+    def PyTessBaseAPI(
+        self,
+        *,
+        path: str,
+        lang: str,
+        psm: int,
+        oem: int,
+    ) -> _FakeApi:
+        assert Path(path).exists()
+        assert lang == "eng"
+        assert oem == self.OEM.LSTM_ONLY
+        self.created_psm = psm
+        return self.api
+
+
+def test_digits_engine_uses_single_word_page_segmentation(tmp_path: Path) -> None:
+    (tmp_path / "eng.traineddata").touch()
+    tesserocr = _FakeTesserocr()
+
+    engine = TesserDigitsEngine(
+        tessdata_dir=str(tmp_path),
+        tesserocr_module=tesserocr,
+    )
+    try:
+        assert tesserocr.created_psm == tesserocr.PSM.SINGLE_WORD
+        assert tesserocr.api.variables["tessedit_char_whitelist"] == "0123456789"
+        assert tesserocr.api.variables["classify_bln_numeric_mode"] == "1"
+    finally:
+        engine.close()
+
+    assert tesserocr.api.closed


### PR DESCRIPTION
## Summary
- treat each calibrated coordinate ROI as a single OCR word instead of a generic single text line
- keep the existing digits-only whitelist/numeric mode
- make the Tesseract module injectable so the page-segmentation configuration is unit-testable
- add a regression test that locks the coordinate engine to `PSM.SINGLE_WORD`

## Why
Two live suspect captures read five-digit latitude values as six digits by inserting a repeatable `7` (`24921 -> 249271`, `25421 -> 254271`). The calibrated ROI already contains exactly one numeric token, so `PSM.SINGLE_LINE` is unnecessarily permissive and can over-segment one connected glyph.

Replaying the supplied crops through the current preprocessing with Tesseract 5.5 reproduced the failure for `25421`: `PSM.SINGLE_LINE` returned `254271`, while `PSM.SINGLE_WORD` returned `25421`. Longitude samples remained `20603` and `20688` under the single-word mode.

## Validation
- local crop replay: `24921`, `20603`, `25421`, `20688` all recognized correctly with the existing preprocessing + `PSM.SINGLE_WORD`
- unit test added for OCR segmentation mode and numeric Tesseract variables
