### PR TITLE
fix(ocr): widen Finder details OCR bbox

### DIFF
--- a/apps/ocr-worker/src/zml_ocr_worker/pipelines/mining_finder/vision.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/pipelines/mining_finder/vision.py
@@ -43,7 +43,7 @@ class FinderFeatureDetector(Protocol):
 class FinderPanelLayout:
     radar: RelativeRect = (0.02, 0.03, 0.48, 0.70)
     modes: RelativeRect = (0.02, 0.72, 0.48, 0.98)
-    details: RelativeRect = (0.50, 0.03, 0.98, 0.35)
+    details: RelativeRect = (0.50, 0.03, 1.00, 0.35)
     units: RelativeRect = (0.50, 0.72, 0.98, 0.98)
     status: RelativeRect = (0.50, 0.36, 0.98, 0.70)
 


### PR DESCRIPTION
## What changed

- extends the Finder `details` OCR region from `x2=0.98` to the full right edge (`x2=1.00`)
- keeps the other Finder OCR regions unchanged

## Why

Live 0.3.2 still occasionally drops the final character of resource names. The full Finder crop is now correctly sized, so the remaining clipping is inside the `details` OCR bbox itself.