### PR TITLE
fix(ocr): stabilize leading coordinate digit diagnostics

### DIFF
--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/coordinate_ocr.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/coordinate_ocr.py
@@ -143,7 +143,9 @@ class CoordinateTextCalibrator:
         _, value_word = match
 
         line_height = max(1, line_roi.y2 - line_roi.y1)
-        left_padding = max(2, round(line_height * 0.08))
+        # Keep two extra source pixels before the first digit. Live suspect captures
+        # showed both a clipped leading 2 and a spurious leading 9 at this edge.
+        left_padding = max(2, round(line_height * 0.08)) + 2
         right_padding = max(4, round(line_height * 0.18))
         vertical_padding = max(1, round(line_height * 0.08))
         rect = RoiRect(

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/recording.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/recording.py
@@ -12,6 +12,7 @@ import numpy as np
 from zml_ocr_worker.calibration.model import LocatedCompass
 from zml_ocr_worker.pipelines.position.model import CoordinateRois
 from zml_ocr_worker.pipelines.position.pipeline import PositionReadResult
+from zml_ocr_worker.pipelines.position.preprocess import DigitsPreprocessor
 from zml_ocr_worker.runtime.paths import get_app_data_dir
 
 logger = logging.getLogger(__name__)
@@ -40,12 +41,14 @@ class CalibrationSnapshotRecorder:
     Normal production reads do not touch disk. A bounded sample is written only when
     the numeric digit count unexpectedly changes, a run of invalid reads reaches the
     recovery threshold, or confidence first enters a very-low-confidence state.
-    Samples contain the Compass crop plus the active Lon/Lat lines needed to improve
-    OCR later; chat and the rest of the game frame are never recorded.
+    Samples contain the Compass crop plus the raw and preprocessed Lon/Lat lines
+    needed to reproduce OCR later; chat and the rest of the game frame are never
+    recorded.
     """
 
     def __init__(self, *, config: CalibrationSnapshotConfig) -> None:
         self._config = config
+        self._preprocessor = DigitsPreprocessor()
         self._last_recorded_ts_ms: int | None = None
         self._expected_digit_counts: tuple[int, int] | None = None
         self._pending_digit_counts: tuple[int, int] | None = None
@@ -84,6 +87,9 @@ class CalibrationSnapshotRecorder:
         if lon_line is None or lat_line is None:
             return None
 
+        lon_preprocessed = self._preprocessor.process(lon_line)
+        lat_preprocessed = self._preprocessor.process(lat_line)
+
         sample_dir = self._config.root_dir / f"sample-{ts_ms}-{reason}"
         sample_dir.mkdir(parents=True, exist_ok=True)
 
@@ -101,6 +107,8 @@ class CalibrationSnapshotRecorder:
         _write_png(sample_dir / "overview.png", overview)
         _write_png(sample_dir / "lon-line.png", lon_line)
         _write_png(sample_dir / "lat-line.png", lat_line)
+        _write_png(sample_dir / "lon-line-pre.png", lon_preprocessed)
+        _write_png(sample_dir / "lat-line-pre.png", lat_preprocessed)
         (sample_dir / "meta.txt").write_text(
             _metadata_text(
                 reason=reason,

--- a/apps/ocr-worker/tests/test_calibration_recording.py
+++ b/apps/ocr-worker/tests/test_calibration_recording.py
@@ -59,9 +59,20 @@ def test_calibration_snapshot_records_only_suspicious_digit_count_change(tmp_pat
     assert (sample_dir / "overview.png").exists()
     assert (sample_dir / "lon-line.png").exists()
     assert (sample_dir / "lat-line.png").exists()
+    assert (sample_dir / "lon-line-pre.png").exists()
+    assert (sample_dir / "lat-line-pre.png").exists()
     assert (sample_dir / "meta.txt").exists()
     assert not (sample_dir / "lon-mask.png").exists()
     assert not (sample_dir / "lat-mask.png").exists()
+
+    lon_line = cv2.imread(str(sample_dir / "lon-line.png"), cv2.IMREAD_UNCHANGED)
+    lon_pre = cv2.imread(str(sample_dir / "lon-line-pre.png"), cv2.IMREAD_GRAYSCALE)
+    assert lon_line is not None
+    assert lon_pre is not None
+    assert lon_pre.ndim == 2
+    assert lon_pre.shape[0] == lon_line.shape[0] * 2
+    assert lon_pre.shape[1] == lon_line.shape[1] * 2
+    assert set(np.unique(lon_pre)).issubset({0, 255})
 
     metadata = (sample_dir / "meta.txt").read_text(encoding="utf-8")
     assert "reason=digit-count-changed" in metadata

--- a/apps/ocr-worker/tests/test_coordinate_text_calibration.py
+++ b/apps/ocr-worker/tests/test_coordinate_text_calibration.py
@@ -111,9 +111,9 @@ def test_coordinate_text_calibrator_returns_tight_digit_rois_clear_of_labels() -
 
     assert calibration is not None
     assert not calibration.rois.extract_numeric_tokens
-    assert calibration.rois.lon.x1 == 20 + 52 - 2
+    assert calibration.rois.lon.x1 == 20 + 52 - 4
     assert calibration.rois.lon.x2 == 20 + 94 + 4
-    assert calibration.rois.lat.x1 == 20 + 60 - 2
+    assert calibration.rois.lat.x1 == 20 + 60 - 4
     assert calibration.rois.lat.x2 == 20 + 94 + 4
     assert calibration.rois.lon.x1 > 20 + 40
     assert calibration.rois.lat.x1 > 20 + 44


### PR DESCRIPTION
## Summary
- add two extra source pixels of left padding to calibrated Lon/Lat digit ROIs
- keep the existing right/vertical padding unchanged
- record `lon-line-pre.png` and `lat-line-pre.png` for every suspect coordinate snapshot
- keep the existing raw line PNGs and overview/meta files
- add tests for the wider left ROI and preprocessed snapshot output

## Why
New live suspect captures showed leading-digit failures (`25784 -> 925784`, `25753 -> 925753`, `24777 -> 4777`) while the saved raw line crops replay correctly through Tesseract. That points at the left edge/preprocessing path rather than the earlier internal `2 -> 27` over-segmentation issue.

The calibrated digit ROI currently has only about two pixels of source padding before the first glyph. This change gives that edge another two pixels without widening the right side or changing OCR segmentation.

The additional preprocessed PNGs capture the binary/upscaled image produced by the same `DigitsPreprocessor` configuration used by the runtime default path, so the next suspect sample can be replayed much closer to what Tesseract actually received.
