### PR TITLE
feat(ocr): stabilize and persist Compass calibration

### DIFF
--- a/apps/backend/src/zml_backend/api/routes/ocr_calibration.py
+++ b/apps/backend/src/zml_backend/api/routes/ocr_calibration.py
@@ -56,6 +56,7 @@ def get_ocr_calibration(request: Request) -> dict[str, object]:
 @router.post("/recalibrate")
 def recalibrate_ocr(request: Request) -> dict[str, object]:
     runtime = _runtime(request)
+    settings = _settings(request)
     workers = _object_dict(runtime.health().get("workers"))
     if workers is None:
         raise HTTPException(status_code=409, detail="OCR worker health is unavailable")
@@ -70,6 +71,15 @@ def recalibrate_ocr(request: Request) -> dict[str, object]:
     if not isinstance(raw_pid, int) or isinstance(raw_pid, bool) or raw_pid <= 0:
         raise HTTPException(status_code=409, detail="OCR worker process is not running")
 
+    calibration_path = _compass_calibration_path(settings)
+    try:
+        calibration_path.unlink(missing_ok=True)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Failed to clear persisted Compass calibration: {exc}",
+        ) from exc
+
     try:
         os.kill(raw_pid, signal.SIGTERM)
     except OSError as exc:
@@ -78,7 +88,7 @@ def recalibrate_ocr(request: Request) -> dict[str, object]:
     return {
         "ok": True,
         "workerPid": raw_pid,
-        "message": "OCR worker restart requested; automatic calibration will run after restart",
+        "message": "OCR worker restart requested; Compass calibration will be rebuilt",
     }
 
 
@@ -94,6 +104,10 @@ def _snapshot_command(settings: Settings, *, output_dir: Path) -> list[str]:
         "--profile",
         str(settings.ocr_profile_path),
     ]
+
+
+def _compass_calibration_path(settings: Settings) -> Path:
+    return settings.ocr_profile_path.with_name("compass_calibration.json")
 
 
 def _read_region(output_dir: Path, region: str) -> dict[str, object]:

--- a/apps/backend/src/zml_backend/runtime/bootstrap.py
+++ b/apps/backend/src/zml_backend/runtime/bootstrap.py
@@ -185,13 +185,16 @@ def build_ocr_input_source(
         position_sink=position_sink,
         signal_sink=signal_sink,
     )
