### PR TITLE
fix(ocr): stabilize first-run calibration and diagnostics

### DIFF
--- a/apps/backend/src/zml_backend/api/routes/ocr_calibration.py
+++ b/apps/backend/src/zml_backend/api/routes/ocr_calibration.py
@@ -23,12 +23,14 @@ def get_ocr_calibration(request: Request) -> dict[str, object]:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     command = _snapshot_command(settings, output_dir=output_dir)
+    environment = os.environ.copy()
+    environment["ZML_COMPASS_CALIBRATION_PATH"] = str(_compass_calibration_path(settings))
     creation_flags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     try:
         completed = subprocess.run(
             command,
             cwd=None,
-            env=os.environ.copy(),
+            env=environment,
             capture_output=True,
             text=True,
             timeout=12.0,

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/live_snapshot.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/live_snapshot.py
@@ -77,11 +77,12 @@ def run_live_calibration_snapshot(
             result["capturedTsMs"] = ts_ms
             calibrated = compass_runtime.step(frame, ts_ms=ts_ms)
 
-        if calibrated.compass is not None:
+        active_rois = compass_runtime.active_rois
+        if calibrated.compass is not None and active_rois is not None:
             recorder.record_compass(
                 frame,
                 compass=calibrated.compass,
-                rois=compass_runtime.active_rois,
+                rois=active_rois,
                 ts_ms=ts_ms,
             )
             result["compass"] = {"available": True}

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/live_snapshot.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/live_snapshot.py
@@ -17,7 +17,7 @@ from zml_ocr_worker.config import load_ocr_roi_profile
 from zml_ocr_worker.pipelines.mining_finder.presence import FinderPresenceDetector
 from zml_ocr_worker.pipelines.position.pipeline import PositionPipeline
 
-_COMPASS_SNAPSHOT_TIMEOUT_S = 3.0
+_COMPASS_SNAPSHOT_TIMEOUT_S = 5.0
 _COMPASS_SAMPLE_INTERVAL_S = 0.11
 
 

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/live_snapshot.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/live_snapshot.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 from zml_ocr_worker.calibration.finder import FinderLocator
+from zml_ocr_worker.calibration.persistence import CompassCalibrationStore
 from zml_ocr_worker.calibration.runtime import CompassCalibrationRuntime
 from zml_ocr_worker.calibration.ui_diagnostics import (
     CalibrationUiDiagnosticsConfig,
@@ -15,6 +16,9 @@ from zml_ocr_worker.capture.window_capturer import WindowCapturer
 from zml_ocr_worker.config import load_ocr_roi_profile
 from zml_ocr_worker.pipelines.mining_finder.presence import FinderPresenceDetector
 from zml_ocr_worker.pipelines.position.pipeline import PositionPipeline
+
+_COMPASS_SNAPSHOT_TIMEOUT_S = 3.0
+_COMPASS_SAMPLE_INTERVAL_S = 0.11
 
 
 def run_live_calibration_snapshot(
@@ -35,17 +39,21 @@ def run_live_calibration_snapshot(
 
     capturer = WindowCapturer(title_contains="Entropia Universe Client")
     position_pipeline = PositionPipeline(profile.position_rois.to_position_rois())
-    compass_runtime = CompassCalibrationRuntime(position_pipeline=position_pipeline)
+    compass_runtime = CompassCalibrationRuntime(
+        position_pipeline=position_pipeline,
+        state_store=CompassCalibrationStore(),
+    )
     finder_locator = FinderLocator(presence_detector=FinderPresenceDetector())
-    ts_ms = time.time_ns() // 1_000_000
 
     result: dict[str, object] = {
-        "capturedTsMs": ts_ms,
+        "capturedTsMs": None,
         "finder": {"available": False},
         "compass": {"available": False},
     }
     try:
         frame = capturer.grab()
+        ts_ms = time.time_ns() // 1_000_000
+        result["capturedTsMs"] = ts_ms
 
         finder = finder_locator.locate(frame)
         if finder is not None:
@@ -57,7 +65,18 @@ def run_live_calibration_snapshot(
             )
             result["finder"] = {"available": True}
 
+        deadline = time.monotonic() + _COMPASS_SNAPSHOT_TIMEOUT_S
         calibrated = compass_runtime.step(frame, ts_ms=ts_ms)
+        while (
+            (calibrated.compass is None or compass_runtime.active_rois is None)
+            and time.monotonic() < deadline
+        ):
+            time.sleep(_COMPASS_SAMPLE_INTERVAL_S)
+            frame = capturer.grab()
+            ts_ms = time.time_ns() // 1_000_000
+            result["capturedTsMs"] = ts_ms
+            calibrated = compass_runtime.step(frame, ts_ms=ts_ms)
+
         if calibrated.compass is not None:
             recorder.record_compass(
                 frame,

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/live_snapshot.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/live_snapshot.py
@@ -68,9 +68,8 @@ def run_live_calibration_snapshot(
         deadline = time.monotonic() + _COMPASS_SNAPSHOT_TIMEOUT_S
         calibrated = compass_runtime.step(frame, ts_ms=ts_ms)
         while (
-            (calibrated.compass is None or compass_runtime.active_rois is None)
-            and time.monotonic() < deadline
-        ):
+            calibrated.compass is None or compass_runtime.active_rois is None
+        ) and time.monotonic() < deadline:
             time.sleep(_COMPASS_SAMPLE_INTERVAL_S)
             frame = capturer.grab()
             ts_ms = time.time_ns() // 1_000_000

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_coordinate.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_coordinate.py
@@ -96,7 +96,7 @@ def _consensus_coordinate_calibration(
 
     lon = _median_rect([sample.rois.lon for sample in inliers])
     lat = _median_rect([sample.rois.lat for sample in inliers])
-    if lon.x2 <= lon.x1 or lon.y2 <= lon.y1 or lat.x2 <= lat.x1 or lat.y2 <= lat.y1:
+    if not _valid_rect(lon) or not _valid_rect(lat):
         return None
 
     extract_numeric_tokens = inliers[0].rois.extract_numeric_tokens
@@ -131,3 +131,7 @@ def _rect_is_close(rect: RoiRect, expected: RoiRect, *, tolerance: int) -> bool:
             (rect.y2, expected.y2),
         )
     )
+
+
+def _valid_rect(rect: RoiRect) -> bool:
+    return rect.x2 > rect.x1 and rect.y2 > rect.y1

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_coordinate.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/multiframe_coordinate.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import median
+
+import numpy as np
+
+from zml_ocr_worker.calibration.coordinate_ocr import (
+    CoordinateCalibration,
+    CoordinateTextCalibrator,
+)
+from zml_ocr_worker.capture.model import RoiRect
+from zml_ocr_worker.pipelines.position.model import CoordinateRois
+
+
+@dataclass(frozen=True, slots=True)
+class MultiFrameCoordinateTextCalibratorConfig:
+    sample_count: int = 5
+    min_inliers: int = 4
+    edge_tolerance_px: int = 4
+
+
+class MultiFrameCoordinateTextCalibrator:
+    """Require stable Lon/Lat value boxes across consecutive frames."""
+
+    def __init__(
+        self,
+        *,
+        calibrator: CoordinateTextCalibrator | None = None,
+        config: MultiFrameCoordinateTextCalibratorConfig | None = None,
+    ) -> None:
+        self._calibrator = calibrator or CoordinateTextCalibrator()
+        self._config = config or MultiFrameCoordinateTextCalibratorConfig()
+        self._samples: list[CoordinateCalibration] = []
+
+    @property
+    def acquiring(self) -> bool:
+        return bool(self._samples)
+
+    def reset(self) -> None:
+        self._samples.clear()
+
+    def calibrate(
+        self,
+        compass_roi: np.ndarray,
+        *,
+        search_rois: CoordinateRois,
+    ) -> CoordinateCalibration | None:
+        try:
+            candidate = self._calibrator.calibrate(
+                compass_roi,
+                search_rois=search_rois,
+            )
+        except Exception:
+            self.reset()
+            raise
+
+        if candidate is None:
+            self.reset()
+            return None
+
+        self._samples.append(candidate)
+        sample_count = max(1, self._config.sample_count)
+        if len(self._samples) < sample_count:
+            return None
+
+        samples = self._samples[-sample_count:]
+        self.reset()
+        return _consensus_coordinate_calibration(samples, config=self._config)
+
+    def close(self) -> None:
+        self._calibrator.close()
+
+
+def _consensus_coordinate_calibration(
+    samples: list[CoordinateCalibration],
+    *,
+    config: MultiFrameCoordinateTextCalibratorConfig,
+) -> CoordinateCalibration | None:
+    if not samples:
+        return None
+
+    median_lon = _median_rect([sample.rois.lon for sample in samples])
+    median_lat = _median_rect([sample.rois.lat for sample in samples])
+    tolerance = max(0, config.edge_tolerance_px)
+
+    inliers = [
+        sample
+        for sample in samples
+        if _rect_is_close(sample.rois.lon, median_lon, tolerance=tolerance)
+        and _rect_is_close(sample.rois.lat, median_lat, tolerance=tolerance)
+    ]
+    min_inliers = min(max(1, config.min_inliers), max(1, config.sample_count))
+    if len(inliers) < min_inliers:
+        return None
+
+    lon = _median_rect([sample.rois.lon for sample in inliers])
+    lat = _median_rect([sample.rois.lat for sample in inliers])
+    if lon.x2 <= lon.x1 or lon.y2 <= lon.y1 or lat.x2 <= lat.x1 or lat.y2 <= lat.y1:
+        return None
+
+    extract_numeric_tokens = inliers[0].rois.extract_numeric_tokens
+    if any(sample.rois.extract_numeric_tokens != extract_numeric_tokens for sample in inliers):
+        return None
+
+    return CoordinateCalibration(
+        rois=CoordinateRois(
+            lon=lon,
+            lat=lat,
+            extract_numeric_tokens=extract_numeric_tokens,
+        )
+    )
+
+
+def _median_rect(rects: list[RoiRect]) -> RoiRect:
+    return RoiRect(
+        x1=round(median(rect.x1 for rect in rects)),
+        x2=round(median(rect.x2 for rect in rects)),
+        y1=round(median(rect.y1 for rect in rects)),
+        y2=round(median(rect.y2 for rect in rects)),
+    )
+
+
+def _rect_is_close(rect: RoiRect, expected: RoiRect, *, tolerance: int) -> bool:
+    return all(
+        abs(observed - target) <= tolerance
+        for observed, target in (
+            (rect.x1, expected.x1),
+            (rect.x2, expected.x2),
+            (rect.y1, expected.y1),
+            (rect.y2, expected.y2),
+        )
+    )

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
@@ -79,6 +79,7 @@ class CompassCalibrationRuntime:
         self._frame_size: tuple[int, int] | None = None
         self._persisted_restore_attempted = False
         self._calibration_persisted = False
+        self._calibration_verified = state_store is None
         self._verified_read_streak = 0
 
         self._next_search_ts_ms = 0
@@ -107,6 +108,7 @@ class CompassCalibrationRuntime:
         self._expected_digit_counts = None
         self._frame_size = None
         self._calibration_persisted = False
+        self._calibration_verified = self._state_store is None
         self._verified_read_streak = 0
         self._reset_coordinate_health()
         self._next_search_ts_ms = max(0, next_search_ts_ms)
@@ -178,8 +180,7 @@ class CompassCalibrationRuntime:
             if self._expected_digit_counts is None:
                 self._remember_digit_counts(read)
                 self._reset_coordinate_health()
-                read = self._position_pipeline.emit_read(read, ts_ms=ts_ms)
-                self._record_verified_read()
+                read = self._emit_verified_read(read, ts_ms=ts_ms)
                 return CalibratedPositionStep(
                     compass=compass,
                     compass_roi=compass_roi,
@@ -207,8 +208,7 @@ class CompassCalibrationRuntime:
                 )
 
             self._reset_coordinate_health()
-            read = self._position_pipeline.emit_read(read, ts_ms=ts_ms)
-            self._record_verified_read()
+            read = self._emit_verified_read(read, ts_ms=ts_ms)
             return CalibratedPositionStep(
                 compass=compass,
                 compass_roi=compass_roi,
@@ -265,19 +265,16 @@ class CompassCalibrationRuntime:
                         )
                         self._remember_digit_counts(fresh)
                         self._reset_coordinate_health()
-                        fresh = self._position_pipeline.emit_read(fresh, ts_ms=ts_ms)
-                        self._record_verified_read()
+                        fresh = self._emit_verified_read(fresh, ts_ms=ts_ms)
                         read = fresh
                     elif fresh_counts == expected:
                         self._reset_coordinate_health()
-                        fresh = self._position_pipeline.emit_read(fresh, ts_ms=ts_ms)
-                        self._record_verified_read()
+                        fresh = self._emit_verified_read(fresh, ts_ms=ts_ms)
                         read = fresh
                 else:
                     self._remember_digit_counts(fresh)
                     self._reset_coordinate_health()
-                    fresh = self._position_pipeline.emit_read(fresh, ts_ms=ts_ms)
-                    self._record_verified_read()
+                    fresh = self._emit_verified_read(fresh, ts_ms=ts_ms)
                     read = fresh
 
         return CalibratedPositionStep(
@@ -335,6 +332,7 @@ class CompassCalibrationRuntime:
         self._expected_digit_counts = None
         self._frame_size = (frame_width, frame_height)
         self._calibration_persisted = True
+        self._calibration_verified = True
         self._verified_read_streak = 0
         self._reset_coordinate_health()
         self._next_search_ts_ms = 0
@@ -362,6 +360,7 @@ class CompassCalibrationRuntime:
         self._expected_digit_counts = None
         self._frame_size = (int(frame.shape[1]), int(frame.shape[0]))
         self._calibration_persisted = False
+        self._calibration_verified = self._state_store is None
         self._verified_read_streak = 0
         self._reset_coordinate_health()
         self._next_search_ts_ms = 0
@@ -410,6 +409,7 @@ class CompassCalibrationRuntime:
         self._coordinate_rois = calibration.rois
         self._coordinate_failure_streak = 0
         self._calibration_persisted = False
+        self._calibration_verified = self._state_store is None
         self._verified_read_streak = 0
         lon = calibration.rois.lon
         lat = calibration.rois.lat
@@ -420,14 +420,26 @@ class CompassCalibrationRuntime:
             (lat.x1, lat.y1, lat.x2, lat.y2),
         )
 
+    def _emit_verified_read(
+        self,
+        read: PositionReadResult,
+        *,
+        ts_ms: int,
+    ) -> PositionReadResult:
+        self._record_verified_read()
+        if not self._calibration_verified:
+            return read
+        return self._position_pipeline.emit_read(read, ts_ms=ts_ms)
+
     def _record_verified_read(self) -> None:
-        if self._calibration_persisted:
+        if self._calibration_verified:
             return
         store = self._state_store
         compass = self._compass
         rois = self._coordinate_rois
         frame_size = self._frame_size
         if store is None or compass is None or rois is None or frame_size is None:
+            self._calibration_verified = True
             return
 
         self._verified_read_streak += 1
@@ -435,6 +447,7 @@ class CompassCalibrationRuntime:
         if self._verified_read_streak < threshold:
             return
 
+        self._calibration_verified = True
         frame_width, frame_height = frame_size
         state = PersistedCompassCalibration(
             frame_width=frame_width,
@@ -444,11 +457,12 @@ class CompassCalibrationRuntime:
         )
         if store.save(state):
             self._calibration_persisted = True
-            logger.info(
-                "compass_calibration_verified reads=%s rect=%s",
-                self._verified_read_streak,
-                _rect_tuple(compass.rect),
-            )
+        logger.info(
+            "compass_calibration_verified reads=%s rect=%s persisted=%s",
+            self._verified_read_streak,
+            _rect_tuple(compass.rect),
+            self._calibration_persisted,
+        )
 
     def _read_fast(self, compass_roi: np.ndarray, *, ts_ms: int) -> PositionReadResult:
         rois = self._coordinate_rois

--- a/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
+++ b/apps/ocr-worker/src/zml_ocr_worker/calibration/runtime.py
@@ -13,6 +13,7 @@ from zml_ocr_worker.calibration.coordinate_ocr import (
 from zml_ocr_worker.calibration.coordinates import CompassCoordinateLayout
 from zml_ocr_worker.calibration.model import LocatedCompass
 from zml_ocr_worker.calibration.multiframe_compass import MultiFrameCompassLocator
+from zml_ocr_worker.calibration.multiframe_coordinate import MultiFrameCoordinateTextCalibrator
 from zml_ocr_worker.calibration.persistence import (
     CompassCalibrationStore,
     PersistedCompassCalibration,
@@ -30,6 +31,7 @@ class CompassCalibrationRuntimeConfig:
     acquisition_sample_interval_ms: int = 100
     reacquire_delay_ms: int = 250
     locked_validation_interval_ms: int = 1000
+    coordinate_acquisition_sample_interval_ms: int = 100
     coordinate_recalibration_cooldown_ms: int = 2000
     consecutive_failures_before_recalibrate: int = 5
     verified_reads_before_persist: int = 10
@@ -65,7 +67,7 @@ class CompassCalibrationRuntime:
         self._position_pipeline = position_pipeline
         self._locator = locator or MultiFrameCompassLocator()
         self._layout = layout or CompassCoordinateLayout()
-        self._coordinate_calibrator = coordinate_calibrator or CoordinateTextCalibrator()
+        self._coordinate_calibrator = coordinate_calibrator or MultiFrameCoordinateTextCalibrator()
         self._state_store = state_store
         self._config = config or CompassCalibrationRuntimeConfig()
 
@@ -110,6 +112,7 @@ class CompassCalibrationRuntime:
         self._calibration_persisted = False
         self._calibration_verified = self._state_store is None
         self._verified_read_streak = 0
+        self._reset_coordinate_calibration_acquisition()
         self._reset_coordinate_health()
         self._next_search_ts_ms = max(0, next_search_ts_ms)
         self._next_locked_validation_ts_ms = 0
@@ -354,6 +357,7 @@ class CompassCalibrationRuntime:
         if not variants:
             return False
 
+        self._reset_coordinate_calibration_acquisition()
         self._compass = compass
         self._search_rois = variants[0].rois
         self._coordinate_rois = None
@@ -378,25 +382,39 @@ class CompassCalibrationRuntime:
         search_rois = self._search_rois
         if search_rois is None:
             return False
-        self._next_coordinate_calibration_ts_ms = ts_ms + max(
-            1, self._config.coordinate_recalibration_cooldown_ms
-        )
         try:
             calibration = self._coordinate_calibrator.calibrate(
                 compass_roi,
                 search_rois=search_rois,
             )
         except Exception:
+            self._next_coordinate_calibration_ts_ms = ts_ms + max(
+                1, self._config.coordinate_recalibration_cooldown_ms
+            )
             logger.warning(
                 "coordinate_text_calibration_failed reason=%s error=exception",
                 reason,
                 exc_info=True,
             )
             return False
+
+        acquisition_in_progress = bool(getattr(self._coordinate_calibrator, "acquiring", False))
         if calibration is None:
-            logger.info("coordinate_text_calibration_failed reason=%s", reason)
+            delay_ms = (
+                self._config.coordinate_acquisition_sample_interval_ms
+                if acquisition_in_progress
+                else self._config.coordinate_recalibration_cooldown_ms
+            )
+            self._next_coordinate_calibration_ts_ms = ts_ms + max(1, delay_ms)
+            if acquisition_in_progress:
+                logger.debug("coordinate_text_calibration_acquiring reason=%s", reason)
+            else:
+                logger.info("coordinate_text_calibration_failed reason=%s", reason)
             return False
 
+        self._next_coordinate_calibration_ts_ms = ts_ms + max(
+            1, self._config.coordinate_recalibration_cooldown_ms
+        )
         self._apply_coordinate_calibration(calibration, reason=reason)
         return True
 
@@ -497,6 +515,11 @@ class CompassCalibrationRuntime:
             return
         self._pending_digit_counts = counts
         self._pending_digit_count_streak = 1
+
+    def _reset_coordinate_calibration_acquisition(self) -> None:
+        reset = getattr(self._coordinate_calibrator, "reset", None)
+        if callable(reset):
+            reset()
 
     def _reset_coordinate_health(self) -> None:
         self._coordinate_failure_streak = 0

--- a/apps/ocr-worker/tests/test_compass_calibration_persistence_runtime.py
+++ b/apps/ocr-worker/tests/test_compass_calibration_persistence_runtime.py
@@ -171,10 +171,12 @@ def test_runtime_persists_new_calibration_after_ten_consecutive_valid_reads() ->
     for index in range(9):
         runtime.step(frame, ts_ms=100 + index * 10)
         assert not store.saved
+        assert pipeline.emit_calls == 0
 
     runtime.step(frame, ts_ms=190)
 
     assert len(store.saved) == 1
+    assert pipeline.emit_calls == 1
     saved = store.saved[0]
     assert saved.frame_width == 500
     assert saved.frame_height == 500

--- a/apps/ocr-worker/tests/test_multiframe_coordinate.py
+++ b/apps/ocr-worker/tests/test_multiframe_coordinate.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+
+from zml_ocr_worker.calibration.coordinate_ocr import CoordinateCalibration
+from zml_ocr_worker.calibration.model import LocatedCompass
+from zml_ocr_worker.calibration.multiframe_coordinate import (
+    MultiFrameCoordinateTextCalibrator,
+    MultiFrameCoordinateTextCalibratorConfig,
+)
+from zml_ocr_worker.calibration.runtime import (
+    CompassCalibrationRuntime,
+    CompassCalibrationRuntimeConfig,
+)
+from zml_ocr_worker.capture.model import RoiRect
+from zml_ocr_worker.pipelines.position.model import CoordinateRois
+from zml_ocr_worker.pipelines.position.pipeline import PositionReadResult
+
+
+class _StubCoordinateCalibrator:
+    def __init__(self, *samples: CoordinateCalibration | None) -> None:
+        self._samples = deque(samples)
+        self.calls = 0
+
+    def calibrate(
+        self,
+        compass_roi: np.ndarray,
+        *,
+        search_rois: CoordinateRois,
+    ) -> CoordinateCalibration | None:
+        self.calls += 1
+        if not self._samples:
+            return None
+        return self._samples.popleft()
+
+    def close(self) -> None:
+        return None
+
+
+class _SequencedAcquiringCalibrator:
+    def __init__(self, calibration: CoordinateCalibration) -> None:
+        self._calibration = calibration
+        self.calls = 0
+
+    @property
+    def acquiring(self) -> bool:
+        return 0 < self.calls < 3
+
+    def calibrate(
+        self,
+        compass_roi: np.ndarray,
+        *,
+        search_rois: CoordinateRois,
+    ) -> CoordinateCalibration | None:
+        self.calls += 1
+        return self._calibration if self.calls >= 3 else None
+
+    def close(self) -> None:
+        return None
+
+
+class _FakeLocator:
+    def __init__(self, compass: LocatedCompass) -> None:
+        self._compass = compass
+
+    def locate(self, frame: np.ndarray) -> LocatedCompass | None:
+        return self._compass
+
+    def locked_is_valid(self, frame: np.ndarray, compass: LocatedCompass) -> bool:
+        return True
+
+    def validate_locked(self, frame: np.ndarray, compass: LocatedCompass) -> float:
+        return 1.0
+
+
+class _FakePositionPipeline:
+    def __init__(self) -> None:
+        self.read_calls = 0
+        self.emit_calls = 0
+
+    def read(
+        self,
+        compass_roi: np.ndarray,
+        ts_ms: int,
+        *,
+        rois: CoordinateRois | None = None,
+        emit: bool = True,
+    ) -> PositionReadResult:
+        self.read_calls += 1
+        return PositionReadResult(longitude=31156, latitude=9515, position=None)
+
+    def emit_read(self, read: PositionReadResult, *, ts_ms: int) -> PositionReadResult:
+        self.emit_calls += 1
+        return read
+
+
+def _calibration(*, dx: int = 0, dy: int = 0) -> CoordinateCalibration:
+    return CoordinateCalibration(
+        rois=CoordinateRois(
+            lon=RoiRect(x1=40 + dx, x2=100 + dx, y1=250 + dy, y2=275 + dy),
+            lat=RoiRect(x1=42 + dx, x2=102 + dx, y1=280 + dy, y2=305 + dy),
+        )
+    )
+
+
+def _search_rois() -> CoordinateRois:
+    return CoordinateRois(
+        lon=RoiRect(x1=20, x2=140, y1=230, y2=280),
+        lat=RoiRect(x1=20, x2=140, y1=270, y2=320),
+    )
+
+
+def _compass() -> LocatedCompass:
+    return LocatedCompass(
+        rect=RoiRect(x1=100, x2=360, y1=80, y2=400),
+        confidence=0.95,
+        scale=1.0,
+        center_x=230.0,
+        center_y=230.0,
+        radius=100.0,
+    )
+
+
+def test_multiframe_coordinate_calibrator_uses_median_and_rejects_outlier() -> None:
+    base = _StubCoordinateCalibrator(
+        _calibration(dx=-1),
+        _calibration(dy=1),
+        _calibration(dx=1),
+        _calibration(),
+        _calibration(dx=35, dy=-20),
+    )
+    calibrator = MultiFrameCoordinateTextCalibrator(
+        calibrator=base,  # type: ignore[arg-type]
+        config=MultiFrameCoordinateTextCalibratorConfig(sample_count=5, min_inliers=4),
+    )
+    frame = np.zeros((320, 260, 3), dtype=np.uint8)
+
+    for _ in range(4):
+        assert calibrator.calibrate(frame, search_rois=_search_rois()) is None
+        assert calibrator.acquiring
+
+    result = calibrator.calibrate(frame, search_rois=_search_rois())
+
+    assert result is not None
+    assert not calibrator.acquiring
+    assert result.rois.lon == RoiRect(x1=40, x2=100, y1=250, y2=275)
+    assert result.rois.lat == RoiRect(x1=42, x2=102, y1=280, y2=305)
+
+
+def test_multiframe_coordinate_calibrator_requires_consecutive_successes() -> None:
+    base = _StubCoordinateCalibrator(
+        _calibration(),
+        _calibration(),
+        None,
+        _calibration(),
+        _calibration(),
+        _calibration(),
+        _calibration(),
+        _calibration(),
+    )
+    calibrator = MultiFrameCoordinateTextCalibrator(
+        calibrator=base,  # type: ignore[arg-type]
+        config=MultiFrameCoordinateTextCalibratorConfig(sample_count=5, min_inliers=4),
+    )
+    frame = np.zeros((320, 260, 3), dtype=np.uint8)
+
+    assert calibrator.calibrate(frame, search_rois=_search_rois()) is None
+    assert calibrator.calibrate(frame, search_rois=_search_rois()) is None
+    assert calibrator.acquiring
+    assert calibrator.calibrate(frame, search_rois=_search_rois()) is None
+    assert not calibrator.acquiring
+
+    result = None
+    for _ in range(5):
+        result = calibrator.calibrate(frame, search_rois=_search_rois())
+
+    assert result is not None
+
+
+def test_runtime_samples_coordinate_calibration_at_acquisition_interval() -> None:
+    pipeline = _FakePositionPipeline()
+    calibrator = _SequencedAcquiringCalibrator(_calibration())
+    runtime = CompassCalibrationRuntime(
+        position_pipeline=pipeline,  # type: ignore[arg-type]
+        locator=_FakeLocator(_compass()),  # type: ignore[arg-type]
+        coordinate_calibrator=calibrator,  # type: ignore[arg-type]
+        config=CompassCalibrationRuntimeConfig(
+            locked_validation_interval_ms=10_000,
+            coordinate_acquisition_sample_interval_ms=100,
+            coordinate_recalibration_cooldown_ms=2_000,
+        ),
+    )
+    frame = np.zeros((500, 500, 3), dtype=np.uint8)
+
+    first = runtime.step(frame, ts_ms=100)
+    assert first.read.position is None
+    assert calibrator.calls == 1
+
+    runtime.step(frame, ts_ms=150)
+    assert calibrator.calls == 1
+
+    runtime.step(frame, ts_ms=200)
+    assert calibrator.calls == 2
+
+    third = runtime.step(frame, ts_ms=300)
+    assert calibrator.calls == 3
+    assert runtime.active_rois == _calibration().rois
+    assert third.read.valid
+    assert pipeline.read_calls == 1
+    assert pipeline.emit_calls == 1


### PR DESCRIPTION
## Summary
- make the Calibration UI snapshot use the same persisted Compass calibration store as the live OCR worker
- let diagnostic Compass capture follow the new multi-frame acquisition flow instead of sampling only one frame
- pass the exact Compass calibration-state path from backend settings into the diagnostic worker process
- stabilize the Lon/Lat OCR boxes across 5 consecutive successful calibration frames, reject outlier geometry, and use the median ROI
- sample coordinate calibration at ~100 ms while acquisition is in progress instead of waiting for the normal recovery cooldown
- treat a fresh/recalibrated Compass state as a warm-up state: hold position emission until 10 consecutive valid reads verify it
- keep restored last-known-good calibration immediately trusted, so normal subsequent launches still emit positions without the warm-up delay

## Why
The release diagnostics were still one-shot while Compass discovery now requires a multi-frame consensus, so the Calibration tab could report no Compass in packaged builds.

The first-run quality issue also predates multi-frame Compass acquisition. Coordinate text calibration was itself one-shot: a single frame decided the final Lon/Lat digit ROIs, and the first parseable read was immediately trusted. A slightly bad but still syntactically valid ROI could therefore produce consistently wrong same-digit-count coordinates without triggering recovery.

## Behavior after this change
- existing valid `compass_calibration.json`: restore and emit immediately
- missing/stale state: acquire Compass from 7 frames, then acquire Lon/Lat ROI consensus from 5 consecutive successful frames
- coordinate ROI consensus requires at least 4/5 geometrically consistent samples; individual edge outliers beyond 4 px are rejected
- after coordinate consensus, collect 10 consecutive valid digit reads without publishing positions; persist/verify the state, then start publishing
- any failed coordinate-calibration sample resets that 5-frame acquisition so samples from different transient UI states are not mixed
- Recalibrate OCR: persisted state is cleared, so the full Compass -> coordinate ROI -> 10-read verification path runs again
- Calibration UI: reuses persisted state when valid; otherwise follows the same acquisition path and waits up to 5 seconds for Compass + Lon/Lat boxes