+    compass_calibration_path = settings.ocr_profile_path.with_name("compass_calibration.json")
     return OcrWorkerSupervisor(
         config=OcrWorkerSupervisorConfig(
             enabled=settings.ocr_enabled,
             desired_config=build_desired_ocr_config(settings),
             process=OcrWorkerProcessConfig(
                 command=command,
-                environment={},
+                environment={
+                    "ZML_COMPASS_CALIBRATION_PATH": str(compass_calibration_path),
+                },
             ),
         ),
         supervisor=supervisor,
@@ -212,7 +215,6 @@ def build_cloud_sync_worker(
         if base_url is not None and token is not None
         else None
     )
-
     return CloudSyncWorker(
         db_path=settings.db_path,
         pending_db_commands=pending_db_commands,

--- a/apps/backend/tests/runtime/test_ocr_bootstrap.py
+++ b/apps/backend/tests/runtime/test_ocr_bootstrap.py
@@ -36,9 +36,14 @@ def test_ocr_always_uses_external_process_from_path_or_configured_executable(
 
     assert isinstance(default_source, OcrWorkerSupervisor)
     assert default_source.config.process.command == ("zml-ocr-worker", "stdio")
+    assert default_source.config.process.environment == {
+        "ZML_COMPASS_CALIBRATION_PATH": str(tmp_path / "compass_calibration.json"),
+    }
     assert isinstance(configured_source, OcrWorkerSupervisor)
     assert configured_source.config.process.command == ("C:\\ZML\\zml-ocr-worker.exe", "stdio")
-    assert configured_source.config.process.environment == {}
+    assert configured_source.config.process.environment == {
+        "ZML_COMPASS_CALIBRATION_PATH": str(tmp_path / "compass_calibration.json"),
+    }
     assert configured_source.config.desired_config.revision == 1
     assert configured_source.config.desired_config.config.roi_profile.name == "mvp-default"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zml/desktop",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Local-first Entropia Universe mining tracker",
   "type": "module",
   "scripts": {

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_compass.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_compass.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import hypot
+from statistics import median
+
+import numpy as np
+
+from zml_ocr_worker.calibration.compass import CompassLocator, CompassLocatorConfig
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.capture.model import RoiRect
+
+
+@dataclass(frozen=True, slots=True)
+class MultiFrameCompassLocatorConfig:
+    sample_count: int = 7
+    min_inliers: int = 5
+    center_tolerance_radius_fraction: float = 0.08
+    radius_tolerance_fraction: float = 0.08
+
+
+class MultiFrameCompassLocator(CompassLocator):
+    """Require a stable Compass consensus across several consecutive frames."""
+
+    def __init__(
+        self,
+        *,
+        locator_config: CompassLocatorConfig | None = None,
+        config: MultiFrameCompassLocatorConfig | None = None,
+    ) -> None:
+        super().__init__(config=locator_config)
+        self._multi_config = config or MultiFrameCompassLocatorConfig()
+        self._samples: list[LocatedCompass] = []
+
+    @property
+    def acquiring(self) -> bool:
+        return bool(self._samples)
+
+    def locate(self, frame: np.ndarray) -> LocatedCompass | None:
+        candidate = self._locate_single(frame)
+        if candidate is None:
+            self._samples.clear()
+            return None
+
+        self._samples.append(candidate)
+        sample_count = max(1, self._multi_config.sample_count)
+        if len(self._samples) < sample_count:
+            return None
+
+        samples = self._samples[-sample_count:]
+        self._samples.clear()
+        consensus = _consensus_compass(samples, config=self._multi_config)
+        if consensus is None:
+            return None
+
+        # CompassLocator intentionally tolerates one failed locked validation.
+        # Require two checks before accepting a newly aggregated calibration.
+        if not self.locked_is_valid(frame, consensus) or not self.locked_is_valid(frame, consensus):
+            return None
+        return consensus
+
+    def _locate_single(self, frame: np.ndarray) -> LocatedCompass | None:
+        return super().locate(frame)
+
+
+def _consensus_compass(
+    samples: list[LocatedCompass],
+    *,
+    config: MultiFrameCompassLocatorConfig,
+) -> LocatedCompass | None:
+    if not samples:
+        return None
+
+    median_center_x = float(median(sample.center_x for sample in samples))
+    median_center_y = float(median(sample.center_y for sample in samples))
+    median_radius = float(median(sample.radius for sample in samples))
+    center_tolerance = max(3.0, median_radius * config.center_tolerance_radius_fraction)
+    radius_tolerance = max(2.0, median_radius * config.radius_tolerance_fraction)
+
+    inliers = [
+        sample
+        for sample in samples
+        if hypot(sample.center_x - median_center_x, sample.center_y - median_center_y)
+        <= center_tolerance
+        and abs(sample.radius - median_radius) <= radius_tolerance
+    ]
+    min_inliers = min(max(1, config.min_inliers), max(1, config.sample_count))
+    if len(inliers) < min_inliers:
+        return None
+
+    x1 = round(median(sample.rect.x1 for sample in inliers))
+    x2 = round(median(sample.rect.x2 for sample in inliers))
+    y1 = round(median(sample.rect.y1 for sample in inliers))
+    y2 = round(median(sample.rect.y2 for sample in inliers))
+    if x2 <= x1 or y2 <= y1:
+        return None
+
+    return LocatedCompass(
+        rect=RoiRect(x1=x1, x2=x2, y1=y1, y2=y2),
+        confidence=float(median(sample.confidence for sample in inliers)),
+        scale=float(median(sample.scale for sample in inliers)),
+        center_x=float(median(sample.center_x for sample in inliers)),
+        center_y=float(median(sample.center_y for sample in inliers)),
+        radius=float(median(sample.radius for sample in inliers)),
+    )

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_compass.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_compass.py
@@ -55,7 +55,9 @@ class MultiFrameCompassLocator(CompassLocator):
 
         # CompassLocator intentionally tolerates one failed locked validation.
         # Require two checks before accepting a newly aggregated calibration.
-        if not self.locked_is_valid(frame, consensus) or not self.locked_is_valid(frame, consensus):
+        if not self.locked_is_valid(frame, consensus) or not self.locked_is_valid(
+            frame, consensus
+        ):
             return None
         return consensus
 

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_compass.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_compass.py
@@ -55,9 +55,7 @@ class MultiFrameCompassLocator(CompassLocator):
 
         # CompassLocator intentionally tolerates one failed locked validation.
         # Require two checks before accepting a newly aggregated calibration.
-        if not self.locked_is_valid(frame, consensus) or not self.locked_is_valid(
-            frame, consensus
-        ):
+        if not self.locked_is_valid(frame, consensus) or not self.locked_is_valid(frame, consensus):
             return None
         return consensus
 

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/persistence.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/persistence.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.capture.model import RoiRect
+from zml_ocr_worker.pipelines.position.model import CoordinateRois
+from zml_ocr_worker.runtime.paths import get_app_data_dir
+
+logger = logging.getLogger(__name__)
+
+_STATE_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedCompassCalibration:
+    frame_width: int
+    frame_height: int
+    compass: LocatedCompass
+    rois: CoordinateRois
+
+
+class CompassCalibrationStore:
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or default_compass_calibration_path()
+
+    def load(self) -> PersistedCompassCalibration | None:
+        if not self.path.exists():
+            return None
+        try:
+            payload: object = json.loads(self.path.read_text(encoding="utf-8"))
+            return _state_from_json(payload)
+        except Exception:
+            logger.warning(
+                "compass_calibration_state_load_failed path=%s",
+                self.path,
+                exc_info=True,
+            )
+            return None
+
+    def save(self, state: PersistedCompassCalibration) -> bool:
+        temp_path = self.path.with_name(f"{self.path.name}.tmp")
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            temp_path.write_text(
+                json.dumps(_state_to_json(state), ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            os.replace(temp_path, self.path)
+        except OSError:
+            logger.warning(
+                "compass_calibration_state_write_failed path=%s",
+                self.path,
+                exc_info=True,
+            )
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return False
+        logger.info("compass_calibration_state_saved path=%s", self.path)
+        return True
+
+    def clear(self) -> bool:
+        try:
+            self.path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning(
+                "compass_calibration_state_clear_failed path=%s",
+                self.path,
+                exc_info=True,
+            )
+            return False
+        return True
+
+
+def default_compass_calibration_path() -> Path:
+    configured = os.getenv("ZML_COMPASS_CALIBRATION_PATH")
+    if configured is not None and configured.strip() != "":
+        return Path(configured)
+    return get_app_data_dir() / "config" / "compass_calibration.json"
+
+
+def _state_to_json(state: PersistedCompassCalibration) -> dict[str, object]:
+    compass = state.compass
+    return {
+        "version": _STATE_VERSION,
+        "frame": {
+            "width": state.frame_width,
+            "height": state.frame_height,
+        },
+        "compass": {
+            "rect": _rect_to_json(compass.rect),
+            "confidence": compass.confidence,
+            "scale": compass.scale,
+            "center_x": compass.center_x,
+            "center_y": compass.center_y,
+            "radius": compass.radius,
+        },
+        "coordinates": {
+            "lon": _rect_to_json(state.rois.lon),
+            "lat": _rect_to_json(state.rois.lat),
+            "extract_numeric_tokens": state.rois.extract_numeric_tokens,
+        },
+    }
+
+
+def _state_from_json(value: object) -> PersistedCompassCalibration:
+    payload = _object(value)
+    if _required_int(payload, "version") != _STATE_VERSION:
+        raise ValueError("Unsupported compass calibration state version")
+
+    frame = _object(payload.get("frame"))
+    frame_width = _required_positive_int(frame, "width")
+    frame_height = _required_positive_int(frame, "height")
+
+    compass_payload = _object(payload.get("compass"))
+    compass = LocatedCompass(
+        rect=_rect_from_json(compass_payload.get("rect")),
+        confidence=_required_float(compass_payload, "confidence", minimum=0.0, maximum=1.0),
+        scale=_required_float(compass_payload, "scale", minimum=0.0),
+        center_x=_required_float(compass_payload, "center_x"),
+        center_y=_required_float(compass_payload, "center_y"),
+        radius=_required_float(compass_payload, "radius", minimum=0.0),
+    )
+    if compass.scale <= 0.0 or compass.radius <= 0.0:
+        raise ValueError("Compass scale and radius must be positive")
+
+    coordinates = _object(payload.get("coordinates"))
+    extract_numeric_tokens = coordinates.get("extract_numeric_tokens", False)
+    if not isinstance(extract_numeric_tokens, bool):
+        raise ValueError("extract_numeric_tokens must be a boolean")
+    rois = CoordinateRois(
+        lon=_rect_from_json(coordinates.get("lon")),
+        lat=_rect_from_json(coordinates.get("lat")),
+        extract_numeric_tokens=extract_numeric_tokens,
+    )
+    return PersistedCompassCalibration(
+        frame_width=frame_width,
+        frame_height=frame_height,
+        compass=compass,
+        rois=rois,
+    )
+
+
+def _rect_to_json(rect: RoiRect) -> dict[str, int]:
+    return {
+        "x1": rect.x1,
+        "x2": rect.x2,
+        "y1": rect.y1,
+        "y2": rect.y2,
+    }
+
+
+def _rect_from_json(value: object) -> RoiRect:
+    payload = _object(value)
+    rect = RoiRect(
+        x1=_required_non_negative_int(payload, "x1"),
+        x2=_required_positive_int(payload, "x2"),
+        y1=_required_non_negative_int(payload, "y1"),
+        y2=_required_positive_int(payload, "y2"),
+    )
+    if rect.x2 <= rect.x1 or rect.y2 <= rect.y1:
+        raise ValueError("Calibration rectangle must have positive width and height")
+    return rect
+
+
+def _object(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError("Expected JSON object")
+    return cast(dict[str, object], value)
+
+
+def _required_int(payload: dict[str, object], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _required_non_negative_int(payload: dict[str, object], key: str) -> int:
+    value = _required_int(payload, key)
+    if value < 0:
+        raise ValueError(f"{key} must be non-negative")
+    return value
+
+
+def _required_positive_int(payload: dict[str, object], key: str) -> int:
+    value = _required_int(payload, key)
+    if value <= 0:
+        raise ValueError(f"{key} must be positive")
+    return value
+
+
+def _required_float(
+    payload: dict[str, object],
+    key: str,
+    *,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float:
+    value = payload.get(key)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{key} must be numeric")
+    number = float(value)
+    if minimum is not None and number < minimum:
+        raise ValueError(f"{key} must be >= {minimum}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{key} must be <= {maximum}")
+    return number

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/persistence.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/persistence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -58,10 +59,8 @@ class CompassCalibrationStore:
                 self.path,
                 exc_info=True,
             )
-            try:
+            with suppress(OSError):
                 temp_path.unlink(missing_ok=True)
-            except OSError:
-                pass
             return False
         logger.info("compass_calibration_state_saved path=%s", self.path)
         return True

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
@@ -12,6 +12,10 @@ from zml_ocr_worker.calibration.coordinate_ocr import (
 )
 from zml_ocr_worker.calibration.coordinates import CompassCoordinateLayout
 from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.calibration.persistence import (
+    CompassCalibrationStore,
+    PersistedCompassCalibration,
+)
 from zml_ocr_worker.pipelines.position.model import CoordinateRois
 from zml_ocr_worker.pipelines.position.pipeline import PositionPipeline, PositionReadResult
 
@@ -25,6 +29,7 @@ class CompassCalibrationRuntimeConfig:
     locked_validation_interval_ms: int = 1000
     coordinate_recalibration_cooldown_ms: int = 2000
     consecutive_failures_before_recalibrate: int = 5
+    verified_reads_before_persist: int = 10
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,12 +56,14 @@ class CompassCalibrationRuntime:
         locator: CompassLocator | None = None,
         layout: CompassCoordinateLayout | None = None,
         coordinate_calibrator: CoordinateTextCalibrator | None = None,
+        state_store: CompassCalibrationStore | None = None,
         config: CompassCalibrationRuntimeConfig | None = None,
     ) -> None:
         self._position_pipeline = position_pipeline
         self._locator = locator or CompassLocator()
         self._layout = layout or CompassCoordinateLayout()
         self._coordinate_calibrator = coordinate_calibrator or CoordinateTextCalibrator()
+        self._state_store = state_store
         self._config = config or CompassCalibrationRuntimeConfig()
 
         self._compass: LocatedCompass | None = None
@@ -66,6 +73,10 @@ class CompassCalibrationRuntime:
         self._pending_digit_counts: tuple[int, int] | None = None
         self._pending_digit_count_streak = 0
         self._coordinate_failure_streak = 0
+        self._frame_size: tuple[int, int] | None = None
+        self._persisted_restore_attempted = False
+        self._calibration_persisted = False
+        self._verified_read_streak = 0
 
         self._next_search_ts_ms = 0
         self._next_locked_validation_ts_ms = 0
@@ -91,12 +102,19 @@ class CompassCalibrationRuntime:
         self._search_rois = None
         self._coordinate_rois = None
         self._expected_digit_counts = None
+        self._frame_size = None
+        self._calibration_persisted = False
+        self._verified_read_streak = 0
         self._reset_coordinate_health()
         self._next_search_ts_ms = max(0, next_search_ts_ms)
         self._next_locked_validation_ts_ms = 0
         self._next_coordinate_calibration_ts_ms = 0
 
     def step(self, frame: np.ndarray, *, ts_ms: int) -> CalibratedPositionStep:
+        if self._compass is None and not self._persisted_restore_attempted:
+            self._persisted_restore_attempted = True
+            self._try_restore_persisted(frame)
+
         if self._compass is None:
             if ts_ms < self._next_search_ts_ms:
                 return _empty_step()
@@ -152,6 +170,7 @@ class CompassCalibrationRuntime:
                 self._remember_digit_counts(read)
                 self._reset_coordinate_health()
                 read = self._position_pipeline.emit_read(read, ts_ms=ts_ms)
+                self._record_verified_read()
                 return CalibratedPositionStep(
                     compass=compass,
                     compass_roi=compass_roi,
@@ -159,6 +178,7 @@ class CompassCalibrationRuntime:
                 )
 
             if self._digit_count_changed(read):
+                self._verified_read_streak = 0
                 changed_counts = _digit_counts(read)
                 self._record_digit_count_mismatch(changed_counts)
                 if self._pending_digit_count_streak == 1:
@@ -179,12 +199,14 @@ class CompassCalibrationRuntime:
 
             self._reset_coordinate_health()
             read = self._position_pipeline.emit_read(read, ts_ms=ts_ms)
+            self._record_verified_read()
             return CalibratedPositionStep(
                 compass=compass,
                 compass_roi=compass_roi,
                 read=read,
             )
 
+        self._verified_read_streak = 0
         self._pending_digit_counts = None
         self._pending_digit_count_streak = 0
         return self._recover_unhealthy_read(
@@ -204,6 +226,7 @@ class CompassCalibrationRuntime:
         ts_ms: int,
         reason: str,
     ) -> CalibratedPositionStep:
+        self._verified_read_streak = 0
         self._coordinate_failure_streak += 1
         threshold = max(1, self._config.consecutive_failures_before_recalibrate)
         if (
@@ -234,15 +257,18 @@ class CompassCalibrationRuntime:
                         self._remember_digit_counts(fresh)
                         self._reset_coordinate_health()
                         fresh = self._position_pipeline.emit_read(fresh, ts_ms=ts_ms)
+                        self._record_verified_read()
                         read = fresh
                     elif fresh_counts == expected:
                         self._reset_coordinate_health()
                         fresh = self._position_pipeline.emit_read(fresh, ts_ms=ts_ms)
+                        self._record_verified_read()
                         read = fresh
                 else:
                     self._remember_digit_counts(fresh)
                     self._reset_coordinate_health()
                     fresh = self._position_pipeline.emit_read(fresh, ts_ms=ts_ms)
+                    self._record_verified_read()
                     read = fresh
 
         return CalibratedPositionStep(
@@ -250,6 +276,68 @@ class CompassCalibrationRuntime:
             compass_roi=compass_roi,
             read=read,
         )
+
+    def _try_restore_persisted(self, frame: np.ndarray) -> bool:
+        store = self._state_store
+        if store is None:
+            return False
+        state = store.load()
+        if state is None:
+            return False
+
+        frame_height = int(frame.shape[0])
+        frame_width = int(frame.shape[1])
+        if state.frame_width != frame_width or state.frame_height != frame_height:
+            logger.info(
+                "compass_calibration_state_ignored reason=frame_size stored=%sx%s current=%sx%s",
+                state.frame_width,
+                state.frame_height,
+                frame_width,
+                frame_height,
+            )
+            return False
+
+        compass_roi = state.compass.rect.crop(frame)
+        if (
+            compass_roi is None
+            or state.rois.lon.crop(compass_roi) is None
+            or state.rois.lat.crop(compass_roi) is None
+        ):
+            logger.info("compass_calibration_state_ignored reason=invalid_rois")
+            return False
+
+        variants = self._layout.variants(state.compass)
+        if not variants:
+            logger.info("compass_calibration_state_ignored reason=no_layout")
+            return False
+
+        # A locked locator intentionally tolerates one failed validation. Require
+        # two successful checks here so stale persisted geometry cannot consume
+        # that grace period during startup.
+        if not self._locator.locked_is_valid(frame, state.compass) or not self._locator.locked_is_valid(
+            frame, state.compass
+        ):
+            logger.info("compass_calibration_state_ignored reason=locked_validation")
+            return False
+
+        self._compass = state.compass
+        self._search_rois = variants[0].rois
+        self._coordinate_rois = state.rois
+        self._expected_digit_counts = None
+        self._frame_size = (frame_width, frame_height)
+        self._calibration_persisted = True
+        self._verified_read_streak = 0
+        self._reset_coordinate_health()
+        self._next_search_ts_ms = 0
+        self._next_locked_validation_ts_ms = 0
+        self._next_coordinate_calibration_ts_ms = 0
+        logger.info(
+            "compass_calibration_state_restored rect=%s lon_roi=%s lat_roi=%s",
+            _rect_tuple(state.compass.rect),
+            _rect_tuple(state.rois.lon),
+            _rect_tuple(state.rois.lat),
+        )
+        return True
 
     def _locate(self, frame: np.ndarray) -> bool:
         compass = self._locator.locate(frame)
@@ -263,6 +351,9 @@ class CompassCalibrationRuntime:
         self._search_rois = variants[0].rois
         self._coordinate_rois = None
         self._expected_digit_counts = None
+        self._frame_size = (int(frame.shape[1]), int(frame.shape[0]))
+        self._calibration_persisted = False
+        self._verified_read_streak = 0
         self._reset_coordinate_health()
         self._next_search_ts_ms = 0
         self._next_locked_validation_ts_ms = 0
@@ -309,6 +400,8 @@ class CompassCalibrationRuntime:
     ) -> None:
         self._coordinate_rois = calibration.rois
         self._coordinate_failure_streak = 0
+        self._calibration_persisted = False
+        self._verified_read_streak = 0
         lon = calibration.rois.lon
         lat = calibration.rois.lat
         logger.info(
@@ -317,6 +410,36 @@ class CompassCalibrationRuntime:
             (lon.x1, lon.y1, lon.x2, lon.y2),
             (lat.x1, lat.y1, lat.x2, lat.y2),
         )
+
+    def _record_verified_read(self) -> None:
+        if self._calibration_persisted:
+            return
+        store = self._state_store
+        compass = self._compass
+        rois = self._coordinate_rois
+        frame_size = self._frame_size
+        if store is None or compass is None or rois is None or frame_size is None:
+            return
+
+        self._verified_read_streak += 1
+        threshold = max(1, self._config.verified_reads_before_persist)
+        if self._verified_read_streak < threshold:
+            return
+
+        frame_width, frame_height = frame_size
+        state = PersistedCompassCalibration(
+            frame_width=frame_width,
+            frame_height=frame_height,
+            compass=compass,
+            rois=rois,
+        )
+        if store.save(state):
+            self._calibration_persisted = True
+            logger.info(
+                "compass_calibration_verified reads=%s rect=%s",
+                self._verified_read_streak,
+                _rect_tuple(compass.rect),
+            )
 
     def _read_fast(self, compass_roi: np.ndarray, *, ts_ms: int) -> PositionReadResult:
         rois = self._coordinate_rois
@@ -365,6 +488,11 @@ def _digit_counts(read: PositionReadResult) -> tuple[int, int] | None:
         len(str(abs(read.longitude))),
         len(str(abs(read.latitude))),
     )
+
+
+def _rect_tuple(rect: object) -> tuple[int, int, int, int]:
+    typed = rect
+    return typed.x1, typed.y1, typed.x2, typed.y2  # type: ignore[attr-defined, no-any-return]
 
 
 def _empty_step(*, reacquire_requested: bool = False) -> CalibratedPositionStep:

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
@@ -12,6 +12,7 @@ from zml_ocr_worker.calibration.coordinate_ocr import (
 )
 from zml_ocr_worker.calibration.coordinates import CompassCoordinateLayout
 from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.calibration.multiframe_compass import MultiFrameCompassLocator
 from zml_ocr_worker.calibration.persistence import (
     CompassCalibrationStore,
     PersistedCompassCalibration,
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True, slots=True)
 class CompassCalibrationRuntimeConfig:
     search_interval_ms: int = 1000
+    acquisition_sample_interval_ms: int = 100
     reacquire_delay_ms: int = 250
     locked_validation_interval_ms: int = 1000
     coordinate_recalibration_cooldown_ms: int = 2000
@@ -61,7 +63,7 @@ class CompassCalibrationRuntime:
         config: CompassCalibrationRuntimeConfig | None = None,
     ) -> None:
         self._position_pipeline = position_pipeline
-        self._locator = locator or CompassLocator()
+        self._locator = locator or MultiFrameCompassLocator()
         self._layout = layout or CompassCoordinateLayout()
         self._coordinate_calibrator = coordinate_calibrator or CoordinateTextCalibrator()
         self._state_store = state_store
@@ -119,8 +121,14 @@ class CompassCalibrationRuntime:
         if self._compass is None:
             if ts_ms < self._next_search_ts_ms:
                 return _empty_step()
-            self._next_search_ts_ms = ts_ms + max(1, self._config.search_interval_ms)
             if not self._locate(frame):
+                acquisition_in_progress = bool(getattr(self._locator, "acquiring", False))
+                delay_ms = (
+                    self._config.acquisition_sample_interval_ms
+                    if acquisition_in_progress
+                    else self._config.search_interval_ms
+                )
+                self._next_search_ts_ms = ts_ms + max(1, delay_ms)
                 return _empty_step()
 
         compass = self._compass

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
@@ -16,6 +16,7 @@ from zml_ocr_worker.calibration.persistence import (
     CompassCalibrationStore,
     PersistedCompassCalibration,
 )
+from zml_ocr_worker.capture.model import RoiRect
 from zml_ocr_worker.pipelines.position.model import CoordinateRois
 from zml_ocr_worker.pipelines.position.pipeline import PositionPipeline, PositionReadResult
 
@@ -314,9 +315,9 @@ class CompassCalibrationRuntime:
         # A locked locator intentionally tolerates one failed validation. Require
         # two successful checks here so stale persisted geometry cannot consume
         # that grace period during startup.
-        if not self._locator.locked_is_valid(frame, state.compass) or not self._locator.locked_is_valid(
+        if not self._locator.locked_is_valid(
             frame, state.compass
-        ):
+        ) or not self._locator.locked_is_valid(frame, state.compass):
             logger.info("compass_calibration_state_ignored reason=locked_validation")
             return False
 
@@ -490,9 +491,8 @@ def _digit_counts(read: PositionReadResult) -> tuple[int, int] | None:
     )
 
 
-def _rect_tuple(rect: object) -> tuple[int, int, int, int]:
-    typed = rect
-    return typed.x1, typed.y1, typed.x2, typed.y2  # type: ignore[attr-defined, no-any-return]
+def _rect_tuple(rect: RoiRect) -> tuple[int, int, int, int]:
+    return rect.x1, rect.y1, rect.x2, rect.y2
 
 
 def _empty_step(*, reacquire_requested: bool = False) -> CalibratedPositionStep:

--- a/apps/ocr-worker/src/zml_ocr_worker/runtime/runner.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/runtime/runner.py
@@ -14,6 +14,7 @@ from zml_ocr_protocol.messages import AgentToBridgeMessage
 
 from zml_ocr_worker.calibration.finder import FinderLocator
 from zml_ocr_worker.calibration.model import LocatedRegion
+from zml_ocr_worker.calibration.persistence import CompassCalibrationStore
 from zml_ocr_worker.calibration.recording import (
     CalibrationSnapshotRecorder,
     calibration_snapshot_config_from_env,
@@ -94,7 +95,15 @@ def start_ocr_input(
         position_rois,
         profiler=profiler,
     )
-    compass_calibration = CompassCalibrationRuntime(position_pipeline=position_pipeline)
+    compass_calibration_store = CompassCalibrationStore()
+    logger.info(
+        "compass_calibration_persistence_enabled path=%s",
+        compass_calibration_store.path,
+    )
+    compass_calibration = CompassCalibrationRuntime(
+        position_pipeline=position_pipeline,
+        state_store=compass_calibration_store,
+    )
     last_compass_rect: tuple[int, int, int, int] | None = None
 
     calibration_snapshot_config = calibration_snapshot_config_from_env()

--- a/apps/ocr-worker/tests/test_calibration_persistence.py
+++ b/apps/ocr-worker/tests/test_calibration_persistence.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.calibration.persistence import (
+    CompassCalibrationStore,
+    PersistedCompassCalibration,
+    default_compass_calibration_path,
+)
+from zml_ocr_worker.capture.model import RoiRect
+from zml_ocr_worker.pipelines.position.model import CoordinateRois
+
+
+def _state() -> PersistedCompassCalibration:
+    return PersistedCompassCalibration(
+        frame_width=2560,
+        frame_height=1440,
+        compass=LocatedCompass(
+            rect=RoiRect(x1=2190, x2=2551, y1=965, y2=1411),
+            confidence=0.94,
+            scale=1.0,
+            center_x=2363.0,
+            center_y=1177.0,
+            radius=142.0,
+        ),
+        rois=CoordinateRois(
+            lon=RoiRect(x1=85, x2=145, y1=350, y2=370),
+            lat=RoiRect(x1=90, x2=145, y1=375, y2=395),
+        ),
+    )
+
+
+def test_compass_calibration_store_round_trips_state(tmp_path: Path) -> None:
+    path = tmp_path / "config" / "compass_calibration.json"
+    store = CompassCalibrationStore(path)
+    state = _state()
+
+    assert store.save(state)
+    assert store.load() == state
+    assert not path.with_name("compass_calibration.json.tmp").exists()
+
+
+def test_compass_calibration_store_rejects_corrupt_state(tmp_path: Path) -> None:
+    path = tmp_path / "compass_calibration.json"
+    path.write_text(json.dumps({"version": 1, "frame": {}}), encoding="utf-8")
+
+    assert CompassCalibrationStore(path).load() is None
+
+
+def test_default_compass_calibration_path_honors_env(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    expected = tmp_path / "saved.json"
+    monkeypatch.setenv("ZML_COMPASS_CALIBRATION_PATH", str(expected))
+
+    assert default_compass_calibration_path() == expected

--- a/apps/ocr-worker/tests/test_compass_calibration_persistence_runtime.py
+++ b/apps/ocr-worker/tests/test_compass_calibration_persistence_runtime.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+
+from zml_ocr_worker.calibration.coordinate_ocr import CoordinateCalibration
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.calibration.persistence import PersistedCompassCalibration
+from zml_ocr_worker.calibration.runtime import (
+    CompassCalibrationRuntime,
+    CompassCalibrationRuntimeConfig,
+)
+from zml_ocr_worker.capture.model import RoiRect
+from zml_ocr_worker.pipelines.position.model import CoordinateRois
+from zml_ocr_worker.pipelines.position.pipeline import PositionReadResult
+
+
+class _FakeStore:
+    def __init__(self, loaded: PersistedCompassCalibration | None = None) -> None:
+        self.loaded = loaded
+        self.load_calls = 0
+        self.saved: list[PersistedCompassCalibration] = []
+
+    def load(self) -> PersistedCompassCalibration | None:
+        self.load_calls += 1
+        return self.loaded
+
+    def save(self, state: PersistedCompassCalibration) -> bool:
+        self.saved.append(state)
+        return True
+
+
+class _FakeLocator:
+    def __init__(self, compass: LocatedCompass, *, locked_valid: bool = True) -> None:
+        self._compass = compass
+        self._locked_valid = locked_valid
+        self.locate_calls = 0
+        self.locked_calls = 0
+
+    def locate(self, frame: np.ndarray) -> LocatedCompass | None:
+        self.locate_calls += 1
+        return self._compass
+
+    def locked_is_valid(self, frame: np.ndarray, compass: LocatedCompass) -> bool:
+        self.locked_calls += 1
+        return self._locked_valid
+
+    def validate_locked(self, frame: np.ndarray, compass: LocatedCompass) -> float:
+        return 1.0 if self._locked_valid else 0.0
+
+
+class _FakeCalibrator:
+    def __init__(self, *responses: CoordinateCalibration | None) -> None:
+        self._responses = deque(responses)
+        self.calls = 0
+
+    def calibrate(
+        self,
+        compass_roi: np.ndarray,
+        *,
+        search_rois: CoordinateRois,
+    ) -> CoordinateCalibration | None:
+        self.calls += 1
+        if not self._responses:
+            return None
+        return self._responses.popleft()
+
+    def close(self) -> None:
+        return None
+
+
+class _FakePositionPipeline:
+    def __init__(self, *reads: PositionReadResult) -> None:
+        self._reads = deque(reads)
+        self.read_calls = 0
+        self.emit_calls = 0
+
+    def read(
+        self,
+        compass_roi: np.ndarray,
+        ts_ms: int,
+        *,
+        rois: CoordinateRois | None = None,
+        emit: bool = True,
+    ) -> PositionReadResult:
+        self.read_calls += 1
+        if not self._reads:
+            return PositionReadResult(longitude=None, latitude=None, position=None)
+        return self._reads.popleft()
+
+    def emit_read(self, read: PositionReadResult, *, ts_ms: int) -> PositionReadResult:
+        self.emit_calls += 1
+        return read
+
+
+def _compass() -> LocatedCompass:
+    return LocatedCompass(
+        rect=RoiRect(x1=100, x2=360, y1=80, y2=400),
+        confidence=0.95,
+        scale=1.0,
+        center_x=230.0,
+        center_y=230.0,
+        radius=100.0,
+    )
+
+
+def _digit_rois() -> CoordinateRois:
+    return CoordinateRois(
+        lon=RoiRect(x1=40, x2=100, y1=250, y2=275),
+        lat=RoiRect(x1=40, x2=100, y1=280, y2=305),
+    )
+
+
+def _calibration() -> CoordinateCalibration:
+    return CoordinateCalibration(rois=_digit_rois())
+
+
+def _read() -> PositionReadResult:
+    return PositionReadResult(longitude=31156, latitude=9515, position=None)
+
+
+def test_runtime_restores_persisted_compass_without_full_reacquire() -> None:
+    persisted = PersistedCompassCalibration(
+        frame_width=500,
+        frame_height=500,
+        compass=_compass(),
+        rois=_digit_rois(),
+    )
+    store = _FakeStore(persisted)
+    locator = _FakeLocator(_compass())
+    calibrator = _FakeCalibrator()
+    pipeline = _FakePositionPipeline(_read())
+    runtime = CompassCalibrationRuntime(
+        position_pipeline=pipeline,  # type: ignore[arg-type]
+        locator=locator,  # type: ignore[arg-type]
+        coordinate_calibrator=calibrator,  # type: ignore[arg-type]
+        state_store=store,  # type: ignore[arg-type]
+        config=CompassCalibrationRuntimeConfig(locked_validation_interval_ms=10_000),
+    )
+    frame = np.zeros((500, 500, 3), dtype=np.uint8)
+
+    step = runtime.step(frame, ts_ms=100)
+
+    assert step.compass == persisted.compass
+    assert runtime.active_rois == persisted.rois
+    assert locator.locate_calls == 0
+    assert locator.locked_calls >= 2
+    assert calibrator.calls == 0
+    assert pipeline.emit_calls == 1
+    assert not store.saved
+
+
+def test_runtime_persists_new_calibration_after_ten_consecutive_valid_reads() -> None:
+    store = _FakeStore()
+    locator = _FakeLocator(_compass())
+    calibrator = _FakeCalibrator(_calibration())
+    pipeline = _FakePositionPipeline(*[_read() for _ in range(10)])
+    runtime = CompassCalibrationRuntime(
+        position_pipeline=pipeline,  # type: ignore[arg-type]
+        locator=locator,  # type: ignore[arg-type]
+        coordinate_calibrator=calibrator,  # type: ignore[arg-type]
+        state_store=store,  # type: ignore[arg-type]
+        config=CompassCalibrationRuntimeConfig(
+            locked_validation_interval_ms=10_000,
+            verified_reads_before_persist=10,
+        ),
+    )
+    frame = np.zeros((500, 500, 3), dtype=np.uint8)
+
+    for index in range(9):
+        runtime.step(frame, ts_ms=100 + index * 10)
+        assert not store.saved
+
+    runtime.step(frame, ts_ms=190)
+
+    assert len(store.saved) == 1
+    saved = store.saved[0]
+    assert saved.frame_width == 500
+    assert saved.frame_height == 500
+    assert saved.compass == _compass()
+    assert saved.rois == _digit_rois()

--- a/apps/ocr-worker/tests/test_multiframe_compass.py
+++ b/apps/ocr-worker/tests/test_multiframe_compass.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.calibration.multiframe_compass import (
+    MultiFrameCompassLocator,
+    MultiFrameCompassLocatorConfig,
+)
+from zml_ocr_worker.capture.model import RoiRect
+
+
+class _StubMultiFrameLocator(MultiFrameCompassLocator):
+    def __init__(self, *samples: LocatedCompass | None) -> None:
+        super().__init__(
+            config=MultiFrameCompassLocatorConfig(
+                sample_count=7,
+                min_inliers=5,
+            )
+        )
+        self._stub_samples = deque(samples)
+
+    def _locate_single(self, frame: np.ndarray) -> LocatedCompass | None:
+        if not self._stub_samples:
+            return None
+        return self._stub_samples.popleft()
+
+    def locked_is_valid(self, frame: np.ndarray, compass: LocatedCompass) -> bool:
+        return True
+
+
+def _compass(*, dx: int = 0, dy: int = 0, dr: int = 0) -> LocatedCompass:
+    return LocatedCompass(
+        rect=RoiRect(
+            x1=100 + dx,
+            x2=360 + dx,
+            y1=80 + dy,
+            y2=400 + dy,
+        ),
+        confidence=0.95,
+        scale=1.0 + dr / 100.0,
+        center_x=230.0 + dx,
+        center_y=230.0 + dy,
+        radius=100.0 + dr,
+    )
+
+
+def test_multiframe_locator_uses_consensus_and_rejects_single_outlier() -> None:
+    locator = _StubMultiFrameLocator(
+        _compass(dx=-1),
+        _compass(dy=1),
+        _compass(dx=1),
+        _compass(dr=1),
+        _compass(dx=-1, dy=-1),
+        _compass(),
+        _compass(dx=80, dy=-60, dr=35),
+    )
+    frame = np.zeros((500, 500, 3), dtype=np.uint8)
+
+    for _ in range(6):
+        assert locator.locate(frame) is None
+        assert locator.acquiring
+
+    result = locator.locate(frame)
+
+    assert result is not None
+    assert not locator.acquiring
+    assert abs(result.center_x - 230.0) <= 1.0
+    assert abs(result.center_y - 230.0) <= 1.0
+    assert abs(result.radius - 100.0) <= 1.0
+    assert result.rect.x1 == 100
+    assert result.rect.x2 == 360
+
+
+def test_multiframe_locator_requires_consecutive_successful_frames() -> None:
+    locator = _StubMultiFrameLocator(
+        _compass(),
+        _compass(),
+        None,
+        _compass(),
+        _compass(),
+        _compass(),
+        _compass(),
+        _compass(),
+        _compass(),
+        _compass(),
+    )
+    frame = np.zeros((500, 500, 3), dtype=np.uint8)
+
+    assert locator.locate(frame) is None
+    assert locator.locate(frame) is None
+    assert locator.acquiring
+    assert locator.locate(frame) is None
+    assert not locator.acquiring
+
+    result = None
+    for _ in range(7):
+        result = locator.locate(frame)
+
+    assert result is not None


### PR DESCRIPTION
## Summary
- persist only Compass calibration state, leaving Finder auto-calibration unchanged
- acquire a new Compass from multiple consecutive frames instead of trusting one Hough result
- collect 7 successful Compass detections at ~100 ms spacing, build a median consensus, reject geometric outliers, and require at least 5 inliers
- validate the consensus twice with the existing locked-ring check before using it
- store the detected Compass geometry together with calibrated Lon/Lat OCR ROIs and client frame size
- require 10 consecutive valid coordinate reads before a newly discovered/calibrated state becomes the persisted last-known-good state
- restore persisted state on startup only when frame size matches and locked Compass validation succeeds
- fall back to normal multi-frame auto-calibration when persisted geometry is stale or invalid
- write calibration state atomically via temporary file + replace
- make the backend pass a shared calibration-state path to the OCR worker
- make `Recalibrate OCR` delete the persisted Compass state before restarting the worker

## Multi-frame acquisition
Normal startup first tries the persisted last-known-good Compass. When there is no usable persisted state, acquisition runs in stages:
1. collect 7 consecutive successful Compass detections from separate frames,
2. compute median center/radius/outer rect and reject detections outside the geometry tolerance,
3. require at least 5 inliers,
4. run the existing locked Compass validation twice on the aggregate before starting coordinate text calibration.

While a consensus is being collected, samples are requested every ~100 ms. If a frame cannot locate the Compass, the partial sample set is discarded so a consensus cannot span unrelated UI states.

## Persistence
Default packaged location is alongside `ocr_profile.json` as `config/compass_calibration.json`. The backend explicitly passes the exact path to the worker via `ZML_COMPASS_CALIBRATION_PATH`, so dev/custom profile paths stay aligned as well.

## Verification rule
A newly generated Compass + Lon/Lat calibration is saved only after 10 consecutive valid reads. Any invalid read or suspect digit-count change resets the verification streak. Once a calibration is already persisted, ordinary transient OCR failures do not erase the last-known-good file.